### PR TITLE
Rename input value methods

### DIFF
--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -160,7 +160,7 @@ pub trait FromInputValue: Sized {
 /// Losslessly clones a Rust data type into an InputValue.
 pub trait ToInputValue: Sized {
     /// Performs the conversion.
-    fn to(&self) -> InputValue;
+    fn to_input_value(&self) -> InputValue;
 }
 
 impl<'a> Type<'a> {

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -154,7 +154,7 @@ pub type Document<'a> = Vec<Definition<'a>>;
 /// enums or scalars.
 pub trait FromInputValue: Sized {
     /// Performs the conversion.
-    fn from(v: &InputValue) -> Option<Self>;
+    fn from_input_value(v: &InputValue) -> Option<Self>;
 }
 
 /// Losslessly clones a Rust data type into an InputValue.
@@ -302,7 +302,7 @@ impl InputValue {
     where
         T: FromInputValue,
     {
-        <T as FromInputValue>::from(self)
+        <T as FromInputValue>::from_input_value(self)
     }
 
     /// Does the value represent null?

--- a/juniper/src/executor.rs
+++ b/juniper/src/executor.rs
@@ -485,7 +485,7 @@ impl<'r> Registry<'r> {
     where
         T: GraphQLType + ToInputValue + FromInputValue,
     {
-        Argument::new(name, self.get_type::<Option<T>>(info)).default_value(value.to())
+        Argument::new(name, self.get_type::<Option<T>>(info)).default_value(value.to_input_value())
     }
 
     fn insert_placeholder(&mut self, name: Name, of_type: Type<'r>) {

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -24,7 +24,7 @@ mod test {
         let raw = "123e4567-e89b-12d3-a456-426655440000";
         let input = ::InputValue::String(raw.to_string());
 
-        let parsed: Uuid = ::FromInputValue::from(&input).unwrap();
+        let parsed: Uuid = ::FromInputValue::from_input_value(&input).unwrap();
         let id = Uuid::parse_str(raw).unwrap();
 
         assert_eq!(parsed, id);

--- a/juniper/src/macros/enums.rs
+++ b/juniper/src/macros/enums.rs
@@ -94,7 +94,7 @@ macro_rules! graphql_enum {
         }
 
         impl $crate::FromInputValue for $name {
-            fn from(v: &$crate::InputValue) -> Option<$name> {
+            fn from_input_value(v: &$crate::InputValue) -> Option<$name> {
                 match v.as_enum_value().or_else(|| v.as_string_value()) {
                     $(
                         Some(graphql_enum!(@as_pattern, $ename))

--- a/juniper/src/macros/enums.rs
+++ b/juniper/src/macros/enums.rs
@@ -105,7 +105,7 @@ macro_rules! graphql_enum {
         }
 
         impl $crate::ToInputValue for $name {
-            fn to(&self) -> $crate::InputValue {
+            fn to_input_value(&self) -> $crate::InputValue {
                 match *self {
                     $(
                         graphql_enum!(@as_pattern, $eval) =>

--- a/juniper/src/macros/input_object.rs
+++ b/juniper/src/macros/input_object.rs
@@ -69,8 +69,8 @@ macro_rules! graphql_input_object {
 
                 match v {
                     $( Some(&&$crate::InputValue::Null) | None if true => $default, )*
-                        Some(v) => $crate::FromInputValue::from(v).unwrap(),
-                        _ => $crate::FromInputValue::from(&$crate::InputValue::null()).unwrap()
+                        Some(v) => $crate::FromInputValue::from_input_value(v).unwrap(),
+                        _ => $crate::FromInputValue::from_input_value(&$crate::InputValue::null()).unwrap()
                 }
             } ),*
         })
@@ -221,7 +221,7 @@ macro_rules! graphql_input_object {
         graphql_input_object!(@generate_struct_fields, $meta, $pubmod, $name, $fields);
 
         impl $crate::FromInputValue for $name {
-            fn from(value: &$crate::InputValue) -> Option<$name> {
+            fn from_input_value(value: &$crate::InputValue) -> Option<$name> {
                 if let Some(obj) = value.to_object_value() {
                     graphql_input_object!(@generate_from_input_value, $name, obj, $fields)
                 }

--- a/juniper/src/macros/input_object.rs
+++ b/juniper/src/macros/input_object.rs
@@ -84,7 +84,7 @@ macro_rules! graphql_input_object {
     ) => {
         $crate::InputValue::object(vec![
             $(
-                ($crate::to_camel_case(stringify!($field_name)), $selfvar.$field_name.to())
+                ($crate::to_camel_case(stringify!($field_name)), $selfvar.$field_name.to_input_value())
             ),*
         ].into_iter().collect())
     };
@@ -232,7 +232,7 @@ macro_rules! graphql_input_object {
         }
 
         impl $crate::ToInputValue for $name {
-            fn to(&self) -> $crate::InputValue {
+            fn to_input_value(&self) -> $crate::InputValue {
                 graphql_input_object!(@generate_to_input_value, $name, self, $fields)
             }
         }

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -51,7 +51,7 @@ macro_rules! graphql_scalar {
     // string or none).
     //
     // ( $resolve_selfvar, $resolve_body ): the "self" argument and body for the
-    // resolve() method on GraphQLType and the to() method on ToInputValue.
+    // resolve() method on GraphQLType and the to_input_value() method on ToInputValue.
     //
     // ( $fiv_arg, $fiv_result, $fiv_body ): the method argument, result type,
     // and body for the from() method on FromInputValue.
@@ -88,8 +88,8 @@ macro_rules! graphql_scalar {
         }
 
         impl $crate::ToInputValue for $name {
-            fn to(&$resolve_selfvar) -> $crate::InputValue {
-                $crate::ToInputValue::to(&$resolve_body)
+            fn to_input_value(&$resolve_selfvar) -> $crate::InputValue {
+                $crate::ToInputValue::to_input_value(&$resolve_body)
             }
         }
 

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -94,7 +94,7 @@ macro_rules! graphql_scalar {
         }
 
         impl $crate::FromInputValue for $name {
-            fn from($fiv_arg: &$crate::InputValue) -> $fiv_result {
+            fn from_input_value($fiv_arg: &$crate::InputValue) -> $fiv_result {
                 $fiv_body
             }
         }

--- a/juniper/src/macros/tests/input_object.rs
+++ b/juniper/src/macros/tests/input_object.rs
@@ -194,7 +194,7 @@ fn default_name_input_value() {
             .collect(),
     );
 
-    let dv: Option<DefaultName> = FromInputValue::from(&iv);
+    let dv: Option<DefaultName> = FromInputValue::from_input_value(&iv);
 
     assert!(dv.is_some());
 

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -345,7 +345,7 @@ impl<'a> ScalarMeta<'a> {
         ScalarMeta {
             name: name,
             description: None,
-            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from(v).is_some()),
+            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from_input_value(v).is_some()),
         }
     }
 
@@ -431,7 +431,7 @@ impl<'a> EnumMeta<'a> {
             name: name,
             description: None,
             values: values.to_vec(),
-            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from(v).is_some()),
+            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from_input_value(v).is_some()),
         }
     }
 
@@ -510,7 +510,7 @@ impl<'a> InputObjectMeta<'a> {
             name: name,
             description: None,
             input_fields: input_fields.to_vec(),
-            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from(v).is_some()),
+            try_parse_fn: Box::new(|v: &InputValue| <T as FromInputValue>::from_input_value(v).is_some()),
         }
     }
 

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -37,7 +37,7 @@ impl<T> FromInputValue for Option<T>
 where
     T: FromInputValue,
 {
-    fn from(v: &InputValue) -> Option<Option<T>> {
+    fn from_input_value(v: &InputValue) -> Option<Option<T>> {
         match v {
             &InputValue::Null => Some(None),
             v => match v.convert() {
@@ -93,7 +93,7 @@ impl<T> FromInputValue for Vec<T>
 where
     T: FromInputValue,
 {
-    fn from(v: &InputValue) -> Option<Vec<T>> {
+    fn from_input_value(v: &InputValue) -> Option<Vec<T>> {
         match *v {
             InputValue::List(ref ls) => {
                 let v: Vec<_> = ls.iter().filter_map(|i| i.item.convert()).collect();

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -52,9 +52,9 @@ impl<T> ToInputValue for Option<T>
 where
     T: ToInputValue,
 {
-    fn to(&self) -> InputValue {
+    fn to_input_value(&self) -> InputValue {
         match *self {
-            Some(ref v) => v.to(),
+            Some(ref v) => v.to_input_value(),
             None => InputValue::null(),
         }
     }
@@ -117,8 +117,8 @@ impl<T> ToInputValue for Vec<T>
 where
     T: ToInputValue,
 {
-    fn to(&self) -> InputValue {
-        InputValue::list(self.iter().map(|v| v.to()).collect())
+    fn to_input_value(&self) -> InputValue {
+        InputValue::list(self.iter().map(|v| v.to_input_value()).collect())
     }
 }
 
@@ -155,7 +155,7 @@ impl<'a, T> ToInputValue for &'a [T]
 where
     T: ToInputValue,
 {
-    fn to(&self) -> InputValue {
-        InputValue::list(self.iter().map(|v| v.to()).collect())
+    fn to_input_value(&self) -> InputValue {
+        InputValue::list(self.iter().map(|v| v.to_input_value()).collect())
     }
 }

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -54,8 +54,8 @@ impl<T> FromInputValue for Box<T>
 where
     T: FromInputValue,
 {
-    fn from(v: &InputValue) -> Option<Box<T>> {
-        match <T as FromInputValue>::from(v) {
+    fn from_input_value(v: &InputValue) -> Option<Box<T>> {
+        match <T as FromInputValue>::from_input_value(v) {
             Some(v) => Some(Box::new(v)),
             None => None,
         }

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -66,8 +66,8 @@ impl<T> ToInputValue for Box<T>
 where
     T: ToInputValue,
 {
-    fn to(&self) -> InputValue {
-        (**self).to()
+    fn to_input_value(&self) -> InputValue {
+        (**self).to_input_value()
     }
 }
 
@@ -120,7 +120,7 @@ impl<'a, T> ToInputValue for &'a T
 where
     T: ToInputValue,
 {
-    fn to(&self) -> InputValue {
-        (**self).to()
+    fn to_input_value(&self) -> InputValue {
+        (**self).to_input_value()
     }
 }

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -77,7 +77,7 @@ impl<'a> GraphQLType for &'a str {
 }
 
 impl<'a> ToInputValue for &'a str {
-    fn to(&self) -> InputValue {
+    fn to_input_value(&self) -> InputValue {
         InputValue::string(self)
     }
 }

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -141,7 +141,7 @@ impl GraphQLType for () {
 }
 
 impl FromInputValue for () {
-    fn from(_: &InputValue) -> Option<()> {
+    fn from_input_value(_: &InputValue) -> Option<()> {
         None
     }
 }

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -131,7 +131,7 @@ impl GraphQLType for DogCommand {
 }
 
 impl FromInputValue for DogCommand {
-    fn from(v: &InputValue) -> Option<DogCommand> {
+    fn from_input_value(v: &InputValue) -> Option<DogCommand> {
         match v.as_enum_value() {
             Some("SIT") => Some(DogCommand::Sit),
             Some("HEEL") => Some(DogCommand::Heel),
@@ -204,7 +204,7 @@ impl GraphQLType for FurColor {
 }
 
 impl FromInputValue for FurColor {
-    fn from(v: &InputValue) -> Option<FurColor> {
+    fn from_input_value(v: &InputValue) -> Option<FurColor> {
         match v.as_enum_value() {
             Some("BROWN") => Some(FurColor::Brown),
             Some("BLACK") => Some(FurColor::Black),
@@ -382,7 +382,7 @@ impl GraphQLType for ComplexInput {
 }
 
 impl FromInputValue for ComplexInput {
-    fn from(v: &InputValue) -> Option<ComplexInput> {
+    fn from_input_value(v: &InputValue) -> Option<ComplexInput> {
         let obj = match v.to_object_value() {
             Some(o) => o,
             None => return None,

--- a/juniper/src/value.rs
+++ b/juniper/src/value.rs
@@ -110,7 +110,7 @@ impl Value {
 }
 
 impl ToInputValue for Value {
-    fn to(&self) -> InputValue {
+    fn to_input_value(&self) -> InputValue {
         match *self {
             Value::Null => InputValue::Null,
             Value::Int(i) => InputValue::Int(i),
@@ -118,12 +118,12 @@ impl ToInputValue for Value {
             Value::String(ref s) => InputValue::String(s.clone()),
             Value::Boolean(b) => InputValue::Boolean(b),
             Value::List(ref l) => {
-                InputValue::List(l.iter().map(|x| Spanning::unlocated(x.to())).collect())
+                InputValue::List(l.iter().map(|x| Spanning::unlocated(x.to_input_value())).collect())
             }
             Value::Object(ref o) => InputValue::Object(
                 o.iter()
                     .map(|(k, v)| {
-                        (Spanning::unlocated(k.clone()), Spanning::unlocated(v.to()))
+                        (Spanning::unlocated(k.clone()), Spanning::unlocated(v.to_input_value()))
                     })
                     .collect(),
             ),

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -172,7 +172,7 @@ pub fn impl_enum(ast: &syn::DeriveInput) -> Tokens {
         }
 
         impl ::juniper::FromInputValue for #ident {
-            fn from(v: &::juniper::InputValue) -> Option<#ident> {
+            fn from_input_value(v: &::juniper::InputValue) -> Option<#ident> {
                 match v.as_enum_value().or_else(|| v.as_string_value()) {
                     #(#from_inputs)*
                     _ => None,

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -181,7 +181,7 @@ pub fn impl_enum(ast: &syn::DeriveInput) -> Tokens {
         }
 
         impl ::juniper::ToInputValue for #ident {
-            fn to(&self) -> ::juniper::InputValue {
+            fn to_input_value(&self) -> ::juniper::InputValue {
                 match self {
                     #(#to_inputs)*
                 }

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -169,8 +169,8 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
                 // TODO: investigate the unwraps here, they seem dangerous!
                 match obj.get(#name) {
                     #from_input_default
-                    Some(v) => ::juniper::FromInputValue::from(v).unwrap(),
-                    _ => ::juniper::FromInputValue::from(&::juniper::InputValue::null()).unwrap()
+                    Some(v) => ::juniper::FromInputValue::from_input_value(v).unwrap(),
+                    _ => ::juniper::FromInputValue::from_input_value(&::juniper::InputValue::null()).unwrap()
                 }
             },
         };
@@ -203,7 +203,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
         }
 
         impl ::juniper::FromInputValue for #ident {
-            fn from(value: &::juniper::InputValue) -> Option<#ident> {
+            fn from_input_value(value: &::juniper::InputValue) -> Option<#ident> {
                 if let Some(obj) = value.to_object_value() {
                     let item = #ident {
                         #(#from_inputs)*

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -178,7 +178,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
 
         // Build to_input clause.
         let to_input = quote!{
-            (#name, self.#field_ident.to()),
+            (#name, self.#field_ident.to_input_value()),
         };
         to_inputs.push(to_input);
     }
@@ -217,7 +217,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
         }
 
         impl ::juniper::ToInputValue for #ident {
-            fn to(&self) -> ::juniper::InputValue {
+            fn to_input_value(&self) -> ::juniper::InputValue {
                 ::juniper::InputValue::object(vec![
                     #(#to_inputs)*
                 ].into_iter().collect())

--- a/juniper_tests/src/codegen/derive_enum.rs
+++ b/juniper_tests/src/codegen/derive_enum.rs
@@ -28,14 +28,14 @@ fn test_derived_enum() {
     // Test Regular variant.
     assert_eq!(SomeEnum::Regular.to(), InputValue::String("REGULAR".into()));
     assert_eq!(
-        FromInputValue::from(&InputValue::String("REGULAR".into())),
+        FromInputValue::from_input_value(&InputValue::String("REGULAR".into())),
         Some(SomeEnum::Regular)
     );
 
     // Test FULL variant.
     assert_eq!(SomeEnum::Full.to(), InputValue::String("FULL".into()));
     assert_eq!(
-        FromInputValue::from(&InputValue::String("FULL".into())),
+        FromInputValue::from_input_value(&InputValue::String("FULL".into())),
         Some(SomeEnum::Full)
     );
 }

--- a/juniper_tests/src/codegen/derive_enum.rs
+++ b/juniper_tests/src/codegen/derive_enum.rs
@@ -26,14 +26,14 @@ fn test_derived_enum() {
     assert_eq!(meta.description(), Some(&"enum descr".to_string()));
 
     // Test Regular variant.
-    assert_eq!(SomeEnum::Regular.to(), InputValue::String("REGULAR".into()));
+    assert_eq!(SomeEnum::Regular.to_input_value(), InputValue::String("REGULAR".into()));
     assert_eq!(
         FromInputValue::from_input_value(&InputValue::String("REGULAR".into())),
         Some(SomeEnum::Regular)
     );
 
     // Test FULL variant.
-    assert_eq!(SomeEnum::Full.to(), InputValue::String("FULL".into()));
+    assert_eq!(SomeEnum::Full.to_input_value(), InputValue::String("FULL".into()));
     assert_eq!(
         FromInputValue::from_input_value(&InputValue::String("FULL".into())),
         Some(SomeEnum::Full)

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -26,6 +26,6 @@ fn test_derived_input_object() {
         regular_field: "a".to_string(),
         c: 33,
     };
-    let restored: Input = FromInputValue::from_input_value(&obj.to()).unwrap();
+    let restored: Input = FromInputValue::from_input_value(&obj.to_input_value()).unwrap();
     assert_eq!(obj, restored);
 }

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -26,6 +26,6 @@ fn test_derived_input_object() {
         regular_field: "a".to_string(),
         c: 33,
     };
-    let restored: Input = FromInputValue::from(&obj.to()).unwrap();
+    let restored: Input = FromInputValue::from_input_value(&obj.to()).unwrap();
     assert_eq!(obj, restored);
 }


### PR DESCRIPTION
* Rename FromInputValue::from to from_input_value
* Rename ToInputValue::to to to_input_value

Fixes #56 .