### PR TITLE
Do not assign `field` to itself if no description specified when deriving input object

### DIFF
--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -148,7 +148,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
         };
         let field_description = match field_attrs.description {
             Some(s) => quote!{ let field = field.description(#s); },
-            None => quote!{ let field = field; },
+            None => quote!{},
         };
 
         let default = {
@@ -197,7 +197,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
         };
         meta_fields.push(meta_field);
 
-        // Buil from_input clause.
+        // Build from_input clause.
 
         let from_input_default = match default {
             Some(ref def) => {


### PR DESCRIPTION
If a field has a description, we properly generate a meta field definition like:

```rust
{
  let field = registry.field::<String>("id", &());
  let field = field.description("Whatever");
  field
}
```

If a field does not have a description, we were generating something like:

```rust
{
  let field = registry.field::<String>("id", &());
  let field = field; // <--- Note not needed
  field
}
```

This of course works (and was likely optimized out by the compiler), but bloats
generated code for no benefit.

This change merely makes the second case generate:

```rust
{
  let field = registry.field::<String>("id", &());

  field
}
```

Fixes https://github.com/graphql-rust/juniper/issues/185.