### PR TITLE
Make tests compile on latest nightly

### DIFF
--- a/juniper/src/value.rs
+++ b/juniper/src/value.rs
@@ -196,10 +196,12 @@ where
 /// ```rust
 /// #[macro_use] extern crate juniper;
 ///
+/// # fn main() {
 /// graphql_value!(1234);
 /// graphql_value!("test");
 /// graphql_value!([ 1234, "test", true ]);
 /// graphql_value!({ "key": "value", "foo": 1234 });
+/// # }
 /// ```
 #[macro_export]
 macro_rules! graphql_value {


### PR DESCRIPTION
Without this change tests were failing to compile:

```
---- src/value.rs - graphql_value (line 196) stdout ----
    error[E0468]: an `extern crate` loading macros must be at the crate root
 --> src/value.rs:197:14
  |
3 | #[macro_use] extern crate juniper;
  |              ^^^^^^^^^^^^^^^^^^^^^

thread 'rustc' panicked at 'couldn't compile the test', librustdoc/test.rs:295:13
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

I also confirmed that `main` does not show up in the docs with
this change.