### PR TITLE
Switched to FnvHashMap and removed nightly only features to fix failing tests

### DIFF
--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -115,11 +115,8 @@ To support this, Juniper offers additional crates that integrate with popular we
 [object_integrations]: integrations/index.html
 
 */
-#![cfg_attr(feature = "nightly", feature(test))]
 #![warn(missing_docs)]
 
-#[cfg(feature = "nightly")]
-extern crate test;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/juniper_tests/Cargo.toml
+++ b/juniper_tests/Cargo.toml
@@ -7,6 +7,9 @@ juniper = { path = "../juniper" }
 juniper_codegen = { path = "../juniper_codegen" }
 serde_json = { version = "^1.0.2" }
 
+[dev-dependencies]
+fnv = "1.0.3"
+
 [[test]]
 name = "integration_tests"
 path = "src/lib.rs"

--- a/juniper_tests/src/codegen/derive_enum.rs
+++ b/juniper_tests/src/codegen/derive_enum.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 #[cfg(test)]
 use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
@@ -19,7 +19,7 @@ fn test_derived_enum() {
     assert_eq!(SomeEnum::name(&()), Some("Some"));
 
     // Ensure validity of meta info.
-    let mut registry = juniper::Registry::new(HashMap::new());
+    let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = SomeEnum::meta(&(), &mut registry);
 
     assert_eq!(meta.name(), Some("Some"));

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 #[cfg(test)]
 use juniper::{self, FromInputValue, GraphQLType, ToInputValue};
@@ -17,7 +17,7 @@ fn test_derived_input_object() {
     assert_eq!(Input::name(&()), Some("MyInput"));
 
     // Validate meta info.
-    let mut registry = juniper::Registry::new(HashMap::new());
+    let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = Input::meta(&(), &mut registry);
     assert_eq!(meta.name(), Some("MyInput"));
     assert_eq!(meta.description(), Some(&"input descr".to_string()));

--- a/juniper_tests/src/codegen/derive_object.rs
+++ b/juniper_tests/src/codegen/derive_object.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};
@@ -28,7 +28,7 @@ fn test_derived_object() {
     assert_eq!(Obj::name(&()), Some("MyObj"));
 
     // Verify meta info.
-    let mut registry = juniper::Registry::new(HashMap::new());
+    let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = Obj::meta(&(), &mut registry);
 
     assert_eq!(meta.name(), Some("MyObj"));

--- a/juniper_tests/src/lib.rs
+++ b/juniper_tests/src/lib.rs
@@ -4,4 +4,7 @@ extern crate juniper;
 extern crate juniper_codegen;
 extern crate serde_json;
 
+#[cfg(test)]
+extern crate fnv;
+
 mod codegen;


### PR DESCRIPTION
* Tests needed to be updated from `std::collections::HashMap` to `fnv::FnvHashMap` to match the `Registry` constructor
* Nightly only features needed to be removed for stable branches to pass in CI