### PR TITLE
(juniper_rocket) Bump minimum rocket version to 0.3.9

### DIFF
--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = {version="1.0.2" }
 serde_json = { version = "1.0.2" }
 juniper = { version = "0.9.2" , path = "../juniper"}
 
-rocket = { version = "0.3.6" }
-rocket_codegen = { version = "0.3.6" }
+rocket = { version = "0.3.9" }
+rocket_codegen = { version = "0.3.9" }
 
 [dev-dependencies.juniper]
 version = "0.9.2"


### PR DESCRIPTION
Needed to bump minimum version to allow working on latest nightly.