### PR TITLE
Add a ResultExt trait to replace the current `From<Display>` error

### DIFF
--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -107,6 +107,7 @@ pub struct FieldError {
     data: Value,
 }
 
+/*
 impl<T: Display> From<T> for FieldError {
     fn from(e: T) -> FieldError {
         FieldError {
@@ -115,6 +116,7 @@ impl<T: Display> From<T> for FieldError {
         }
     }
 }
+*/
 
 impl FieldError {
     /// Construct a new error with additional data
@@ -165,6 +167,21 @@ impl FieldError {
     #[doc(hidden)]
     pub fn data(&self) -> &Value {
         &self.data
+    }
+}
+
+pub trait FieldResultExt<T, E> {
+    fn fmt_err(self) -> Result<T, FieldError>;
+}
+
+impl<T, E> FieldResultExt<T, E> for Result<T, E>
+    where E: Display
+{
+    fn fmt_err(self) -> Result<T, FieldError> {
+        self.map_err(|e| FieldError {
+            message: format!("{}", e),
+            data: Value::null(),
+        })
     }
 }
 


### PR DESCRIPTION
See the reasoning for this change in https://github.com/graphql-rust/juniper/issues/157