### PR TITLE
Add helpers to build custom GraphQLResponse

### DIFF
--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -69,6 +69,17 @@ pub struct ExecutionError {
     error: FieldError,
 }
 
+impl ExecutionError {
+    /// Construct a new execution error occuring at the beginning of the query
+    pub fn at_origin(error: FieldError) -> ExecutionError {
+        ExecutionError {
+            location: SourcePosition::new_origin(),
+            path: Vec::new(),
+            error: error,
+        }
+    }
+}
+
 impl Eq for ExecutionError {}
 
 impl PartialOrd for ExecutionError {

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -7,7 +7,7 @@ use serde::ser::SerializeMap;
 
 use ast::InputValue;
 use executor::ExecutionError;
-use {GraphQLError, GraphQLType, RootNode, Value, Variables};
+use {FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
 
 /// The expected structure of the decoded JSON document for either POST or GET requests.
 ///
@@ -86,6 +86,11 @@ impl GraphQLRequest {
 pub struct GraphQLResponse<'a>(Result<(Value, Vec<ExecutionError>), GraphQLError<'a>>);
 
 impl<'a> GraphQLResponse<'a> {
+    /// Constructs an error response outside of the normal execution flow
+    pub fn error(error: FieldError) -> Self {
+        GraphQLResponse(Ok((Value::null(), vec![ExecutionError::at_origin(error)])))
+    }
+
     /// Was the request successful or not?
     ///
     /// Note that there still might be errors in the response even though it's

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -113,15 +113,18 @@ impl GraphQLResponse {
     /// # extern crate juniper_rocket;
     /// # extern crate rocket;
     /// #
+    /// # use rocket::http::Cookies;
     /// # use rocket::response::content;
     /// # use rocket::State;
     /// #
     /// # use juniper::tests::model::Database;
     /// # use juniper::{EmptyMutation, FieldError, RootNode, Value};
     /// #
+    /// # type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
+    /// #
     /// #[get("/graphql?<request>")]
     /// fn get_graphql_handler(
-    ///     cookies: Cookies,
+    ///     mut cookies: Cookies,
     ///     context: State<Database>,
     ///     request: juniper_rocket::GraphQLRequest,
     ///     schema: State<Schema>,

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -102,6 +102,38 @@ impl GraphQLRequest {
 
 impl GraphQLResponse {
     /// Constructs an error response outside of the normal execution flow
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(plugin)]
+    /// # #![plugin(rocket_codegen)]
+    /// #
+    /// # extern crate juniper;
+    /// # extern crate juniper_rocket;
+    /// # extern crate rocket;
+    /// #
+    /// # use rocket::response::content;
+    /// # use rocket::State;
+    /// #
+    /// # use juniper::tests::model::Database;
+    /// # use juniper::{EmptyMutation, FieldError, RootNode, Value};
+    /// #
+    /// #[get("/graphql?<request>")]
+    /// fn get_graphql_handler(
+    ///     cookies: Cookies,
+    ///     context: State<Database>,
+    ///     request: juniper_rocket::GraphQLRequest,
+    ///     schema: State<Schema>,
+    /// ) -> juniper_rocket::GraphQLResponse {
+    ///     if cookies.get_private("user_id").is_none() {
+    ///         let err = FieldError::new("User is not logged in", Value::null());
+    ///         return juniper_rocket::GraphQLResponse::error(err);
+    ///     }
+    ///
+    ///     request.execute(&schema, &context)
+    /// }
+    /// ```
     pub fn error(error: FieldError) -> Self {
         let response = http::GraphQLResponse::error(error);
         let json = serde_json::to_string(&response).unwrap();

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -58,6 +58,7 @@ use juniper::InputValue;
 use juniper::http;
 
 use juniper::GraphQLType;
+use juniper::FieldError;
 use juniper::RootNode;
 
 /// Simple wrapper around an incoming GraphQL request
@@ -95,6 +96,25 @@ impl GraphQLRequest {
         };
         let json = serde_json::to_string(&response).unwrap();
 
+        GraphQLResponse(status, json)
+    }
+}
+
+impl GraphQLResponse {
+    /// Constructs an error response outside of the normal execution flow
+    pub fn error(error: FieldError) -> Self {
+        let response = http::GraphQLResponse::error(error);
+        let json = serde_json::to_string(&response).unwrap();
+        GraphQLResponse(Status::BadRequest, json)
+    }
+
+    /// Constructs a custom response outside of the normal execution flow
+    ///
+    /// This is intended for highly customized integrations and should only
+    /// be used as a last resort. For normal juniper use, use the response
+    /// from GraphQLRequest::execute(..).
+    pub fn custom(status: Status, response: serde_json::Value) -> Self {
+        let json = serde_json::to_string(&response).unwrap();
         GraphQLResponse(status, json)
     }
 }


### PR DESCRIPTION
While using juniper with Rocket, I found the desire to create custom GraphQLResponses without having to call execute; specifically Rocket has a separate error handling flow that I want to allow to sometimes return normal GraphQLResponse errors.

This adds helpers to manually construct graphql responses with errors.