### PR TITLE
Reject types with invalid names

### DIFF
--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use types::base::GraphQLType;
+use types::name::Name;
 use executor::{Context, Registry};
 use ast::Type;
 use schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
@@ -25,7 +26,7 @@ pub struct RootNode<'a, QueryT: GraphQLType, MutationT: GraphQLType> {
 
 /// Metadata for a schema
 pub struct SchemaType<'a> {
-    types: HashMap<String, MetaType<'a>>,
+    types: HashMap<Name, MetaType<'a>>,
     query_type_name: String,
     mutation_type_name: Option<String>,
     directives: HashMap<String, DirectiveType<'a>>,

--- a/juniper/src/types/mod.rs
+++ b/juniper/src/types/mod.rs
@@ -3,3 +3,4 @@ pub mod scalars;
 pub mod pointers;
 pub mod containers;
 pub mod utilities;
+pub mod name;

--- a/juniper/src/types/name.rs
+++ b/juniper/src/types/name.rs
@@ -1,0 +1,90 @@
+use std::borrow::Borrow;
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::str::FromStr;
+
+// Helper functions until the corresponding AsciiExt methods
+// stabilise (https://github.com/rust-lang/rust/issues/39658).
+
+fn is_ascii_alphabetic(c: char) -> bool {
+    return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
+}
+
+fn is_ascii_digit(c: char) -> bool {
+    return c >= '0' && c <= '9';
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Name(String);
+
+impl Name {
+    pub fn is_valid(input: &str) -> bool {
+        for (i, c) in input.chars().enumerate() {
+            if i == 0 {
+                if !is_ascii_alphabetic(c) && c != '_' {
+                    return false;
+                }
+            } else {
+                if !is_ascii_alphabetic(c) && !is_ascii_digit(c) && c != '_' {
+                    return false;
+                }
+            }
+        }
+        return input.len() > 0;
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NameParseError(String);
+
+impl Display for NameParseError {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        self.0.fmt(f)
+    }
+}
+
+impl Error for NameParseError {
+    fn description(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for Name {
+    type Err = NameParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if Name::is_valid(s) {
+            Ok(Name(s.to_string()))
+        } else {
+            Err(NameParseError(format!(
+                "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                s
+            )))
+        }
+    }
+}
+
+impl Borrow<String> for Name {
+    fn borrow(&self) -> &String {
+        &self.0
+    }
+}
+
+impl Borrow<str> for Name {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+#[test]
+fn test_name_is_valid() {
+    assert!(Name::is_valid("Foo"));
+    assert!(Name::is_valid("foo42"));
+    assert!(Name::is_valid("_Foo"));
+    assert!(Name::is_valid("_Foo42"));
+    assert!(Name::is_valid("_foo42"));
+    assert!(Name::is_valid("_42Foo"));
+
+    assert!(!Name::is_valid("42_Foo"));
+    assert!(!Name::is_valid("Foo-42"));
+    assert!(!Name::is_valid("Foo???"));
+}


### PR DESCRIPTION
Sets up some basic infrastructure for name validation and hooks it up to the registry.

In terms of error messages I tried to stick to the [reference implementation](https://github.com/graphql/graphql-js/blob/7ddd8dd44cb7f8a3a9f7a760d5ab76ac91802931/src/utilities/assertValidName.js#L53).

As a next step we could explore if/how to leverage `Name::is_valid` from the codegen to provide compile-time errors for invalid names, perhaps via the upcoming [`compile_error!`](https://github.com/sgrif/rfcs/blob/sg-add-error-macro/text/0000-add-error-macro.md) macro, or simply via `panic!`-ing (would love your guidance on that, @theduke).

Fixes #72