### PR TITLE
Support std::time types via humantime

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0.8" }
 serde_derive = {version="1.0.2" }
 
 chrono = { version = "0.4.0", optional = true }
+humantime = { version = "1.1.0", optional = true }
 serde_json = { version="1.0.2", optional = true }
 url = { version = "1.5.1", optional = true }
 uuid = { version = "0.5.1", optional = true }

--- a/juniper/src/integrations/humantime.rs
+++ b/juniper/src/integrations/humantime.rs
@@ -1,0 +1,40 @@
+use std::time::{SystemTime};
+
+use humantime::{parse_rfc3339_weak, format_rfc3339};
+
+use Value;
+
+graphql_scalar!(SystemTime as "DateTime" {
+    description: "DateTime represented as a RFC3339 string (in UTC)"
+
+    resolve(&self) -> Value {
+        Value::string(format_rfc3339(*self).to_string())
+    }
+
+    from_input_value(v: &InputValue) -> Option<SystemTime> {
+        v.as_string_value().and_then(|s| {
+            // Uses permissive parser for input
+            parse_rfc3339_weak(s).ok()
+        })
+    }
+});
+
+
+#[cfg(test)]
+mod test {
+    use std::time::{SystemTime, Duration, UNIX_EPOCH};
+
+    fn datetime_utc_test(raw: &'static str, sec: u64) {
+        let input = ::InputValue::String(raw.to_string());
+
+        let parsed: SystemTime = ::FromInputValue::from_input_value(&input).unwrap();
+        let expected: SystemTime = UNIX_EPOCH + Duration::new(sec, 0);
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn datetime_utc_from_input_value() {
+        datetime_utc_test("2014-11-28T21:00:09Z", 1417208409)
+    }
+
+}

--- a/juniper/src/integrations/humantime.rs
+++ b/juniper/src/integrations/humantime.rs
@@ -1,6 +1,7 @@
-use std::time::{SystemTime};
+use std::time::{SystemTime, Duration};
 
 use humantime::{parse_rfc3339_weak, format_rfc3339};
+use humantime::{parse_duration, format_duration};
 
 use Value;
 
@@ -19,6 +20,20 @@ graphql_scalar!(SystemTime as "DateTime" {
     }
 });
 
+graphql_scalar!(Duration as "Duration" {
+    description: "Duration in human-readable form, like '15min 2ms'"
+
+    resolve(&self) -> Value {
+        Value::string(format_duration(*self).to_string())
+    }
+
+    from_input_value(v: &InputValue) -> Option<Duration> {
+        v.as_string_value().and_then(|s| {
+            parse_duration(s).ok()
+        })
+    }
+});
+
 
 #[cfg(test)]
 mod test {
@@ -32,9 +47,20 @@ mod test {
         assert_eq!(parsed, expected);
     }
 
+    fn duration(raw: &'static str) -> Duration {
+        let input = ::InputValue::String(raw.to_string());
+        ::FromInputValue::from_input_value(&input).unwrap()
+    }
+
     #[test]
     fn datetime_utc_from_input_value() {
         datetime_utc_test("2014-11-28T21:00:09Z", 1417208409)
+    }
+
+    #[test]
+    fn duration_test() {
+        assert_eq!(duration("2min"), Duration::new(120, 0));
+        assert_eq!(duration("2m 15sec 12ms"), Duration::new(135, 12_000_000));
     }
 
 }

--- a/juniper/src/integrations/mod.rs
+++ b/juniper/src/integrations/mod.rs
@@ -13,3 +13,7 @@ pub mod url;
 #[cfg(feature = "uuid")]
 /// GraphQL support for [uuid](https://doc.rust-lang.org/uuid/uuid/struct.Uuid.html) types.
 pub mod uuid;
+
+#[cfg(feature = "humantime")]
+/// GraphQL support for stdlib timestamps via [humantime](https://crates.io/crates/humantime) types.
+pub mod humantime;

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -109,6 +109,9 @@ extern crate url;
 #[cfg(any(test, feature = "uuid"))]
 extern crate uuid;
 
+#[cfg(any(test, feature = "humantime"))]
+extern crate humantime;
+
 // Depend on juniper_codegen and re-export everything in it.
 // This allows users to just depend on juniper and get the derive functionality automatically.
 #[allow(unused_imports)]


### PR DESCRIPTION
Hi,

I've noticed two things in current juniper:
1. It doesn't support stdlib's SystemTime
2. Even if I want to use chrono's types, the `time` crate it depends on doesn't work on wasm (and I do use juniper on wasm32-unknown-unknown)

Also, I've recently added timestamp parsing and formatting to `humantime`, so I feel it's a good match here. Here are [benchmarks](https://users.rust-lang.org/t/whats-everyone-working-on-this-week-7-2018/15587/17) for humantime against chrono. And [binary size/dependency tree comparison](https://github.com/sebasmagri/env_logger/pull/67#issue-169754040) (this is on different use case so take it with a grain of salt).

It looks like timestamps in the form of rfc3339 are more or less standard in graphql community. But I'm less sure for durations. While durations like humantime represents are good for configuration files they are less convenient for calculations. So we may favor millisecond representation for javascript. I've put Duration support in different commit which we can remove it.

What do you think?