### PR TITLE
Field error refactor

### DIFF
--- a/juniper/src/executor.rs
+++ b/juniper/src/executor.rs
@@ -109,6 +109,21 @@ impl<T: Display> From<T> for FieldError {
 impl FieldError {
     /// Construct a new error with additional data
     ///
+    /// You can use the `graphql_value!` macro to construct an error:
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate juniper;
+    /// use juniper::FieldError;
+    ///
+    /// # fn sample() {
+    /// FieldError::new(
+    ///     "Could not open connection to the database",
+    ///     graphql_value!({ "internal_error": "Connection refused" })
+    /// );
+    /// # }
+    /// # fn main() { }
+    /// ```
+    ///
     /// The `data` parameter will be added to the `"data"` field of the error
     /// object in the JSON response:
     ///

--- a/juniper/src/executor.rs
+++ b/juniper/src/executor.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+use std::fmt::Display;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -51,18 +53,101 @@ where
 ///
 /// All execution errors contain the source position in the query of the field
 /// that failed to resolve. It also contains the field stack.
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub struct ExecutionError {
     location: SourcePosition,
     path: Vec<String>,
+    error: FieldError,
+}
+
+impl Eq for ExecutionError {}
+
+impl PartialOrd for ExecutionError {
+    fn partial_cmp(&self, other: &ExecutionError) -> Option<Ordering> {
+        (&self.location, &self.path, &self.error.message)
+            .partial_cmp(&(&other.location, &other.path, &other.error.message))
+    }
+}
+
+impl Ord for ExecutionError {
+    fn cmp(&self, other: &ExecutionError) -> Ordering {
+        (&self.location, &self.path, &self.error.message)
+            .cmp(&(&other.location, &other.path, &other.error.message))
+    }
+}
+
+/// Error type for errors that occur during field resolution
+///
+/// Field errors are represented by a human-readable error message and an
+/// optional `Value` structure containing additional information.
+///
+/// They can be converted to from any type that implements `std::fmt::Display`,
+/// which makes error chaining with the `?` operator a breeze:
+///
+/// ```rust
+/// # use juniper::FieldError;
+/// fn get_string(data: Vec<u8>) -> Result<String, FieldError> {
+///     let s = String::from_utf8(data)?;
+///     Ok(s)
+/// }
+/// ```
+#[derive(Debug, PartialEq)]
+pub struct FieldError {
     message: String,
+    data: Value,
+}
+
+impl<T: Display> From<T> for FieldError {
+    fn from(e: T) -> FieldError {
+        FieldError {
+            message: format!("{}", e),
+            data: Value::null(),
+        }
+    }
+}
+
+impl FieldError {
+    /// Construct a new error with additional data
+    ///
+    /// The `data` parameter will be added to the `"data"` field of the error
+    /// object in the JSON response:
+    ///
+    /// ```json
+    /// {
+    ///   "errors": [
+    ///     "message": "Could not open connection to the database",
+    ///     "locations": [{"line": 2, "column": 4}],
+    ///     "data": {
+    ///       "internal_error": "Connection refused"
+    ///     }
+    ///   ]
+    /// }
+    /// ```
+    ///
+    /// If the argument is `Value::null()`, no extra data will be included.
+    pub fn new<T: Display>(e: T, data: Value) -> FieldError {
+        FieldError {
+            message: format!("{}", e),
+            data: data,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    #[doc(hidden)]
+    pub fn data(&self) -> &Value {
+        &self.data
+    }
 }
 
 /// The result of resolving the value of a field of type `T`
-pub type FieldResult<T> = Result<T, String>;
+pub type FieldResult<T> = Result<T, FieldError>;
 
 /// The result of resolving an unspecified field
-pub type ExecutionResult = Result<Value, String>;
+pub type ExecutionResult = Result<Value, FieldError>;
 
 /// The map of variables used for substitution during query execution
 pub type Variables = HashMap<String, InputValue>;
@@ -255,7 +340,7 @@ impl<'a, CtxT> Executor<'a, CtxT> {
     }
 
     /// Add an error to the execution engine
-    pub fn push_error(&self, error: String, location: SourcePosition) {
+    pub fn push_error(&self, error: FieldError, location: SourcePosition) {
         let mut path = Vec::new();
         self.field_path.construct_path(&mut path);
 
@@ -264,7 +349,7 @@ impl<'a, CtxT> Executor<'a, CtxT> {
         errors.push(ExecutionError {
             location: location,
             path: path,
-            message: error,
+            error: error,
         });
     }
 }
@@ -289,17 +374,17 @@ impl<'a> FieldPath<'a> {
 
 impl ExecutionError {
     #[doc(hidden)]
-    pub fn new(location: SourcePosition, path: &[&str], message: &str) -> ExecutionError {
+    pub fn new(location: SourcePosition, path: &[&str], error: FieldError) -> ExecutionError {
         ExecutionError {
             location: location,
             path: path.iter().map(|s| (*s).to_owned()).collect(),
-            message: message.to_owned(),
+            error: error,
         }
     }
 
     /// The error message
-    pub fn message(&self) -> &str {
-        &self.message
+    pub fn error(&self) -> &FieldError {
+        &self.error
     }
 
     /// The source location _in the query_ of the field that failed to resolve

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -15,10 +15,10 @@ impl ser::Serialize for ExecutionError {
     where
         S: ser::Serializer,
     {
-        let mut map = try!(serializer.serialize_map(Some(3)));
+        let mut map = try!(serializer.serialize_map(Some(4)));
 
         try!(map.serialize_key("message"));
-        try!(map.serialize_value(self.message()));
+        try!(map.serialize_value(self.error().message()));
 
         let locations = vec![self.location()];
         try!(map.serialize_key("locations"));
@@ -26,6 +26,11 @@ impl ser::Serialize for ExecutionError {
 
         try!(map.serialize_key("path"));
         try!(map.serialize_value(self.path()));
+
+        if !self.error().data().is_null() {
+            try!(map.serialize_key("data"));
+            try!(map.serialize_value(self.error().data()));
+        }
 
         map.end()
     }

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -57,11 +57,12 @@ graphql_object!(User: Database |&self| {
         &self.name
     }
 
-    // FieldResult<T> is an alias for Result<T, String> - simply return
-    // a string from this method and it will be correctly inserted into
-    // the execution response.
+    // FieldResult<T> is an alias for Result<T, FieldError>, which can be
+    // converted to from anything that implements std::fmt::Display - simply
+    // return an error with a string using the ? operator from this method and
+    // it will be correctly inserted into the execution response.
     field secret() -> FieldResult<&String> {
-        Err("Can't touch this".to_owned())
+        Err("Can't touch this".to_owned())?
     }
 
     // Field accessors can optionally take an "executor" as their first
@@ -153,8 +154,8 @@ use executor::execute_validated_query;
 pub use ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
 pub use value::Value;
 pub use types::base::{Arguments, GraphQLType, TypeKind};
-pub use executor::{Context, ExecutionError, ExecutionResult, Executor, FieldResult, FromContext,
-                   IntoResolvable, Registry, Variables};
+pub use executor::{Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
+                   FromContext, IntoResolvable, Registry, Variables};
 pub use validation::RuleError;
 pub use types::scalars::{EmptyMutation, ID};
 pub use schema::model::RootNode;

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -120,10 +120,16 @@ even have to be backed by a trait!
 
 ## Emitting errors
 
-`FieldResult<T>` is a simple type alias for `Result<T, String>`. In the end,
-errors that fields emit are serialized into strings in the response. However,
-the execution system will keep track of the source of all errors, and will
-continue executing despite some fields failing.
+`FieldResult<T>` is a type alias for `Result<T, FieldError>`, where
+`FieldResult` is a tuple that contains an error message and optionally a
+JSON-like data structure. In the end, errors that fields emit are serialized
+into strings in the response. However, the execution system will keep track of
+the source of all errors, and will continue executing despite some fields
+failing.
+
+Anything that implements `std::fmt::Display` can be converted to a `FieldError`
+automatically via the `?` operator, or you can construct them yourself using
+`FieldError::new`.
 
 ```
 # #[macro_use] extern crate juniper;
@@ -136,7 +142,7 @@ graphql_object!(User: () |&self| {
     }
 
     field name() -> FieldResult<&String> {
-        Err("Does not have a name".to_owned())
+        Err("Does not have a name".to_owned())?
     }
 });
 

--- a/juniper/src/result_ext.rs
+++ b/juniper/src/result_ext.rs
@@ -1,20 +1,22 @@
 use std::fmt;
 use std::result::Result;
 
+use FieldError;
+
 /**
 Helper trait to produce `FieldResult`s
 
 `FieldResult` only have strings as errors as that's what's going out
 in the GraphQL response. As such, all errors must be manually
 converted to strings. Importing the `ResultExt` macro and using its
-only method `to_field_err` can help with that:
+only method `to_field_result` can help with that:
 
 ```rust
 use std::str::FromStr;
 use juniper::{FieldResult, ResultExt};
 
 fn sample_fn(s: &str) -> FieldResult<i32> {
-    i32::from_str(s).to_field_err()
+    i32::from_str(s).to_field_result()
 }
 
 # fn main() { assert_eq!(sample_fn("12"), Ok(12)); }
@@ -42,12 +44,12 @@ fn sample_fn(s: &str) -> FieldResult<i32> {
  */
 pub trait ResultExt<T, E: fmt::Display> {
     /// Convert the error to a string by using it's `Display` implementation
-    fn to_field_err(self) -> Result<T, String>;
+    fn to_field_result(self) -> Result<T, FieldError>;
 }
 
 impl<T, E: fmt::Display> ResultExt<T, E> for Result<T, E> {
-    fn to_field_err(self) -> Result<T, String> {
-        self.map_err(|e| format!("{}", e))
+    fn to_field_result(self) -> Result<T, FieldError> {
+        self.map_err(|e| FieldError::from(e))
     }
 }
 
@@ -59,5 +61,5 @@ trait.
  */
 #[macro_export]
 macro_rules! jtry {
-    ( $e:expr ) => { try!($crate::ResultExt::to_field_err($e)) }
+    ( $e:expr ) => { try!($crate::ResultExt::to_field_result($e)) }
 }


### PR DESCRIPTION
An initial attempt at solving #69 and #40. It pretty much matches what I wrote here: https://github.com/graphql-rust/juniper/issues/40#issuecomment-320870842.

To ease construction of custom error objects, I built a small macro to construct `Value` instances from JSON syntax. This might be a bit out of place, in which case it can be removed from the PR. I also don't think it's going to be used for other purposes, but whatever :)

This obviously breaks all users of `.to_field_err` because of the renaming and places where you return `Err("string literal".to_owned())` from a field, but all instances of e.g. `let txn = executor.context().db.transaction()?` should continue to work.