### PR TITLE
perf(schema): use FnvHashMap for type and directive names

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -25,6 +25,7 @@ expose-test-schema = []
 default = ["url", "uuid"]
 
 [dependencies]
+fnv = "1.0.3"
 ordermap = { version = "^0.2.11", features = ["serde-1"] }
 serde = { version = "^1.0.8" }
 serde_derive = {version="^1.0.8" }

--- a/juniper/src/executor.rs
+++ b/juniper/src/executor.rs
@@ -4,6 +4,8 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::RwLock;
 
+use fnv::FnvHashMap;
+
 use GraphQLError;
 use ast::{Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
           ToInputValue, Type};
@@ -24,7 +26,7 @@ use types::name::Name;
 /// into `Type` instances and automatically registers them.
 pub struct Registry<'r> {
     /// Currently registered types
-    pub types: HashMap<Name, MetaType<'r>>,
+    pub types: FnvHashMap<Name, MetaType<'r>>,
 }
 
 #[derive(Clone)]
@@ -519,7 +521,7 @@ where
 
 impl<'r> Registry<'r> {
     /// Construct a new registry
-    pub fn new(types: HashMap<Name, MetaType<'r>>) -> Registry<'r> {
+    pub fn new(types: FnvHashMap<Name, MetaType<'r>>) -> Registry<'r> {
         Registry { types: types }
     }
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -122,6 +122,7 @@ extern crate serde_derive;
 #[cfg(any(test, feature = "expose-test-schema"))]
 extern crate serde_json;
 
+extern crate fnv;
 extern crate ordermap;
 
 #[cfg(any(test, feature = "url"))]

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::fmt;
+
+use fnv::FnvHashMap;
 
 use types::base::GraphQLType;
 use types::name::Name;
@@ -26,10 +27,10 @@ pub struct RootNode<'a, QueryT: GraphQLType, MutationT: GraphQLType> {
 
 /// Metadata for a schema
 pub struct SchemaType<'a> {
-    types: HashMap<Name, MetaType<'a>>,
+    types: FnvHashMap<Name, MetaType<'a>>,
     query_type_name: String,
     mutation_type_name: Option<String>,
-    directives: HashMap<String, DirectiveType<'a>>,
+    directives: FnvHashMap<String, DirectiveType<'a>>,
 }
 
 impl<'a> Context for SchemaType<'a> {}
@@ -104,11 +105,11 @@ impl<'a> SchemaType<'a> {
         QueryT: GraphQLType,
         MutationT: GraphQLType,
     {
-        let mut directives = HashMap::new();
+        let mut directives = FnvHashMap::default();
         let query_type_name: String;
         let mutation_type_name: String;
 
-        let mut registry = Registry::new(HashMap::new());
+        let mut registry = Registry::new(FnvHashMap::default());
         query_type_name = registry
             .get_type::<QueryT>(query_info)
             .innermost_name()


### PR DESCRIPTION
Changes `SchemaType` to use a `HashMap` backed by the [https://github.com/servo/rust-fnv](Fowler–Noll–Vo hash function). This hash function performs much better for smaller inputs (think short strings like most GraphQL type names) than the default hash function, SipHash. The downside is that it does not have the same cryptographic properties, which open it up to DoS vulnerabilities when the input can be manipulated from the outside.

In this change set, I have chosen to apply FNV only to the type and directive names tracked by the `SchemaType`, for two reasons:

1. Look-ups in `SchemaType::type_by_name` and co. have been showing up as the most frequent/expensive use of hashing for my workload.
2. I believe it is reasonable to assume that a malicious party would not have control over the schema type, therefore could not leverage FNV for a DoS attack (contrary to e.g. using it in the validation logic).

Here you can see how `SchemaType::type_by_name`, `::concrete_type_by_name` as well as both `::make_type` and `ValidatorContext::with_pushed_type` (these use `type_by_name` internally) show up in my profile:

![schematype-hash-perf](https://user-images.githubusercontent.com/2677165/31069231-424b4608-a7a7-11e7-8cd1-8ca9738d7be2.jpg)

In my (somewhat limited) benchmark, the change appears to lead to a worthwhile performance improvement.

Pre:

```
Running 30s test @ http://localhost:3000/graphql
  2 threads and 4 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   572.58us  336.26us  14.93ms   97.35%
    Req/Sec     3.54k   284.33     3.93k    77.08%
  Latency Distribution
     50%  526.00us
     75%  573.00us
     90%  663.00us
     99%    1.15ms
  211827 requests in 30.10s, 26.46MB read
Requests/sec:   7037.39
Transfer/sec:      0.88MB
```

Post:

```
Running 30s test @ http://localhost:3000/graphql
  2 threads and 4 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   550.45us  213.25us   8.73ms   97.53%
    Req/Sec     3.64k   169.32     3.93k    79.87%
  Latency Distribution
     50%  520.00us
     75%  554.00us
     90%  616.00us
     99%    0.96ms
  217928 requests in 30.10s, 27.23MB read
Requests/sec:   7240.40
Transfer/sec:      0.90MB
```