### PR TITLE
Add a master changelog

### DIFF
--- a/changelog/master.md
+++ b/changelog/master.md
@@ -1,0 +1,9 @@
+## [master]
+
+## Changes
+
+### `__typename` for unions
+
+The [`__typename`](http://graphql.org/learn/queries/#meta-fields) query meta-field now works on unions.
+
+[#112](https://github.com/graphql-rust/juniper/issues/112)

--- a/juniper_rocket/changelog/master.md
+++ b/juniper_rocket/changelog/master.md
@@ -1,0 +1,12 @@
+## [master]
+
+## Changes
+
+### Rocket updated to `0.3.6`
+
+* [Rocket](https://rocket.rs) integration now requires Rocket `0.3.6` to
+  support building with recent Rust nightlies.
+
+  Additional information and supported nightly versions can be found in [Rocket's changelog](https://github.com/SergioBenitez/Rocket/blob/master/CHANGELOG.md#version-036-jan-12-2018).
+
+  [#125](https://github.com/graphql-rust/juniper/issues/125)


### PR DESCRIPTION
This makes it so people using git dependencies know what has changed. It also
gives a spot to make a running changelog so when we do a release we can just
copy and paste.