### PR TITLE
Expose current executor's location

### DIFF
--- a/juniper/src/executor.rs
+++ b/juniper/src/executor.rs
@@ -288,8 +288,7 @@ impl<'a, CtxT> Executor<'a, CtxT> {
         match self.resolve(info, value) {
             Ok(v) => v,
             Err(e) => {
-                let position = self.field_path.location().clone();
-                self.push_error(e, position);
+                self.push_error(e);
                 Value::null()
             }
         }
@@ -355,8 +354,19 @@ impl<'a, CtxT> Executor<'a, CtxT> {
         self.fragments.get(name).map(|f| *f)
     }
 
-    /// Add an error to the execution engine
-    pub fn push_error(&self, error: FieldError, location: SourcePosition) {
+    /// The current location of the executor
+    pub fn location(&self) -> &SourcePosition {
+        self.field_path.location()
+    }
+
+    /// Add an error to the execution engine at the current executor location
+    pub fn push_error(&self, error: FieldError) {
+        let location = self.location().clone();
+        self.push_error_at(error, location);
+    }
+
+    /// Add an error to the execution engine at a specific location
+    pub fn push_error_at(&self, error: FieldError, location: SourcePosition) {
         let mut path = Vec::new();
         self.field_path.construct_path(&mut path);
 

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -390,7 +390,7 @@ fn resolve_selection_set_into<T, CtxT>(
                 match field_result {
                     Ok(v) => merge_key_into(result, response_name, v),
                     Err(e) => {
-                        sub_exec.push_error(e, start_pos.clone());
+                        sub_exec.push_error_at(e, start_pos.clone());
                         result.insert((*response_name).to_owned(), Value::null());
                     }
                 }
@@ -439,7 +439,7 @@ fn resolve_selection_set_into<T, CtxT>(
                             result.insert(k, v);
                         }
                     } else if let Err(e) = sub_result {
-                        sub_exec.push_error(e, start_pos.clone());
+                        sub_exec.push_error_at(e, start_pos.clone());
                     }
                 } else {
                     resolve_selection_set_into(


### PR DESCRIPTION
`Executor` has a `push_error` method which is very useful for reporting
back errors. However, this method needs to know the location of the
error (`SourcePosition`). This commit adds a `location` method to the
executor.