### PR TITLE
Fix warning in `iron_juniper`

### DIFF
--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -265,7 +265,7 @@ where
         let graphql_request = match req.method {
             method::Get => self.handle_get(&mut req)?,
             method::Post => self.handle_post(&mut req)?,
-            _ => return Ok(Response::with((status::MethodNotAllowed))),
+            _ => return Ok(Response::with(status::MethodNotAllowed)),
         };
 
         self.execute(&context, graphql_request)


### PR DESCRIPTION
The warning was:

```
warning: unnecessary parentheses around function argument
   --> juniper_iron/src/lib.rs:268:43
    |
268 |             _ => return Ok(Response::with((status::MethodNotAllowed))),
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: #[warn(unused_parens)] on by default
```