### PR TITLE
Update rocket in juniper_rocket to work with latest nightlies

### DIFF
--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = {version="1.0.2" }
 serde_json = { version = "1.0.2" }
 juniper = { version = "0.9.1" , path = "../juniper"}
 
-rocket = { version = "0.3.4" }
-rocket_codegen = { version = "0.3.4" }
+rocket = { version = "0.3.6" }
+rocket_codegen = { version = "0.3.6" }
 
 [dev-dependencies.juniper]
 version = "0.9.1"


### PR DESCRIPTION
`juniper_rocket` now requires nightly >= 2018-01-12. See
https://github.com/SergioBenitez/Rocket/issues/513#issuecomment-357407524.

Fixes https://github.com/graphql-rust/juniper/issues/125.