### PR TITLE
Fixed case where .unwrap was being called instead of the Option just being propagated up the call chain

### DIFF
--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -111,7 +111,7 @@ impl<'a> Arguments<'a> {
     {
         match self.args {
             Some(ref args) => match args.get(key) {
-                Some(v) => Some(v.convert().unwrap()),
+                Some(v) => v.convert(),
                 None => None,
             },
             None => None,


### PR DESCRIPTION
I ran into a case where Juniper was unwrapping a value and then placing it back into an Option.  It seems reasonable to just pass the Option up the call stack.

I've been playing with Juniper the last few weeks and it's really cool!  Thanks for building, maintaining and extending it!