### PR TITLE
Implement support for dynamic schemas

### DIFF
--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::vec;
@@ -14,13 +15,13 @@ use parser::Spanning;
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Type<'a> {
     /// A nullable named type, e.g. `String`
-    Named(&'a str),
+    Named(Cow<'a, str>),
     /// A nullable list type, e.g. `[String]`
     ///
     /// The list itself is what's nullable, the containing type might be non-null.
     List(Box<Type<'a>>),
     /// A non-null named type, e.g. `String!`
-    NonNullNamed(&'a str),
+    NonNullNamed(Cow<'a, str>),
     /// A non-null list type, e.g. `[String]!`.
     ///
     /// The list itself is what's non-null, the containing type might be null.
@@ -168,7 +169,7 @@ impl<'a> Type<'a> {
     /// Only applies to named types; lists will return `None`.
     pub fn name(&self) -> Option<&str> {
         match *self {
-            Type::Named(n) | Type::NonNullNamed(n) => Some(n),
+            Type::Named(ref n) | Type::NonNullNamed(ref n) => Some(n),
             _ => None,
         }
     }
@@ -178,7 +179,7 @@ impl<'a> Type<'a> {
     /// All type literals contain exactly one named type.
     pub fn innermost_name(&self) -> &str {
         match *self {
-            Type::Named(n) | Type::NonNullNamed(n) => n,
+            Type::Named(ref n) | Type::NonNullNamed(ref n) => n,
             Type::List(ref l) | Type::NonNullList(ref l) => l.innermost_name(),
         }
     }
@@ -195,8 +196,8 @@ impl<'a> Type<'a> {
 impl<'a> fmt::Display for Type<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Type::Named(n) => write!(f, "{}", n),
-            Type::NonNullNamed(n) => write!(f, "{}!", n),
+            Type::Named(ref n) => write!(f, "{}", n),
+            Type::NonNullNamed(ref n) => write!(f, "{}!", n),
             Type::List(ref t) => write!(f, "[{}]", t),
             Type::NonNullList(ref t) => write!(f, "[{}]!", t),
         }

--- a/juniper/src/macros/args.rs
+++ b/juniper/src/macros/args.rs
@@ -42,57 +42,60 @@ macro_rules! __graphql__args {
             .expect("Argument missing - validation must have failed");
     };
 
-    ( @apply_args, $reg:expr, $base:expr, ( ) ) => {
+    ( @apply_args, $reg:expr, $base:expr, $info:expr, ( ) ) => {
         $base
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( , $( $rest:tt )* )
+        $reg:expr, $base:expr, $info:expr, ( , $( $rest:tt )* )
     ) => {
         __graphql__args!(
             @apply_args,
             $reg,
             $base,
+            $info,
             ( $($rest)* ))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( &executor $( $rest:tt )* )
+        $reg:expr, $base:expr, $info:expr, ( &executor $( $rest:tt )* )
     ) => {
         __graphql__args!(
             @apply_args,
             $reg,
             $base,
+            $info,
             ( $($rest)* ))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( $name:ident = $default:tt : $t:ty )
+        $reg:expr, $base:expr, $info:expr, ( $name:ident = $default:tt : $t:ty )
     ) => {
         $base.argument($reg.arg_with_default::<$t>(
             &$crate::to_camel_case(stringify!($name)),
-            &__graphql__args!(@as_expr, $default)))
+            &__graphql__args!(@as_expr, $default), $info))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( $name:ident = $default:tt : $t:ty , $( $rest:tt )* )
+        $reg:expr, $base:expr, $info:expr, ( $name:ident = $default:tt : $t:ty , $( $rest:tt )* )
     ) => {
         __graphql__args!(
             @apply_args,
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
                 &$crate::to_camel_case(stringify!($name)),
-                &__graphql__args!(@as_expr, $default))),
+                &__graphql__args!(@as_expr, $default), $info)),
+            $info,
             ( $($rest)* ))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr,
+        $reg:expr, $base:expr, $info:expr,
         ( $name:ident = $default:tt : $t:ty as $desc:tt $( $rest:tt )* )
     ) => {
         __graphql__args!(
@@ -100,42 +103,45 @@ macro_rules! __graphql__args {
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
                 &$crate::to_camel_case(stringify!($name)),
-                &__graphql__args!(@as_expr, $default))
+                &__graphql__args!(@as_expr, $default), $info)
                 .description($desc)),
+            $info,
             ( $($rest)* ))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( $name:ident : $t:ty )
+        $reg:expr, $base:expr, $info:expr, ( $name:ident : $t:ty )
     ) => {
         $base.argument($reg.arg::<$t>(
-            &$crate::to_camel_case(stringify!($name))))
+            &$crate::to_camel_case(stringify!($name)), $info))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( $name:ident : $t:ty , $( $rest:tt )* )
+        $reg:expr, $base:expr, $info:expr, ( $name:ident : $t:ty , $( $rest:tt )* )
     ) => {
         __graphql__args!(
             @apply_args,
             $reg,
             $base.argument($reg.arg::<$t>(
-                &$crate::to_camel_case(stringify!($name)))),
+                &$crate::to_camel_case(stringify!($name)), $info)),
+            $info,
             ( $($rest)* ))
     };
 
     (
         @apply_args,
-        $reg:expr, $base:expr, ( $name:ident : $t:ty as $desc:tt $( $rest:tt )* )
+        $reg:expr, $base:expr, $info:expr, ( $name:ident : $t:ty as $desc:tt $( $rest:tt )* )
     ) => {
         __graphql__args!(
             @apply_args,
             $reg,
             $base.argument(
                 $reg.arg::<$t>(
-                    &$crate::to_camel_case(stringify!($name)))
+                    &$crate::to_camel_case(stringify!($name)), $info)
                 .description($desc)),
+            $info,
             ( $($rest)* ))
     };
 }

--- a/juniper/src/macros/enums.rs
+++ b/juniper/src/macros/enums.rs
@@ -61,15 +61,16 @@ macro_rules! graphql_enum {
     ) => {
         impl $crate::GraphQLType for $name {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some(graphql_enum!(@as_expr, $outname))
             }
 
-            fn meta<'r>(registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
+            fn meta<'r>(info: &(), registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
                 graphql_enum!(
                     @maybe_apply, $descr, description,
-                    registry.build_enum_type::<$name>(&[
+                    registry.build_enum_type::<$name>(info, &[
                         $(
                             graphql_enum!(
                                 @maybe_apply,
@@ -83,7 +84,7 @@ macro_rules! graphql_enum {
                     .into_meta()
             }
 
-            fn resolve(&self, _: Option<&[$crate::Selection]>, _: &$crate::Executor<Self::Context>) -> $crate::Value {
+            fn resolve(&self, _: &(), _: Option<&[$crate::Selection]>, _: &$crate::Executor<Self::Context>) -> $crate::Value {
                 match *self {
                     $(
                         graphql_enum!(@as_pattern, $eval) =>

--- a/juniper/src/macros/field.rs
+++ b/juniper/src/macros/field.rs
@@ -79,7 +79,7 @@ macro_rules! __graphql__build_field_matches {
 
                 return ($crate::IntoResolvable::into(result, $executorvar.context())).and_then(
                     |res| match res {
-                        Some((ctx, r)) => $executorvar.replaced_context(ctx).resolve_with_ctx(&r),
+                        Some((ctx, r)) => $executorvar.replaced_context(ctx).resolve_with_ctx(&(), &r),
                         None => Ok($crate::Value::null()),
                     })
             }

--- a/juniper/src/macros/input_object.rs
+++ b/juniper/src/macros/input_object.rs
@@ -111,7 +111,7 @@ macro_rules! graphql_input_object {
             $($descr)*,
             $reg.arg_with_default::<$field_type>(
                 &$crate::to_camel_case(stringify!($field_name)),
-                &$default))
+                &$default, &()))
     };
 
     // Generate single field meta for field without default value
@@ -124,7 +124,7 @@ macro_rules! graphql_input_object {
             @apply_description,
             $($descr)*,
             $reg.arg::<$field_type>(
-                &$crate::to_camel_case(stringify!($field_name))))
+                &$crate::to_camel_case(stringify!($field_name)), &()))
     };
 
     // Generate the input field meta list, i.e. &[Argument] for
@@ -239,16 +239,17 @@ macro_rules! graphql_input_object {
 
         impl $crate::GraphQLType for $name {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some($outname)
             }
 
-            fn meta<'r>(registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
+            fn meta<'r>(_: &(), registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
                 let fields = graphql_input_object!(@generate_meta_fields, registry, $fields);
                 graphql_input_object!(
                     @maybe_apply, $descr, description,
-                    registry.build_input_object_type::<$name>(fields)).into_meta()
+                    registry.build_input_object_type::<$name>(&(), fields)).into_meta()
             }
         }
     };

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -239,116 +239,120 @@ macro_rules! graphql_object {
     // field deprecated <reason> <name>(...) -> <type> as <description> { ... }
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         field deprecated $reason:tt $name:ident $args:tt -> $t:ty as $desc:tt $body:block $( $rest:tt )*
     ) => {
         $acc.push(__graphql__args!(
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)), $info)
                 .description($desc)
                 .deprecated($reason),
+            $info,
             $args));
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*);
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*);
     };
 
     // field deprecated <reason> <name>(...) -> <type> { ... }
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         field deprecated $reason:tt $name:ident $args:tt -> $t:ty $body:block $( $rest:tt )*
     ) => {
         $acc.push(__graphql__args!(
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)), $info)
                 .deprecated($reason),
+            $info,
             $args));
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*);
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*);
     };
 
     // field <name>(...) -> <type> as <description> { ... }
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         field $name:ident $args:tt -> $t:ty as $desc:tt $body:block $( $rest:tt )*
     ) => {
         $acc.push(__graphql__args!(
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)))
+                &$crate::to_camel_case(stringify!($name)), $info)
                 .description($desc),
+            $info,
             $args));
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*);
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*);
     };
 
     // field <name>(...) -> <type> { ... }
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         field $name:ident $args:tt -> $t:ty $body:block $( $rest:tt )*
     ) => {
         $acc.push(__graphql__args!(
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name))),
+                &$crate::to_camel_case(stringify!($name)), $info),
+            $info,
             $args));
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*);
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*);
     };
 
     // description: <description>
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         description : $value:tt $( $rest:tt )*
     ) => {
         $descr = Some(graphql_object!(@as_expr, $value));
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*)
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*)
     };
 
     // interfaces: [...]
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
         interfaces : $value:tt $( $rest:tt )*
     ) => {
         graphql_object!(@assign_interfaces, $reg, $ifaces, $value);
 
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*)
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*)
     };
 
     // eat commas
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr, , $( $rest:tt )*
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr, , $( $rest:tt )*
     ) => {
-        graphql_object!(@gather_object_meta, $reg, $acc, $descr, $ifaces, $( $rest )*)
+        graphql_object!(@gather_object_meta, $reg, $acc, $info, $descr, $ifaces, $( $rest )*)
     };
 
     // base case
     (
         @gather_object_meta,
-        $reg:expr, $acc:expr, $descr:expr, $ifaces:expr,
+        $reg:expr, $acc:expr, $info:expr, $descr:expr, $ifaces:expr,
     ) => {};
 
     ( @assign_interfaces, $reg:expr, $tgt:expr, [ $($t:ty,)* ] ) => {
         $tgt = Some(vec![
-            $($reg.get_type::<$t>()),*
+            $($reg.get_type::<$t>(&())),*
         ]);
     };
 
     ( @assign_interfaces, $reg:expr, $tgt:expr, [ $($t:ty),* ] ) => {
         $tgt = Some(vec![
-            $($reg.get_type::<$t>()),*
+            $($reg.get_type::<$t>(&())),*
         ]);
     };
 
@@ -358,22 +362,23 @@ macro_rules! graphql_object {
     ) => {
         graphql_object!(@as_item, impl<$($lifetime)*> $crate::GraphQLType for $name {
             type Context = $ctxt;
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some($outname)
             }
 
             #[allow(unused_assignments)]
             #[allow(unused_mut)]
-            fn meta<'r>(registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
+            fn meta<'r>(info: &(), registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
                 let mut fields = Vec::new();
                 let mut description = None;
                 let mut interfaces: Option<Vec<$crate::Type>> = None;
                 graphql_object!(
                     @gather_object_meta,
-                    registry, fields, description, interfaces, $($items)*
+                    registry, fields, info, description, interfaces, $($items)*
                 );
-                let mut mt = registry.build_object_type::<$name>(&fields);
+                let mut mt = registry.build_object_type::<$name>(info, &fields);
 
                 if let Some(description) = description {
                     mt = mt.description(description);
@@ -394,6 +399,7 @@ macro_rules! graphql_object {
             #[allow(unused_mut)]
             fn resolve_field(
                 &$mainself,
+                info: &(),
                 field: &str,
                 args: &$crate::Arguments,
                 executor: &$crate::Executor<Self::Context>

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -65,20 +65,22 @@ macro_rules! graphql_scalar {
     ) => {
         impl $crate::GraphQLType for $name {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some(graphql_scalar!( @as_expr, $outname ))
             }
 
-            fn meta<'r>(registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
+            fn meta<'r>(info: &(), registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
                 graphql_scalar!(
                     @maybe_apply, $descr, description,
-                    registry.build_scalar_type::<Self>())
+                    registry.build_scalar_type::<Self>(info))
                     .into_meta()
             }
 
             fn resolve(
                 &$resolve_selfvar,
+                _: &(),
                 _: Option<&[$crate::Selection]>,
                 _: &$crate::Executor<Self::Context>) -> $crate::Value {
                 $resolve_body

--- a/juniper/src/macros/union.rs
+++ b/juniper/src/macros/union.rs
@@ -44,7 +44,7 @@ macro_rules! graphql_union {
     ) => {
         $acc = vec![
             $(
-                $reg.get_type::<$srctype>()
+                $reg.get_type::<$srctype>(&())
             ),*
         ];
 
@@ -62,7 +62,7 @@ macro_rules! graphql_union {
 
         $(
             if let Some(_) = $resolver as Option<$srctype> {
-                return (<$srctype as $crate::GraphQLType>::name()).unwrap().to_owned();
+                return (<$srctype as $crate::GraphQLType>::name(&())).unwrap().to_owned();
             }
         )*
 
@@ -79,8 +79,8 @@ macro_rules! graphql_union {
         let $ctxtvar = &$execarg.context();
 
         $(
-            if $typenamearg == (<$srctype as $crate::GraphQLType>::name()).unwrap().to_owned() {
-                return $execarg.resolve(&$resolver);
+            if $typenamearg == (<$srctype as $crate::GraphQLType>::name(&())).unwrap().to_owned() {
+                return $execarg.resolve(&(), &$resolver);
             }
         )*
 
@@ -107,18 +107,19 @@ macro_rules! graphql_union {
     ) => {
         graphql_union!(@as_item, impl<$($lifetime)*> $crate::GraphQLType for $name {
             type Context = $ctxt;
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some($outname)
             }
 
             #[allow(unused_assignments)]
             #[allow(unused_mut)]
-            fn meta<'r>(registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
+            fn meta<'r>(_: &(), registry: &mut $crate::Registry<'r>) -> $crate::meta::MetaType<'r> {
                 let mut types;
                 let mut description = None;
                 graphql_union!(@ gather_meta, (registry, types, description), $($items)*);
-                let mut mt = registry.build_union_type::<$name>(&types);
+                let mut mt = registry.build_union_type::<$name>(&(), &types);
 
                 if let Some(description) = description {
                     mt = mt.description(description);
@@ -136,6 +137,7 @@ macro_rules! graphql_union {
 
             fn resolve_into_type(
                 &$mainself,
+                _: &(),
                 type_name: &str,
                 _: Option<&[$crate::Selection]>,
                 executor: &$crate::Executor<Self::Context>,

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use ast::{Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread,
           InlineFragment, InputValue, Operation, OperationType, Selection, Type,
           VariableDefinition, VariableDefinitions};
@@ -362,7 +364,7 @@ pub fn parse_type<'a>(parser: &mut Parser<'a>) -> ParseResult<'a, Type<'a>> {
         let Spanning { end: end_pos, .. } = try!(parser.expect(&Token::BracketClose));
         Spanning::start_end(&start_pos, &end_pos, Type::List(Box::new(inner_type.item)))
     } else {
-        try!(parser.expect_name()).map(Type::Named)
+        try!(parser.expect_name()).map(|s| Type::Named(Cow::Borrowed(s)))
     };
 
     Ok(match *parser.peek() {

--- a/juniper/src/tests/mod.rs
+++ b/juniper/src/tests/mod.rs
@@ -6,3 +6,5 @@ mod schema;
 mod query_tests;
 #[cfg(test)]
 mod introspection_tests;
+#[cfg(test)]
+mod type_info_tests;

--- a/juniper/src/tests/type_info_tests.rs
+++ b/juniper/src/tests/type_info_tests.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+
+use executor::{ExecutionResult, Executor, Registry, Variables};
+use value::Value;
+use schema::meta::MetaType;
+use schema::model::RootNode;
+use types::base::{Arguments, GraphQLType};
+use types::scalars::EmptyMutation;
+
+pub struct NodeTypeInfo {
+    name: String,
+    attribute_names: Vec<String>,
+}
+
+pub struct Node {
+    attributes: HashMap<String, String>,
+}
+
+impl GraphQLType for Node {
+    type Context = ();
+    type TypeInfo = NodeTypeInfo;
+
+    fn name(info: &Self::TypeInfo) -> Option<&str> {
+        Some(&info.name)
+    }
+
+    fn meta<'r>(info: &Self::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        let fields = info.attribute_names
+            .iter()
+            .map(|name| registry.field::<String>(name, &()))
+            .collect::<Vec<_>>();
+
+        registry
+            .build_object_type::<Node>(info, &fields)
+            .into_meta()
+    }
+
+    fn resolve_field(
+        &self,
+        _: &Self::TypeInfo,
+        field_name: &str,
+        _: &Arguments,
+        executor: &Executor<Self::Context>,
+    ) -> ExecutionResult {
+        executor.resolve(&(), &self.attributes.get(field_name).unwrap())
+    }
+}
+
+#[test]
+fn test_node() {
+    let doc = r#"
+        {
+            foo,
+            bar,
+            baz
+        }"#;
+    let node_info = NodeTypeInfo {
+        name: "MyNode".to_string(),
+        attribute_names: vec!["foo".to_string(), "bar".to_string(), "baz".to_string()],
+    };
+    let mut node = Node {
+        attributes: HashMap::new(),
+    };
+    node.attributes.insert("foo".to_string(), "1".to_string());
+    node.attributes.insert("bar".to_string(), "2".to_string());
+    node.attributes.insert("baz".to_string(), "3".to_string());
+    let schema = RootNode::new_with_info(node, EmptyMutation::new(), node_info, ());
+
+    assert_eq!(
+        ::execute(doc, None, &schema, &Variables::new(), &()),
+        Ok((
+            Value::object(
+                vec![
+                    ("foo", Value::string("1")),
+                    ("bar", Value::string("2")),
+                    ("baz", Value::string("3")),
+                ].into_iter()
+                    .collect()
+            ),
+            vec![]
+        ))
+    );
+}

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -10,18 +10,24 @@ where
     T: GraphQLType<Context = CtxT>,
 {
     type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &T::TypeInfo) -> Option<&str> {
         None
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_nullable_type::<T>().into_meta()
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_nullable_type::<T>(info).into_meta()
     }
 
-    fn resolve(&self, _: Option<&[Selection]>, executor: &Executor<CtxT>) -> Value {
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        _: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
         match *self {
-            Some(ref obj) => executor.resolve_into_value(obj),
+            Some(ref obj) => executor.resolve_into_value(info, obj),
             None => Value::null(),
         }
     }
@@ -59,19 +65,25 @@ where
     T: GraphQLType<Context = CtxT>,
 {
     type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &T::TypeInfo) -> Option<&str> {
         None
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_list_type::<T>().into_meta()
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_list_type::<T>(info).into_meta()
     }
 
-    fn resolve(&self, _: Option<&[Selection]>, executor: &Executor<CtxT>) -> Value {
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        _: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
         Value::list(
             self.iter()
-                .map(|e| executor.resolve_into_value(e))
+                .map(|e| executor.resolve_into_value(info, e))
                 .collect(),
         )
     }
@@ -115,19 +127,25 @@ where
     T: GraphQLType<Context = CtxT>,
 {
     type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &T::TypeInfo) -> Option<&str> {
         None
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_list_type::<T>().into_meta()
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_list_type::<T>(info).into_meta()
     }
 
-    fn resolve(&self, _: Option<&[Selection]>, executor: &Executor<CtxT>) -> Value {
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        _: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
         Value::list(
             self.iter()
-                .map(|e| executor.resolve_into_value(e))
+                .map(|e| executor.resolve_into_value(info, e))
                 .collect(),
         )
     }

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -10,35 +10,43 @@ where
     T: GraphQLType<Context = CtxT>,
 {
     type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
 
-    fn name() -> Option<&'static str> {
-        T::name()
+    fn name(info: &T::TypeInfo) -> Option<&str> {
+        T::name(info)
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        T::meta(registry)
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        T::meta(info, registry)
     }
 
     fn resolve_into_type(
         &self,
+        info: &T::TypeInfo,
         name: &str,
         selection_set: Option<&[Selection]>,
         executor: &Executor<CtxT>,
     ) -> ExecutionResult {
-        (**self).resolve_into_type(name, selection_set, executor)
+        (**self).resolve_into_type(info, name, selection_set, executor)
     }
 
     fn resolve_field(
         &self,
+        info: &T::TypeInfo,
         field: &str,
         args: &Arguments,
         executor: &Executor<CtxT>,
     ) -> ExecutionResult {
-        (**self).resolve_field(field, args, executor)
+        (**self).resolve_field(info, field, args, executor)
     }
 
-    fn resolve(&self, selection_set: Option<&[Selection]>, executor: &Executor<CtxT>) -> Value {
-        (**self).resolve(selection_set, executor)
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        selection_set: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
+        (**self).resolve(info, selection_set, executor)
     }
 }
 
@@ -68,35 +76,43 @@ where
     T: GraphQLType<Context = CtxT>,
 {
     type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
 
-    fn name() -> Option<&'static str> {
-        T::name()
+    fn name(info: &T::TypeInfo) -> Option<&str> {
+        T::name(info)
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        T::meta(registry)
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        T::meta(info, registry)
     }
 
     fn resolve_into_type(
         &self,
+        info: &T::TypeInfo,
         name: &str,
         selection_set: Option<&[Selection]>,
         executor: &Executor<CtxT>,
     ) -> ExecutionResult {
-        (**self).resolve_into_type(name, selection_set, executor)
+        (**self).resolve_into_type(info, name, selection_set, executor)
     }
 
     fn resolve_field(
         &self,
+        info: &T::TypeInfo,
         field: &str,
         args: &Arguments,
         executor: &Executor<CtxT>,
     ) -> ExecutionResult {
-        (**self).resolve_field(field, args, executor)
+        (**self).resolve_field(info, field, args, executor)
     }
 
-    fn resolve(&self, selection_set: Option<&[Selection]>, executor: &Executor<CtxT>) -> Value {
-        (**self).resolve(selection_set, executor)
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        selection_set: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
+        (**self).resolve(info, selection_set, executor)
     }
 }
 

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -61,16 +61,17 @@ graphql_scalar!(String as "String" {
 
 impl<'a> GraphQLType for &'a str {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&str> {
         Some("String")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_scalar_type::<String>().into_meta()
+    fn meta<'r>(_: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_scalar_type::<String>(&()).into_meta()
     }
 
-    fn resolve(&self, _: Option<&[Selection]>, _: &Executor<Self::Context>) -> Value {
+    fn resolve(&self, _: &(), _: Option<&[Selection]>, _: &Executor<Self::Context>) -> Value {
         Value::string(self)
     }
 }
@@ -128,13 +129,14 @@ graphql_scalar!(f64 as "Float" {
 
 impl GraphQLType for () {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&str> {
         Some("__Unit")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_scalar_type::<Self>().into_meta()
+    fn meta<'r>(_: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_scalar_type::<Self>(&()).into_meta()
     }
 }
 
@@ -164,13 +166,14 @@ impl<T> EmptyMutation<T> {
 
 impl<T> GraphQLType for EmptyMutation<T> {
     type Context = T;
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&str> {
         Some("_EmptyMutation")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        registry.build_object_type::<Self>(&[]).into_meta()
+    fn meta<'r>(_: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        registry.build_object_type::<Self>(&(), &[]).into_meta()
     }
 }
 

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -510,8 +510,8 @@ impl<'a> OverlappingFieldsCanBeMerged<'a> {
             (&Type::NonNullList(ref inner1), &Type::NonNullList(ref inner2)) => {
                 self.is_type_conflict(ctx, inner1, inner2)
             }
-            (&Type::NonNullNamed(n1), &Type::NonNullNamed(n2)) |
-            (&Type::Named(n1), &Type::Named(n2)) => {
+            (&Type::NonNullNamed(ref n1), &Type::NonNullNamed(ref n2)) |
+            (&Type::Named(ref n1), &Type::Named(ref n2)) => {
                 let ct1 = ctx.schema.concrete_type_by_name(n1);
                 let ct2 = ctx.schema.concrete_type_by_name(n2);
 
@@ -1357,102 +1357,107 @@ mod tests {
 
     impl GraphQLType for SomeBox {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("SomeBox")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<Option<SomeBox>>("deepBox"),
-                registry.field::<Option<String>>("unrelatedField"),
+                registry.field::<Option<SomeBox>>("deepBox", i),
+                registry.field::<Option<String>>("unrelatedField", i),
             ];
 
-            registry.build_interface_type::<Self>(fields).into_meta()
+            registry.build_interface_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for StringBox {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("StringBox")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<Option<String>>("scalar"),
-                registry.field::<Option<StringBox>>("deepBox"),
-                registry.field::<Option<String>>("unrelatedField"),
-                registry.field::<Option<Vec<Option<StringBox>>>>("listStringBox"),
-                registry.field::<Option<StringBox>>("stringBox"),
-                registry.field::<Option<IntBox>>("intBox"),
+                registry.field::<Option<String>>("scalar", i),
+                registry.field::<Option<StringBox>>("deepBox", i),
+                registry.field::<Option<String>>("unrelatedField", i),
+                registry.field::<Option<Vec<Option<StringBox>>>>("listStringBox", i),
+                registry.field::<Option<StringBox>>("stringBox", i),
+                registry.field::<Option<IntBox>>("intBox", i),
             ];
 
             registry
-                .build_object_type::<Self>(fields)
-                .interfaces(&[registry.get_type::<SomeBox>()])
+                .build_object_type::<Self>(i, fields)
+                .interfaces(&[registry.get_type::<SomeBox>(i)])
                 .into_meta()
         }
     }
 
     impl GraphQLType for IntBox {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("IntBox")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<Option<i32>>("scalar"),
-                registry.field::<Option<IntBox>>("deepBox"),
-                registry.field::<Option<String>>("unrelatedField"),
-                registry.field::<Option<Vec<Option<StringBox>>>>("listStringBox"),
-                registry.field::<Option<StringBox>>("stringBox"),
-                registry.field::<Option<IntBox>>("intBox"),
+                registry.field::<Option<i32>>("scalar", i),
+                registry.field::<Option<IntBox>>("deepBox", i),
+                registry.field::<Option<String>>("unrelatedField", i),
+                registry.field::<Option<Vec<Option<StringBox>>>>("listStringBox", i),
+                registry.field::<Option<StringBox>>("stringBox", i),
+                registry.field::<Option<IntBox>>("intBox", i),
             ];
 
             registry
-                .build_object_type::<Self>(fields)
-                .interfaces(&[registry.get_type::<SomeBox>()])
+                .build_object_type::<Self>(i, fields)
+                .interfaces(&[registry.get_type::<SomeBox>(i)])
                 .into_meta()
         }
     }
 
     impl GraphQLType for NonNullStringBox1 {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("NonNullStringBox1")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-            let fields = &[registry.field::<String>("scalar")];
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+            let fields = &[registry.field::<String>("scalar", i)];
 
-            registry.build_interface_type::<Self>(fields).into_meta()
+            registry.build_interface_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for NonNullStringBox1Impl {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("NonNullStringBox1Impl")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<String>("scalar"),
-                registry.field::<Option<SomeBox>>("deepBox"),
-                registry.field::<Option<String>>("unrelatedField"),
+                registry.field::<String>("scalar", i),
+                registry.field::<Option<SomeBox>>("deepBox", i),
+                registry.field::<Option<String>>("unrelatedField", i),
             ];
 
             registry
-                .build_object_type::<Self>(fields)
+                .build_object_type::<Self>(i, fields)
                 .interfaces(&[
-                    registry.get_type::<NonNullStringBox1>(),
-                    registry.get_type::<SomeBox>(),
+                    registry.get_type::<NonNullStringBox1>(i),
+                    registry.get_type::<SomeBox>(i),
                 ])
                 .into_meta()
         }
@@ -1460,37 +1465,39 @@ mod tests {
 
     impl GraphQLType for NonNullStringBox2 {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("NonNullStringBox2")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-            let fields = &[registry.field::<String>("scalar")];
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+            let fields = &[registry.field::<String>("scalar", i)];
 
-            registry.build_interface_type::<Self>(fields).into_meta()
+            registry.build_interface_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for NonNullStringBox2Impl {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("NonNullStringBox2Impl")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<String>("scalar"),
-                registry.field::<Option<SomeBox>>("deepBox"),
-                registry.field::<Option<String>>("unrelatedField"),
+                registry.field::<String>("scalar", i),
+                registry.field::<Option<SomeBox>>("deepBox", i),
+                registry.field::<Option<String>>("unrelatedField", i),
             ];
 
             registry
-                .build_object_type::<Self>(fields)
+                .build_object_type::<Self>(i, fields)
                 .interfaces(&[
-                    registry.get_type::<NonNullStringBox2>(),
-                    registry.get_type::<SomeBox>(),
+                    registry.get_type::<NonNullStringBox2>(i),
+                    registry.get_type::<SomeBox>(i),
                 ])
                 .into_meta()
         }
@@ -1498,67 +1505,71 @@ mod tests {
 
     impl GraphQLType for Node {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("Node")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
             let fields = &[
-                registry.field::<Option<ID>>("id"),
-                registry.field::<Option<String>>("name"),
+                registry.field::<Option<ID>>("id", i),
+                registry.field::<Option<String>>("name", i),
             ];
 
-            registry.build_object_type::<Self>(fields).into_meta()
+            registry.build_object_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for Edge {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("Edge")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-            let fields = &[registry.field::<Option<Node>>("node")];
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+            let fields = &[registry.field::<Option<Node>>("node", i)];
 
-            registry.build_object_type::<Self>(fields).into_meta()
+            registry.build_object_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for Connection {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("Connection")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-            let fields = &[registry.field::<Option<Vec<Option<Edge>>>>("edges")];
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+            let fields = &[registry.field::<Option<Vec<Option<Edge>>>>("edges", i)];
 
-            registry.build_object_type::<Self>(fields).into_meta()
+            registry.build_object_type::<Self>(i, fields).into_meta()
         }
     }
 
     impl GraphQLType for QueryRoot {
         type Context = ();
+        type TypeInfo = ();
 
-        fn name() -> Option<&'static str> {
+        fn name(_: &()) -> Option<&'static str> {
             Some("QueryRoot")
         }
 
-        fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-            registry.get_type::<IntBox>();
-            registry.get_type::<StringBox>();
-            registry.get_type::<NonNullStringBox1Impl>();
-            registry.get_type::<NonNullStringBox2Impl>();
+        fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+            registry.get_type::<IntBox>(i);
+            registry.get_type::<StringBox>(i);
+            registry.get_type::<NonNullStringBox1Impl>(i);
+            registry.get_type::<NonNullStringBox2Impl>(i);
 
             let fields = &[
-                registry.field::<Option<SomeBox>>("someBox"),
-                registry.field::<Option<Connection>>("connection"),
+                registry.field::<Option<SomeBox>>("someBox", i),
+                registry.field::<Option<Connection>>("connection", i),
             ];
-            registry.build_object_type::<Self>(fields).into_meta()
+            registry.build_object_type::<Self>(i, fields).into_meta()
         }
     }
 

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition};
@@ -48,7 +49,9 @@ impl<'a> VariableInAllowedPosition<'a> {
                 {
                     let expected_type = match (&var_def.default_value, &var_def.var_type.item) {
                         (&Some(_), &Type::List(ref inner)) => Type::NonNullList(inner.clone()),
-                        (&Some(_), &Type::Named(inner)) => Type::NonNullNamed(inner),
+                        (&Some(_), &Type::Named(ref inner)) => {
+                            Type::NonNullNamed(Cow::Borrowed(inner))
+                        }
                         (_, t) => t.clone(),
                     };
 

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -53,72 +53,79 @@ struct ComplexInput {
 
 impl GraphQLType for Being {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Being")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
         ];
 
-        registry.build_interface_type::<Self>(fields).into_meta()
+        registry.build_interface_type::<Self>(i, fields).into_meta()
     }
 }
 
 impl GraphQLType for Pet {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Pet")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
         ];
 
-        registry.build_interface_type::<Self>(fields).into_meta()
+        registry.build_interface_type::<Self>(i, fields).into_meta()
     }
 }
 
 impl GraphQLType for Canine {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Canine")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
         ];
 
-        registry.build_interface_type::<Self>(fields).into_meta()
+        registry.build_interface_type::<Self>(i, fields).into_meta()
     }
 }
 
 impl GraphQLType for DogCommand {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("DogCommand")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         registry
-            .build_enum_type::<Self>(&[
-                EnumValue::new("SIT"),
-                EnumValue::new("HEEL"),
-                EnumValue::new("DOWN"),
-            ])
+            .build_enum_type::<Self>(
+                i,
+                &[
+                    EnumValue::new("SIT"),
+                    EnumValue::new("HEEL"),
+                    EnumValue::new("DOWN"),
+                ],
+            )
             .into_meta()
     }
 }
@@ -136,37 +143,38 @@ impl FromInputValue for DogCommand {
 
 impl GraphQLType for Dog {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Dog")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
-            registry.field::<Option<String>>("nickname"),
-            registry.field::<Option<i32>>("barkVolume"),
-            registry.field::<Option<bool>>("barks"),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
+            registry.field::<Option<String>>("nickname", i),
+            registry.field::<Option<i32>>("barkVolume", i),
+            registry.field::<Option<bool>>("barks", i),
             registry
-                .field::<Option<bool>>("doesKnowCommand")
-                .argument(registry.arg::<Option<DogCommand>>("dogCommand")),
+                .field::<Option<bool>>("doesKnowCommand", i)
+                .argument(registry.arg::<Option<DogCommand>>("dogCommand", i)),
             registry
-                .field::<Option<bool>>("isHousetrained")
-                .argument(registry.arg_with_default("atOtherHomes", &true)),
+                .field::<Option<bool>>("isHousetrained", i)
+                .argument(registry.arg_with_default("atOtherHomes", &true, i)),
             registry
-                .field::<Option<bool>>("isAtLocation")
-                .argument(registry.arg::<Option<i32>>("x"))
-                .argument(registry.arg::<Option<i32>>("y")),
+                .field::<Option<bool>>("isAtLocation", i)
+                .argument(registry.arg::<Option<i32>>("x", i))
+                .argument(registry.arg::<Option<i32>>("y", i)),
         ];
 
         registry
-            .build_object_type::<Self>(fields)
+            .build_object_type::<Self>(i, fields)
             .interfaces(&[
-                registry.get_type::<Being>(),
-                registry.get_type::<Pet>(),
-                registry.get_type::<Canine>(),
+                registry.get_type::<Being>(i),
+                registry.get_type::<Pet>(i),
+                registry.get_type::<Canine>(i),
             ])
             .into_meta()
     }
@@ -174,19 +182,23 @@ impl GraphQLType for Dog {
 
 impl GraphQLType for FurColor {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("FurColor")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         registry
-            .build_enum_type::<Self>(&[
-                EnumValue::new("BROWN"),
-                EnumValue::new("BLACK"),
-                EnumValue::new("TAN"),
-                EnumValue::new("SPOTTED"),
-            ])
+            .build_enum_type::<Self>(
+                i,
+                &[
+                    EnumValue::new("BROWN"),
+                    EnumValue::new("BLACK"),
+                    EnumValue::new("TAN"),
+                    EnumValue::new("SPOTTED"),
+                ],
+            )
             .into_meta()
     }
 }
@@ -205,78 +217,85 @@ impl FromInputValue for FurColor {
 
 impl GraphQLType for Cat {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Cat")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
-            registry.field::<Option<String>>("nickname"),
-            registry.field::<Option<bool>>("meows"),
-            registry.field::<Option<i32>>("meowVolume"),
-            registry.field::<Option<FurColor>>("furColor"),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
+            registry.field::<Option<String>>("nickname", i),
+            registry.field::<Option<bool>>("meows", i),
+            registry.field::<Option<i32>>("meowVolume", i),
+            registry.field::<Option<FurColor>>("furColor", i),
         ];
 
         registry
-            .build_object_type::<Self>(fields)
-            .interfaces(&[registry.get_type::<Being>(), registry.get_type::<Pet>()])
+            .build_object_type::<Self>(i, fields)
+            .interfaces(&[
+                registry.get_type::<Being>(i),
+                registry.get_type::<Pet>(i),
+            ])
             .into_meta()
     }
 }
 
 impl GraphQLType for CatOrDog {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("CatOrDog")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        let types = &[registry.get_type::<Cat>(), registry.get_type::<Dog>()];
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        let types = &[registry.get_type::<Cat>(i), registry.get_type::<Dog>(i)];
 
-        registry.build_union_type::<Self>(types).into_meta()
+        registry.build_union_type::<Self>(i, types).into_meta()
     }
 }
 
 impl GraphQLType for Intelligent {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Intelligent")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        let fields = &[registry.field::<Option<i32>>("iq")];
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        let fields = &[registry.field::<Option<i32>>("iq", i)];
 
-        registry.build_interface_type::<Self>(fields).into_meta()
+        registry.build_interface_type::<Self>(i, fields).into_meta()
     }
 }
 
 impl GraphQLType for Human {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Human")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
-            registry.field::<Option<Vec<Option<Pet>>>>("pets"),
-            registry.field::<Option<Vec<Human>>>("relatives"),
-            registry.field::<Option<i32>>("iq"),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
+            registry.field::<Option<Vec<Option<Pet>>>>("pets", i),
+            registry.field::<Option<Vec<Human>>>("relatives", i),
+            registry.field::<Option<i32>>("iq", i),
         ];
         registry
-            .build_object_type::<Self>(fields)
+            .build_object_type::<Self>(i, fields)
             .interfaces(&[
-                registry.get_type::<Being>(),
-                registry.get_type::<Intelligent>(),
+                registry.get_type::<Being>(i),
+                registry.get_type::<Intelligent>(i),
             ])
             .into_meta()
     }
@@ -284,25 +303,26 @@ impl GraphQLType for Human {
 
 impl GraphQLType for Alien {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("Alien")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("name")
-                .argument(registry.arg::<Option<bool>>("surname")),
-            registry.field::<Option<i32>>("iq"),
-            registry.field::<Option<i32>>("numEyes"),
+                .field::<Option<String>>("name", i)
+                .argument(registry.arg::<Option<bool>>("surname", i)),
+            registry.field::<Option<i32>>("iq", i),
+            registry.field::<Option<i32>>("numEyes", i),
         ];
 
         registry
-            .build_object_type::<Self>(fields)
+            .build_object_type::<Self>(i, fields)
             .interfaces(&[
-                registry.get_type::<Being>(),
-                registry.get_type::<Intelligent>(),
+                registry.get_type::<Being>(i),
+                registry.get_type::<Intelligent>(i),
             ])
             .into_meta()
     }
@@ -310,49 +330,54 @@ impl GraphQLType for Alien {
 
 impl GraphQLType for DogOrHuman {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("DogOrHuman")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        let types = &[registry.get_type::<Dog>(), registry.get_type::<Human>()];
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        let types = &[registry.get_type::<Dog>(i), registry.get_type::<Human>(i)];
 
-        registry.build_union_type::<Self>(types).into_meta()
+        registry.build_union_type::<Self>(i, types).into_meta()
     }
 }
 
 impl GraphQLType for HumanOrAlien {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("HumanOrAlien")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
-        let types = &[registry.get_type::<Human>(), registry.get_type::<Alien>()];
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
+        let types = &[registry.get_type::<Human>(i), registry.get_type::<Alien>(i)];
 
-        registry.build_union_type::<Self>(types).into_meta()
+        registry.build_union_type::<Self>(i, types).into_meta()
     }
 }
 
 impl GraphQLType for ComplexInput {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("ComplexInput")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
-            registry.arg::<bool>("requiredField"),
-            registry.arg::<Option<i32>>("intField"),
-            registry.arg::<Option<String>>("stringField"),
-            registry.arg::<Option<bool>>("booleanField"),
-            registry.arg::<Option<Vec<Option<String>>>>("stringListField"),
+            registry.arg::<bool>("requiredField", i),
+            registry.arg::<Option<i32>>("intField", i),
+            registry.arg::<Option<String>>("stringField", i),
+            registry.arg::<Option<bool>>("booleanField", i),
+            registry.arg::<Option<Vec<Option<String>>>>("stringListField", i),
         ];
 
-        registry.build_input_object_type::<Self>(fields).into_meta()
+        registry
+            .build_input_object_type::<Self>(i, fields)
+            .into_meta()
     }
 }
 
@@ -378,89 +403,93 @@ impl FromInputValue for ComplexInput {
 
 impl GraphQLType for ComplicatedArgs {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("ComplicatedArgs")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<String>>("intArgField")
-                .argument(registry.arg::<Option<i32>>("intArg")),
+                .field::<Option<String>>("intArgField", i)
+                .argument(registry.arg::<Option<i32>>("intArg", i)),
             registry
-                .field::<Option<String>>("nonNullIntArgField")
-                .argument(registry.arg::<i32>("nonNullIntArg")),
+                .field::<Option<String>>("nonNullIntArgField", i)
+                .argument(registry.arg::<i32>("nonNullIntArg", i)),
             registry
-                .field::<Option<String>>("stringArgField")
-                .argument(registry.arg::<Option<String>>("stringArg")),
+                .field::<Option<String>>("stringArgField", i)
+                .argument(registry.arg::<Option<String>>("stringArg", i)),
             registry
-                .field::<Option<String>>("booleanArgField")
-                .argument(registry.arg::<Option<bool>>("booleanArg")),
+                .field::<Option<String>>("booleanArgField", i)
+                .argument(registry.arg::<Option<bool>>("booleanArg", i)),
             registry
-                .field::<Option<String>>("enumArgField")
-                .argument(registry.arg::<Option<FurColor>>("enumArg")),
+                .field::<Option<String>>("enumArgField", i)
+                .argument(registry.arg::<Option<FurColor>>("enumArg", i)),
             registry
-                .field::<Option<String>>("floatArgField")
-                .argument(registry.arg::<Option<f64>>("floatArg")),
+                .field::<Option<String>>("floatArgField", i)
+                .argument(registry.arg::<Option<f64>>("floatArg", i)),
             registry
-                .field::<Option<String>>("idArgField")
-                .argument(registry.arg::<Option<ID>>("idArg")),
+                .field::<Option<String>>("idArgField", i)
+                .argument(registry.arg::<Option<ID>>("idArg", i)),
             registry
-                .field::<Option<String>>("stringListArgField")
-                .argument(registry.arg::<Option<Vec<Option<String>>>>("stringListArg")),
+                .field::<Option<String>>("stringListArgField", i)
+                .argument(
+                    registry.arg::<Option<Vec<Option<String>>>>("stringListArg", i),
+                ),
             registry
-                .field::<Option<String>>("complexArgField")
-                .argument(registry.arg::<Option<ComplexInput>>("complexArg")),
+                .field::<Option<String>>("complexArgField", i)
+                .argument(registry.arg::<Option<ComplexInput>>("complexArg", i)),
             registry
-                .field::<Option<String>>("multipleReqs")
-                .argument(registry.arg::<i32>("req1"))
-                .argument(registry.arg::<i32>("req2")),
+                .field::<Option<String>>("multipleReqs", i)
+                .argument(registry.arg::<i32>("req1", i))
+                .argument(registry.arg::<i32>("req2", i)),
             registry
-                .field::<Option<String>>("multipleOpts")
-                .argument(registry.arg_with_default("opt1", &0i32))
-                .argument(registry.arg_with_default("opt2", &0i32)),
+                .field::<Option<String>>("multipleOpts", i)
+                .argument(registry.arg_with_default("opt1", &0i32, i))
+                .argument(registry.arg_with_default("opt2", &0i32, i)),
             registry
-                .field::<Option<String>>("multipleOptAndReq")
-                .argument(registry.arg::<i32>("req1"))
-                .argument(registry.arg::<i32>("req2"))
-                .argument(registry.arg_with_default("opt1", &0i32))
-                .argument(registry.arg_with_default("opt2", &0i32)),
+                .field::<Option<String>>("multipleOptAndReq", i)
+                .argument(registry.arg::<i32>("req1", i))
+                .argument(registry.arg::<i32>("req2", i))
+                .argument(registry.arg_with_default("opt1", &0i32, i))
+                .argument(registry.arg_with_default("opt2", &0i32, i)),
         ];
 
-        registry.build_object_type::<Self>(fields).into_meta()
+        registry.build_object_type::<Self>(i, fields).into_meta()
     }
 }
 
 impl GraphQLType for QueryRoot {
     type Context = ();
+    type TypeInfo = ();
 
-    fn name() -> Option<&'static str> {
+    fn name(_: &()) -> Option<&'static str> {
         Some("QueryRoot")
     }
 
-    fn meta<'r>(registry: &mut Registry<'r>) -> MetaType<'r> {
+    fn meta<'r>(i: &(), registry: &mut Registry<'r>) -> MetaType<'r> {
         let fields = &[
             registry
-                .field::<Option<Human>>("human")
-                .argument(registry.arg::<Option<ID>>("id")),
-            registry.field::<Option<Alien>>("alien"),
-            registry.field::<Option<Dog>>("dog"),
-            registry.field::<Option<Cat>>("cat"),
-            registry.field::<Option<Pet>>("pet"),
-            registry.field::<Option<CatOrDog>>("catOrDog"),
-            registry.field::<Option<DogOrHuman>>("dorOrHuman"),
-            registry.field::<Option<HumanOrAlien>>("humanOrAlien"),
-            registry.field::<Option<ComplicatedArgs>>("complicatedArgs"),
+                .field::<Option<Human>>("human", i)
+                .argument(registry.arg::<Option<ID>>("id", i)),
+            registry.field::<Option<Alien>>("alien", i),
+            registry.field::<Option<Dog>>("dog", i),
+            registry.field::<Option<Cat>>("cat", i),
+            registry.field::<Option<Pet>>("pet", i),
+            registry.field::<Option<CatOrDog>>("catOrDog", i),
+            registry.field::<Option<DogOrHuman>>("dorOrHuman", i),
+            registry.field::<Option<HumanOrAlien>>("humanOrAlien", i),
+            registry.field::<Option<ComplicatedArgs>>("complicatedArgs", i),
         ];
 
-        registry.build_object_type::<Self>(fields).into_meta()
+        registry.build_object_type::<Self>(i, fields).into_meta()
     }
 }
 
 pub fn validate<'a, R, V, F>(r: R, q: &'a str, factory: F) -> Vec<RuleError>
 where
-    R: GraphQLType,
+    R: GraphQLType<TypeInfo = ()>,
     V: Visitor<'a> + 'a,
     F: Fn() -> V,
 {
@@ -516,7 +545,7 @@ where
 
 pub fn expect_passes_rule_with_schema<'a, R, V, F>(r: R, factory: F, q: &'a str)
 where
-    R: GraphQLType,
+    R: GraphQLType<TypeInfo = ()>,
     V: Visitor<'a> + 'a,
     F: Fn() -> V,
 {
@@ -542,7 +571,7 @@ pub fn expect_fails_rule_with_schema<'a, R, V, F>(
     q: &'a str,
     expected_errors: &[RuleError],
 ) where
-    R: GraphQLType,
+    R: GraphQLType<TypeInfo = ()>,
     V: Visitor<'a> + 'a,
     F: Fn() -> V,
 {

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -150,20 +150,21 @@ pub fn impl_enum(ast: &syn::DeriveInput) -> Tokens {
     quote! {
         impl ::juniper::GraphQLType for #ident {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&'static str> {
                 Some(#name)
             }
 
-            fn meta<'r>(registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
-                let meta = registry.build_enum_type::<#ident>(&[
+            fn meta<'r>(_: &(), registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
+                let meta = registry.build_enum_type::<#ident>(&(), &[
                     #(#values)*
                 ]);
                 #meta_description
                 meta.into_meta()
             }
 
-            fn resolve(&self, _: Option<&[::juniper::Selection]>, _: &::juniper::Executor<Self::Context>) -> ::juniper::Value {
+            fn resolve(&self, _: &(), _: Option<&[::juniper::Selection]>, _: &::juniper::Executor<Self::Context>) -> ::juniper::Value {
                 match self {
                     #(#resolves)*
                 }

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -135,12 +135,12 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
         let create_meta_field = match default {
             Some(ref def) => {
                 quote!{
-                    let field = registry.arg_with_default::<#field_ty>( #name, &#def);
+                    let field = registry.arg_with_default::<#field_ty>( #name, &#def, &());
                 }
             }
             None => {
                 quote!{
-                    let field = registry.arg::<#field_ty>(#name);
+                    let field = registry.arg::<#field_ty>(#name, &());
                 }
             }
         };
@@ -186,16 +186,17 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
     quote! {
         impl ::juniper::GraphQLType for #ident {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&'static str> {
                 Some(#name)
             }
 
-            fn meta<'r>(registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
+            fn meta<'r>(_: &(), registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
                 let fields = &[
                     #(#meta_fields)*
                 ];
-                let meta = registry.build_input_object_type::<#ident>(fields);
+                let meta = registry.build_input_object_type::<#ident>(&(), fields);
                 #meta_description
                 meta.into_meta()
             }

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -125,7 +125,7 @@ pub fn impl_object(ast: &syn::DeriveInput) -> Tokens {
 
         let meta_field = quote!{
             {
-                let field = registry.field::<#field_ty>(#name);
+                let field = registry.field::<#field_ty>(#name, &());
                 let field = #build_description;
                 let field = #build_deprecation;
                 field
@@ -137,7 +137,7 @@ pub fn impl_object(ast: &syn::DeriveInput) -> Tokens {
 
 
         let resolver = quote!{
-            #name => executor.resolve_with_ctx(&self.#field_ident),
+            #name => executor.resolve_with_ctx(&(), &self.#field_ident),
         };
         resolvers.push(resolver);
     }
@@ -145,8 +145,9 @@ pub fn impl_object(ast: &syn::DeriveInput) -> Tokens {
     let toks = quote! {
         impl ::juniper::GraphQLType for #ident {
             type Context = ();
+            type TypeInfo = ();
 
-            fn name() -> Option<&'static str> {
+            fn name(_: &()) -> Option<&str> {
                 Some(#name)
             }
 
@@ -154,16 +155,16 @@ pub fn impl_object(ast: &syn::DeriveInput) -> Tokens {
                 #name.to_string()
             }
 
-            fn meta<'r>(registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
+            fn meta<'r>(_: &(), registry: &mut ::juniper::Registry<'r>) -> ::juniper::meta::MetaType<'r> {
                 let fields = &[
                     #(#meta_fields)*
                 ];
-                let builder = registry.build_object_type::<#ident>(fields);
+                let builder = registry.build_object_type::<#ident>(&(), fields);
                 let builder = #build_description;
                 builder.into_meta()
             }
 
-            fn resolve_field(&self, field_name: &str, _: &::juniper::Arguments, executor: &::juniper::Executor<Self::Context>)
+            fn resolve_field(&self, _: &(), field_name: &str, _: &::juniper::Arguments, executor: &::juniper::Executor<Self::Context>)
                 -> ::juniper::ExecutionResult
             {
 

--- a/juniper_tests/src/codegen/derive_enum.rs
+++ b/juniper_tests/src/codegen/derive_enum.rs
@@ -1,5 +1,7 @@
+#[cfg(test)]
 use std::collections::HashMap;
 
+#[cfg(test)]
 use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
 #[derive(GraphQLEnum, Debug, PartialEq)]
@@ -14,11 +16,11 @@ enum SomeEnum {
 #[test]
 fn test_derived_enum() {
     // Ensure that rename works.
-    assert_eq!(SomeEnum::name(), Some("Some"));
+    assert_eq!(SomeEnum::name(&()), Some("Some"));
 
     // Ensure validity of meta info.
     let mut registry = juniper::Registry::new(HashMap::new());
-    let meta = SomeEnum::meta(&mut registry);
+    let meta = SomeEnum::meta(&(), &mut registry);
 
     assert_eq!(meta.name(), Some("Some"));
     assert_eq!(meta.description(), Some(&"enum descr".to_string()));

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -1,5 +1,7 @@
+#[cfg(test)]
 use std::collections::HashMap;
 
+#[cfg(test)]
 use juniper::{self, FromInputValue, GraphQLType, ToInputValue};
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
@@ -12,11 +14,11 @@ struct Input {
 
 #[test]
 fn test_derived_input_object() {
-    assert_eq!(Input::name(), Some("MyInput"));
+    assert_eq!(Input::name(&()), Some("MyInput"));
 
     // Validate meta info.
     let mut registry = juniper::Registry::new(HashMap::new());
-    let meta = Input::meta(&mut registry);
+    let meta = Input::meta(&(), &mut registry);
     assert_eq!(meta.name(), Some("MyInput"));
     assert_eq!(meta.description(), Some(&"input descr".to_string()));
 

--- a/juniper_tests/src/codegen/derive_object.rs
+++ b/juniper_tests/src/codegen/derive_object.rs
@@ -1,5 +1,7 @@
+#[cfg(test)]
 use std::collections::HashMap;
 
+#[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};
 
 #[derive(GraphQLObject, Debug, PartialEq)]
@@ -23,11 +25,11 @@ graphql_object!(Query: () |&self| {
 
 #[test]
 fn test_derived_object() {
-    assert_eq!(Obj::name(), Some("MyObj"));
+    assert_eq!(Obj::name(&()), Some("MyObj"));
 
     // Verify meta info.
     let mut registry = juniper::Registry::new(HashMap::new());
-    let meta = Obj::meta(&mut registry);
+    let meta = Obj::meta(&(), &mut registry);
 
     assert_eq!(meta.name(), Some("MyObj"));
     assert_eq!(meta.description(), Some(&"obj descr".to_string()));


### PR DESCRIPTION
Hi!

Apologies in advance for the somewhat large patch.

This is my first attempt at a feature contribution. The feature I'm trying to implement scratches an itch of my own, and has been in-use in a project of mine for quite some time now and I thought it might be nice to try and contribute it back up-stream. So I took the time today to rebase it and clean it up.

To frame the problem, I'm working on a database that provides a GraphQL-based API. The objects stored in the database are defined using a schema which the user can configure. The schema will be loaded from a configuration file at start-up.

Previously, it was only possible to define the GraphQL schema at compile time, due to the fact that the `name` and `type` methods in the `GraphQLType` trait do not take any objects as arguments which could carry any sort of schema information, i.e. they are effectively "static" functions.

This patch changes this so that a `GraphQLType` has an associated type `TypeInfo`, which can hold schema information that can be loaded at runtime and passed when constructing a `RootNode`.

I have not added support for custom `TypeInfo` when using the macros yet, so in order to leverage `TypeInfo` the traits need to be implemented manually. In practice this has proven not to be an issue at all, and I'm not even sure if it's a good idea to make the macros more powerful in that sense.

Let me know what you think!

Also, no worries at all if you feel this does not fit within your vision for the `juniper` project, it would just mean that my fork would diverge more and more, which would be sad but also acceptable for me.

But of course, my preference would be to upstream this, so if you are generally interested in the feature, but have a completely different implementation in mind, I'm happy to explore it as well!