### PR TITLE
Derive Clone for GraphQLRequest

### DIFF
--- a/juniper/src/http.rs
+++ b/juniper/src/http.rs
@@ -14,7 +14,7 @@ use executor::ExecutionError;
 ///
 /// For GET, you will need to parse the query string and exctract "query",
 /// "operationName", and "variables" manually.
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct GraphQLRequest {
     query: String,
     #[serde(rename = "operationName")]


### PR DESCRIPTION
This is just a useful thing for me because I need to clone the http request.

This shouldn't really influence anything else, every field already implements `Clone`