### PR TITLE
Change serialization of Chronos NaiveDate

### DIFF
--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -19,7 +19,6 @@ use Value;
 
 #[doc(hidden)]
 pub static RFC3339_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%.f%:z";
-static RFC3339_PARSE_FORMAT: &'static str = "%+";
 
 graphql_scalar!(DateTime<FixedOffset> as "DateTimeFixedOffset" {
     description: "DateTime"
@@ -82,9 +81,7 @@ graphql_scalar!(NaiveDateTime {
 
 #[cfg(test)]
 mod test {
-    use super::RFC3339_PARSE_FORMAT;
     use chrono::prelude::*;
-    use Value;
 
     fn datetime_fixedoffset_test(raw: &'static str) {
         let input = ::InputValue::String(raw.to_string());
@@ -136,8 +133,12 @@ mod test {
         datetime_utc_test("2014-11-28T21:00:09.005+09:00");
     }
 
-    fn naivedate_test(raw: &'static str, y: i32, m: u32, d: u32) {
-        let input = ::InputValue::String(raw.to_string());
+    #[test]
+    fn naivedate_from_input_value() {
+        let input = ::InputValue::String("1996-12-19".to_string());
+        let y = 1996;
+        let m = 12;
+        let d = 19;
 
         let parsed: NaiveDate = ::FromInputValue::from_input_value(&input).unwrap();
         let expected = NaiveDate::from_ymd(y, m, d);
@@ -150,21 +151,6 @@ mod test {
     }
 
     #[test]
-    fn naivedate_from_input_value() {
-        naivedate_test("1996-12-19", 1996, 12, 19);
-    }
-
-    #[test]
-    fn naivedate_serialization() {
-        use types::base::GraphQLType;
-
-        let date = NaiveDate::from_ymd(2000, 1, 2);
-        let value = date.resolve(&(), None, &executor::Executor);
-        let expected = Value::string("2000-01-02".to_string());
-        assert_eq!(value, expected);
-    }
-
-    #[test]
     fn naivedatetime_from_input_value() {
         let raw = 1_000_000_000_f64;
         let input = ::InputValue::Float(raw);
@@ -174,5 +160,70 @@ mod test {
 
         assert_eq!(parsed, expected);
         assert_eq!(raw, expected.timestamp() as f64);
+    }
+}
+
+#[cfg(test)]
+mod integration_test {
+    use chrono::prelude::*;
+    use chrono::Utc;
+
+    use executor::Variables;
+    use value::Value;
+    use schema::model::RootNode;
+    use types::scalars::EmptyMutation;
+
+    #[test]
+    fn test_serialization() {
+        struct Root {}
+        graphql_object!(Root: () |&self| {
+            field exampleNaiveDate() -> NaiveDate {
+                NaiveDate::from_ymd(2015, 3, 14)
+            }
+            field exampleNaiveDateTime() -> NaiveDateTime {
+                NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11)
+            }
+            field exampleDateTimeFixedOffset() -> DateTime<FixedOffset> {
+              DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").unwrap()
+            }
+            field exampleDateTimeUtc() -> DateTime<Utc> {
+              Utc.timestamp(61, 0)
+            }
+        });
+
+        let doc = r#"
+        {
+            exampleNaiveDate,
+            exampleNaiveDateTime,
+            exampleDateTimeFixedOffset,
+            exampleDateTimeUtc,
+        }
+        "#;
+
+        let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
+
+        let (result, errs) =
+            ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+
+        assert_eq!(errs, []);
+
+        assert_eq!(
+            result,
+            Value::object(
+                vec![
+                    ("exampleNaiveDate", Value::string("2015-03-14")),
+                    ("exampleNaiveDateTime", Value::float(1467969011.0)),
+                    (
+                        "exampleDateTimeFixedOffset",
+                        Value::string("1996-12-19T16:39:57-08:00"),
+                    ),
+                    (
+                        "exampleDateTimeUtc",
+                        Value::string("1970-01-01T00:01:01+00:00"),
+                    ),
+                ].into_iter()
+                    .collect()
+            )
+        );
     }
 }

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -6,7 +6,7 @@
 |-------------------------|------------------------|-------------------------------------------|
 | `DateTime<FixedOffset>` | RFC3339 string         |                                           |
 | `DateTime<Utc>`         | RFC3339 string         |                                           |
-| `NaiveDate`             | RFC3339 string         |                                           |
+| `NaiveDate`             | YYYY-MM-DD             |                                           |
 | `NaiveDateTime`         | float (unix timestamp) | JSON numbers (i.e. IEEE doubles) are not  |
 |                         |                        | precise enough for nanoseconds.           |
 |                         |                        | Values will be truncated to microsecond   |


### PR DESCRIPTION
https://github.com/graphql-rust/juniper/issues/150

`NaiveDate` should serialize / deserialize from "2018-01-02" instead of a full ISO date.