### PR TITLE
Update Rocket to latest version

### DIFF
--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = {version="1.0.2" }
 serde_json = { version = "1.0.2" }
 juniper = { version = "0.9.1" , path = "../juniper"}
 
-rocket = { version = "0.3.0" }
-rocket_codegen = { version = "0.3.0" }
+rocket = { version = "0.3.4" }
+rocket_codegen = { version = "0.3.4" }
 
 [dev-dependencies.juniper]
 version = "0.9.1"


### PR DESCRIPTION
Rocket requires nightly, but on nightly 2017-12-13 and after
the version juniper's integration was using wouldn't
build. This is solved by updating Rocket to `0.3.4` which
according to the [changelog](https://github.com/SergioBenitez/Rocket/blob/v0.3.4/CHANGELOG.md#version-034-dec-14-2017):

"Codegen was updated for 2017-12-13 nightly."