### PR TITLE
windows build fix

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,4 @@
 
 [tasks.init]
-condition = { channels = ["beta", "stable"] }
+condition = { channels = ["beta", "stable"], env = { "TARGET" = "x86_64-pc-windows-msvc" } }
 env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "juniper_rocket" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,4 @@
 
 [tasks.init]
-condition = { channels = ["beta", "stable"], env = { "TARGET" = "x86_64-pc-windows-msvc" } }
+condition = { channels = ["beta", "stable"], env = { "TARGET" = "x86_64-pc-windows-gnu" } }
 env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "juniper_rocket" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,4 @@
 
 [tasks.init]
 condition = { channels = ["beta", "stable"] }
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "juniper_rocket;juniper_tests" }
+env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "juniper_rocket" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,7 @@
 
 [tasks.init]
-condition = { channels = ["beta", "stable"], env = { "TARGET" = "x86_64-pc-windows-gnu" } }
+condition = { channels = ["beta", "stable"] }
 env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "juniper_rocket" }
+
+[tasks.init.windows]
+condition = { channels = ["beta", "stable"], env = { "TARGET" = "x86_64-pc-windows-gnu" } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,9 +37,5 @@ install:
 build: false
 
 test_script:
-   - cd juniper && cargo build --verbose && cargo test --verbose && cd ..
-   - cd juniper_codegen && cargo build --verbose && cargo test --verbose && cd ..
-   - cd juniper_tests && cargo build --verbose && cargo test --verbose && cd ..
-   - cd juniper_iron && cargo build --verbose && cargo test --verbose && cd ..
-   - IF NOT %TARGET% == %TARGET:msvc=% ( IF %CHANNEL% == "nightly" ( cd juniper_rocket && cargo test --verbose && cargo build --verbose && cd .. ) )
+   - cargo make workspace-ci-flow --no-workspace
 

--- a/juniper_tests/Makefile.toml
+++ b/juniper_tests/Makefile.toml
@@ -1,0 +1,6 @@
+
+[tasks.build-verbose]
+args = ["build", "--verbose"]
+
+[tasks.test-verbose]
+args = ["test", "--verbose"]


### PR DESCRIPTION
**please do not merge until both linux and windows builds finish successfully.**

The changes include

* remove the --all-features from the juniper tests
* skip juniper rocket for beta/stable rust channel.
* both appveyor and travis will invoke the exact same flow.