### PR TITLE
Fix merging parallel inline fragments

### DIFF
--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -455,7 +455,7 @@ where
 
                     if let Ok(Value::Object(mut hash_map)) = sub_result {
                         for (k, v) in hash_map.drain(..) {
-                            result.insert(k, v);
+                            merge_key_into(result, &k, v);
                         }
                     } else if let Err(e) = sub_result {
                         sub_exec.push_error_at(e, start_pos.clone());

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -505,11 +505,29 @@ fn is_excluded(directives: &Option<Vec<Spanning<Directive>>>, vars: &Variables) 
 
 fn merge_key_into(result: &mut OrderMap<String, Value>, response_name: &str, value: Value) {
     match result.entry(response_name.to_owned()) {
-        Entry::Occupied(mut e) => match (e.get_mut().as_mut_object_value(), value) {
-            (Some(dest_obj), Value::Object(src_obj)) => {
-                merge_maps(dest_obj, src_obj);
+        Entry::Occupied(mut e) => {
+            match e.get_mut() {
+                &mut Value::Object(ref mut dest_obj) => {
+                    if let Value::Object(src_obj) = value {
+                        merge_maps(dest_obj, src_obj);
+                    }
+                },
+                &mut Value::List(ref mut dest_list) => {
+                    if let Value::List(src_list) = value {
+                        dest_list.iter_mut().zip(src_list.into_iter()).for_each(|(d, s)| {
+                            match d {
+                                &mut Value::Object(ref mut d_obj) => {
+                                    if let Value::Object(s_obj) = s {
+                                        merge_maps(d_obj, s_obj);
+                                    }
+                                },
+                                _ => {},
+                            }
+                        });
+                    }
+                },
+                _ => {}
             }
-            _ => {}
         },
         Entry::Vacant(e) => {
             e.insert(value);


### PR DESCRIPTION
Currently, this:

```
query Query {
 user {
   ... Fragment
 }
}

fragment Fragment {
 a
 ... on User {
  b
 }
}
```

returns

```
{
  "user": {
    "b": <value>
  }
}
```

overriding the previous parallel fragment definition. This issue was fixed for pre-defined parallel fragments in https://github.com/graphql-rust/juniper/commit/c5552419780a8d4fccf5c34c5c24bc976829fd4e, the merge logic just hadn't been applied to inline fragments.

This adds that logic (a 1 line change) and adds a test.