### PR TITLE
Give DateTime scalars valid names to pass validation

### DIFF
--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -20,7 +20,7 @@ use ::Value;
 #[doc(hidden)]
 pub static RFC3339_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%z";
 
-graphql_scalar!(DateTime<FixedOffset> {
+graphql_scalar!(DateTime<FixedOffset> as "DateTimeFixedOffset" {
     description: "DateTime"
 
     resolve(&self) -> Value {
@@ -33,7 +33,7 @@ graphql_scalar!(DateTime<FixedOffset> {
     }
 });
 
-graphql_scalar!(DateTime<Utc> {
+graphql_scalar!(DateTime<Utc> as "DateTimeUtc" {
     description: "DateTime"
 
     resolve(&self) -> Value {


### PR DESCRIPTION
I hit this error today, which I assume is related to https://github.com/graphql-rust/juniper/pull/78

```
POST /graphql application/json:
    => Matched: POST /graphql
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: NameParseError("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"DateTime<Utc>\" does not")', src/libcore/result.rs:906:4
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::sys_common::backtrace::_print
   2: std::panicking::default_hook::{{closure}}
   3: std::panicking::default_hook
   4: std::panicking::rust_panic_with_hook
   5: std::panicking::begin_panic
   6: std::panicking::begin_panic_fmt
   7: rust_begin_unwind
   8: core::panicking::panic_fmt
   9: core::result::unwrap_failed
  10: <core::result::Result<T, E>>::unwrap
  11: juniper::executor::Registry::get_type
  12: juniper::executor::Registry::field_convert
  13: sets::graphql::schema::<impl juniper::types::base::GraphQLType for sets::db::models::Stream>::meta
  14: juniper::executor::Registry::get_type
  15: juniper::executor::Registry::build_list_type
  16: juniper::types::containers::<impl juniper::types::base::GraphQLType for alloc::vec::Vec<T>>::meta
  17: juniper::executor::Registry::get_type
  18: juniper::executor::Registry::field_convert
  19: sets::graphql::schema::<impl juniper::types::base::GraphQLType for sets::db::models::User>::meta
  20: juniper::executor::Registry::get_type
  21: juniper::executor::Registry::build_list_type
  22: juniper::types::containers::<impl juniper::types::base::GraphQLType for alloc::vec::Vec<T>>::meta
  23: juniper::executor::Registry::get_type
  24: juniper::executor::Registry::field_convert
  25: <sets::graphql::schema::Query as juniper::types::base::GraphQLType>::meta
  26: juniper::executor::Registry::get_type
  27: juniper::schema::model::SchemaType::new
  28: <juniper::schema::model::RootNode<'a, QueryT, MutationT>>::new_with_info
  29: <juniper::schema::model::RootNode<'a, QueryT, MutationT>>::new
  30: sets::routes::graphql::post_graphql_handler
  31: sets::routes::graphql::rocket_route_fn_post_graphql_handler
  32: rocket::rocket::Rocket::route
  33: rocket::rocket::Rocket::dispatch
  34: <rocket::rocket::Rocket as hyper::server::Handler>::handle
  35: <hyper::server::Worker<H>>::keep_alive_loop
  36: <hyper::server::Worker<H>>::handle_connection
  37: hyper::server::handle::{{closure}}
  38: hyper::server::listener::spawn_with::{{closure}}
```

The model of my schema that triggered this error looks like...
```rust
graphql_object!(Stream: Context |&self| {
    field id() -> i32 {
        self.id
    }
    field started_at() -> DateTime<Utc> {
        Utc.from_utc_datetime(&self.started_at)
    }
    field finished_at() -> Option<DateTime<Utc>> {
        self.finished_at.as_ref().map(|dt| Utc.from_utc_datetime(dt))
    }
    ...
});
```

I've struggled to test this as I received the following error when trying to test my fix
```
error[E0308]: mismatched types
  --> src/routes/graphql.rs:26:21
   |
26 |     request.execute(&schema, &context)
   |                     ^^^^^^^ expected struct `juniper::schema::model::RootNode`, found struct `juniper::RootNode`
   |
   = note: expected type `&juniper::schema::model::RootNode<'_, _, _>`
              found type `&juniper::RootNode<'_, graphql::schema::Query, juniper::EmptyMutation<graphql::context::Context>>`
note: Perhaps two different versions of crate `juniper` are being used?
  --> src/routes/graphql.rs:26:21
   |
26 |     request.execute(&schema, &context)
   |                     ^^^^^^^
```

If I'm simply using the library wrong, let me know. Thanks!