### PR TITLE
Some performance improvements

### DIFF
--- a/juniper/src/executor_tests/directives.rs
+++ b/juniper/src/executor_tests/directives.rs
@@ -1,9 +1,7 @@
-use indexmap::IndexMap;
-
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 struct TestType;
 
@@ -19,7 +17,7 @@ graphql_object!(TestType: () |&self| {
 
 fn run_variable_query<F>(query: &str, vars: Variables, f: F)
 where
-    F: Fn(&IndexMap<String, Value>) -> (),
+    F: Fn(&Object) -> (),
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
@@ -36,7 +34,7 @@ where
 
 fn run_query<F>(query: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>) -> (),
+    F: Fn(&Object) -> (),
 {
     run_variable_query(query, Variables::new(), f);
 }
@@ -44,32 +42,32 @@ where
 #[test]
 fn scalar_include_true() {
     run_query("{ a, b @include(if: true) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn scalar_include_false() {
     run_query("{ a, b @include(if: false) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn scalar_skip_false() {
     run_query("{ a, b @skip(if: false) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn scalar_skip_true() {
     run_query("{ a, b @skip(if: true) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
@@ -78,8 +76,8 @@ fn fragment_spread_include_true() {
     run_query(
         "{ a, ...Frag @include(if: true) } fragment Frag on TestType { b }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), Some(&Value::string("b")));
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
         },
     );
 }
@@ -89,8 +87,8 @@ fn fragment_spread_include_false() {
     run_query(
         "{ a, ...Frag @include(if: false) } fragment Frag on TestType { b }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), None);
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), None);
         },
     );
 }
@@ -100,8 +98,8 @@ fn fragment_spread_skip_false() {
     run_query(
         "{ a, ...Frag @skip(if: false) } fragment Frag on TestType { b }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), Some(&Value::string("b")));
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
         },
     );
 }
@@ -111,8 +109,8 @@ fn fragment_spread_skip_true() {
     run_query(
         "{ a, ...Frag @skip(if: true) } fragment Frag on TestType { b }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), None);
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), None);
         },
     );
 }
@@ -122,8 +120,8 @@ fn inline_fragment_include_true() {
     run_query(
         "{ a, ... on TestType @include(if: true) { b } }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), Some(&Value::string("b")));
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
         },
     );
 }
@@ -133,8 +131,8 @@ fn inline_fragment_include_false() {
     run_query(
         "{ a, ... on TestType @include(if: false) { b } }",
         |result| {
-            assert_eq!(result.get("a"), Some(&Value::string("a")));
-            assert_eq!(result.get("b"), None);
+            assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+            assert_eq!(result.get_field_value("b"), None);
         },
     );
 }
@@ -142,79 +140,79 @@ fn inline_fragment_include_false() {
 #[test]
 fn inline_fragment_skip_false() {
     run_query("{ a, ... on TestType @skip(if: false) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn inline_fragment_skip_true() {
     run_query("{ a, ... on TestType @skip(if: true) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn anonymous_inline_fragment_include_true() {
     run_query("{ a, ... @include(if: true) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn anonymous_inline_fragment_include_false() {
     run_query("{ a, ... @include(if: false) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn anonymous_inline_fragment_skip_false() {
     run_query("{ a, ... @skip(if: false) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn anonymous_inline_fragment_skip_true() {
     run_query("{ a, ... @skip(if: true) { b } }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn scalar_include_true_skip_true() {
     run_query("{ a, b @include(if: true) @skip(if: true) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn scalar_include_true_skip_false() {
     run_query("{ a, b @include(if: true) @skip(if: false) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), Some(&Value::string("b")));
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), Some(&Value::string("b")));
     });
 }
 
 #[test]
 fn scalar_include_false_skip_true() {
     run_query("{ a, b @include(if: false) @skip(if: true) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }
 
 #[test]
 fn scalar_include_false_skip_false() {
     run_query("{ a, b @include(if: false) @skip(if: false) }", |result| {
-        assert_eq!(result.get("a"), Some(&Value::string("a")));
-        assert_eq!(result.get("b"), None);
+        assert_eq!(result.get_field_value("a"), Some(&Value::string("a")));
+        assert_eq!(result.get_field_value("b"), None);
     });
 }

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -1,12 +1,10 @@
-use indexmap::IndexMap;
-
 use ast::InputValue;
 use executor::Variables;
 use parser::SourcePosition;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
 use validation::RuleError;
-use value::Value;
+use value::{Value, Object};
 use GraphQLError::ValidationError;
 
 #[derive(GraphQLEnum, Debug)]
@@ -30,7 +28,7 @@ graphql_object!(TestType: () |&self| {
 
 fn run_variable_query<F>(query: &str, vars: Variables, f: F)
 where
-    F: Fn(&IndexMap<String, Value>) -> (),
+    F: Fn(&Object) -> (),
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
@@ -47,7 +45,7 @@ where
 
 fn run_query<F>(query: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>) -> (),
+    F: Fn(&Object) -> (),
 {
     run_variable_query(query, Variables::new(), f);
 }
@@ -55,14 +53,14 @@ where
 #[test]
 fn accepts_enum_literal() {
     run_query("{ toString(color: RED) }", |result| {
-        assert_eq!(result.get("toString"), Some(&Value::string("Color::Red")));
+        assert_eq!(result.get_field_value("toString"), Some(&Value::string("Color::Red")));
     });
 }
 
 #[test]
 fn serializes_as_output() {
     run_query("{ aColor }", |result| {
-        assert_eq!(result.get("aColor"), Some(&Value::string("RED")));
+        assert_eq!(result.get_field_value("aColor"), Some(&Value::string("RED")));
     });
 }
 
@@ -92,7 +90,7 @@ fn accepts_strings_in_variables() {
             .into_iter()
             .collect(),
         |result| {
-            assert_eq!(result.get("toString"), Some(&Value::string("Color::Red")));
+            assert_eq!(result.get_field_value("toString"), Some(&Value::string("Color::Red")));
         },
     );
 }

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,9 +1,7 @@
-use indexmap::IndexMap;
-
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 /*
 
@@ -76,7 +74,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn((&IndexMap<String, Value>, &Vec<Value>)) -> (),
+    F: Fn((&Object, &Vec<Value>)) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
@@ -90,13 +88,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let values = type_info
-        .get("enumValues")
+        .get_field_value("enumValues")
         .expect("enumValues field missing")
         .as_list_value()
         .expect("enumValues not a list");
@@ -122,8 +120,8 @@ fn default_name_introspection() {
     "#;
 
     run_type_info_query(doc, |(type_info, values)| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("DefaultName")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("DefaultName")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 2);
 
@@ -171,8 +169,8 @@ fn named_introspection() {
     "#;
 
     run_type_info_query(doc, |(type_info, values)| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("ANamedEnum")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("ANamedEnum")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 2);
 
@@ -221,10 +219,10 @@ fn no_trailing_comma_introspection() {
 
     run_type_info_query(doc, |(type_info, values)| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("NoTrailingComma"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 2);
 
@@ -273,11 +271,11 @@ fn enum_description_introspection() {
 
     run_type_info_query(doc, |(type_info, values)| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("EnumDescription"))
         );
         assert_eq!(
-            type_info.get("description"),
+            type_info.get_field_value("description"),
             Some(&Value::string("A description of the enum itself"))
         );
 
@@ -328,10 +326,10 @@ fn enum_value_description_introspection() {
 
     run_type_info_query(doc, |(type_info, values)| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("EnumValueDescription"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 2);
 
@@ -380,10 +378,10 @@ fn enum_deprecation_introspection() {
 
     run_type_info_query(doc, |(type_info, values)| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("EnumDeprecation"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 2);
 
@@ -438,10 +436,10 @@ fn enum_deprecation_no_values_introspection() {
 
     run_type_info_query(doc, |(type_info, values)| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("EnumDeprecation"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(values.len(), 0);
     });

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -1,10 +1,8 @@
-use indexmap::IndexMap;
-
 use ast::{FromInputValue, InputValue};
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 struct Root;
 
@@ -106,7 +104,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>, &Vec<Value>) -> (),
+    F: Fn(&Object, &Vec<Value>) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
@@ -120,13 +118,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let fields = type_info
-        .get("inputFields")
+        .get_field_value("inputFields")
         .expect("inputFields field missing")
         .as_list_value()
         .expect("inputFields not a list");
@@ -156,8 +154,8 @@ fn default_name_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info, fields| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("DefaultName")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("DefaultName")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(fields.len(), 2);
 
@@ -256,10 +254,10 @@ fn no_trailing_comma_introspection() {
 
     run_type_info_query(doc, |type_info, fields| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("NoTrailingComma"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(fields.len(), 2);
 
@@ -337,8 +335,8 @@ fn derive_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info, fields| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("Derive")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("Derive")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(fields.len(), 1);
 
@@ -405,10 +403,10 @@ fn named_introspection() {
 
     run_type_info_query(doc, |type_info, fields| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("ANamedInputObject"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(fields.len(), 1);
 
@@ -461,9 +459,9 @@ fn description_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info, fields| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("Description")));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("Description")));
         assert_eq!(
-            type_info.get("description"),
+            type_info.get_field_value("description"),
             Some(&Value::string("Description for the input object"))
         );
 
@@ -519,10 +517,10 @@ fn field_description_introspection() {
 
     run_type_info_query(doc, |type_info, fields| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("FieldDescription"))
         );
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
 
         assert_eq!(fields.len(), 2);
 
@@ -597,7 +595,7 @@ fn field_with_defaults_introspection() {
 
     run_type_info_query(doc, |type_info, fields| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("FieldWithDefaults"))
         );
 

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -126,21 +126,39 @@ fn enum_introspection() {
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
-    assert_eq!(type_info.get("name"), Some(&Value::string("SampleEnum")));
-    assert_eq!(type_info.get("kind"), Some(&Value::string("ENUM")));
-    assert_eq!(type_info.get("description"), Some(&Value::null()));
-    assert_eq!(type_info.get("interfaces"), Some(&Value::null()));
-    assert_eq!(type_info.get("possibleTypes"), Some(&Value::null()));
-    assert_eq!(type_info.get("inputFields"), Some(&Value::null()));
-    assert_eq!(type_info.get("ofType"), Some(&Value::null()));
+    assert_eq!(
+        type_info.get_field_value("name"),
+        Some(&Value::string("SampleEnum"))
+    );
+    assert_eq!(
+        type_info.get_field_value("kind"),
+        Some(&Value::string("ENUM"))
+    );
+    assert_eq!(
+        type_info.get_field_value("description"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("interfaces"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("possibleTypes"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("inputFields"),
+        Some(&Value::null())
+    );
+    assert_eq!(type_info.get_field_value("ofType"), Some(&Value::null()));
 
     let values = type_info
-        .get("enumValues")
+        .get_field_value("enumValues")
         .expect("enumValues field missing")
         .as_list_value()
         .expect("enumValues not a list");
@@ -219,27 +237,39 @@ fn interface_introspection() {
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     assert_eq!(
-        type_info.get("name"),
+        type_info.get_field_value("name"),
         Some(&Value::string("SampleInterface"))
     );
-    assert_eq!(type_info.get("kind"), Some(&Value::string("INTERFACE")));
     assert_eq!(
-        type_info.get("description"),
+        type_info.get_field_value("kind"),
+        Some(&Value::string("INTERFACE"))
+    );
+    assert_eq!(
+        type_info.get_field_value("description"),
         Some(&Value::string("A sample interface"))
     );
-    assert_eq!(type_info.get("interfaces"), Some(&Value::null()));
-    assert_eq!(type_info.get("enumValues"), Some(&Value::null()));
-    assert_eq!(type_info.get("inputFields"), Some(&Value::null()));
-    assert_eq!(type_info.get("ofType"), Some(&Value::null()));
+    assert_eq!(
+        type_info.get_field_value("interfaces"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("enumValues"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("inputFields"),
+        Some(&Value::null())
+    );
+    assert_eq!(type_info.get_field_value("ofType"), Some(&Value::null()));
 
     let possible_types = type_info
-        .get("possibleTypes")
+        .get_field_value("possibleTypes")
         .expect("possibleTypes field missing")
         .as_list_value()
         .expect("possibleTypes not a list");
@@ -251,7 +281,7 @@ fn interface_introspection() {
     )));
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields field not an object value");
@@ -353,32 +383,47 @@ fn object_introspection() {
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
-    assert_eq!(type_info.get("name"), Some(&Value::string("Root")));
-    assert_eq!(type_info.get("kind"), Some(&Value::string("OBJECT")));
     assert_eq!(
-        type_info.get("description"),
+        type_info.get_field_value("name"),
+        Some(&Value::string("Root"))
+    );
+    assert_eq!(
+        type_info.get_field_value("kind"),
+        Some(&Value::string("OBJECT"))
+    );
+    assert_eq!(
+        type_info.get_field_value("description"),
         Some(&Value::string("The root query object in the schema"))
     );
     assert_eq!(
-        type_info.get("interfaces"),
+        type_info.get_field_value("interfaces"),
         Some(&Value::list(vec![Value::object(
             vec![("name", Value::string("SampleInterface"))]
                 .into_iter()
                 .collect(),
         )]))
     );
-    assert_eq!(type_info.get("enumValues"), Some(&Value::null()));
-    assert_eq!(type_info.get("inputFields"), Some(&Value::null()));
-    assert_eq!(type_info.get("ofType"), Some(&Value::null()));
-    assert_eq!(type_info.get("possibleTypes"), Some(&Value::null()));
+    assert_eq!(
+        type_info.get_field_value("enumValues"),
+        Some(&Value::null())
+    );
+    assert_eq!(
+        type_info.get_field_value("inputFields"),
+        Some(&Value::null())
+    );
+    assert_eq!(type_info.get_field_value("ofType"), Some(&Value::null()));
+    assert_eq!(
+        type_info.get_field_value("possibleTypes"),
+        Some(&Value::null())
+    );
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields field not an object value");
@@ -538,7 +583,7 @@ fn scalar_introspection() {
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing");
 
     assert_eq!(

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -8,7 +8,7 @@ use ast::InputValue;
 use executor::ExecutionError;
 use parser::{ParseError, SourcePosition, Spanning};
 use validation::RuleError;
-use {GraphQLError, Value};
+use {GraphQLError, Object, Value};
 
 #[derive(Serialize)]
 struct SerializeHelper {
@@ -245,6 +245,22 @@ impl<'a> ser::Serialize for Spanning<ParseError<'a>> {
 
         map.serialize_key("locations")?;
         map.serialize_value(&locations)?;
+
+        map.end()
+    }
+}
+
+impl ser::Serialize for Object {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.field_count()))?;
+
+        for &(ref f, ref v) in self.iter() {
+            map.serialize_key(f)?;
+            map.serialize_value(v)?;
+        }
 
         map.end()
     }

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -162,7 +162,7 @@ pub use schema::model::RootNode;
 pub use types::base::{Arguments, GraphQLType, TypeKind};
 pub use types::scalars::{EmptyMutation, ID};
 pub use validation::RuleError;
-pub use value::Value;
+pub use value::{Value, Object};
 
 pub use schema::meta;
 

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -112,13 +112,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields not a list");
@@ -128,7 +128,7 @@ where
         .filter(|f| {
             f.as_object_value()
                 .expect("Field not an object")
-                .get("name")
+                .get_field_value("name")
                 .expect("name field missing from field")
                 .as_string_value()
                 .expect("name is not a string") == field_name
@@ -141,7 +141,7 @@ where
     println!("Field: {:?}", field);
 
     let args = field
-        .get("args")
+        .get_field_value("args")
         .expect("args missing from field")
         .as_list_value()
         .expect("args is not a list");

--- a/juniper/src/macros/tests/interface.rs
+++ b/juniper/src/macros/tests/interface.rs
@@ -1,10 +1,9 @@
-use indexmap::IndexMap;
 use std::marker::PhantomData;
 
 use ast::InputValue;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 /*
 
@@ -130,7 +129,7 @@ graphql_object!(<'a> Root: () as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>, &Vec<Value>) -> (),
+    F: Fn(&Object, &Vec<Value>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {
@@ -157,13 +156,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields field not a list value");
@@ -175,10 +174,10 @@ where
 fn introspect_custom_name() {
     run_type_info_query("ACustomNamedInterface", |object, fields| {
         assert_eq!(
-            object.get("name"),
+            object.get_field_value("name"),
             Some(&Value::string("ACustomNamedInterface"))
         );
-        assert_eq!(object.get("description"), Some(&Value::null()));
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             fields.contains(&Value::object(
@@ -193,8 +192,8 @@ fn introspect_custom_name() {
 #[test]
 fn introspect_with_lifetime() {
     run_type_info_query("WithLifetime", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("WithLifetime")));
-        assert_eq!(object.get("description"), Some(&Value::null()));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("WithLifetime")));
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             fields.contains(&Value::object(
@@ -209,8 +208,8 @@ fn introspect_with_lifetime() {
 #[test]
 fn introspect_with_generics() {
     run_type_info_query("WithGenerics", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("WithGenerics")));
-        assert_eq!(object.get("description"), Some(&Value::null()));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("WithGenerics")));
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             fields.contains(&Value::object(
@@ -225,9 +224,9 @@ fn introspect_with_generics() {
 #[test]
 fn introspect_description_first() {
     run_type_info_query("DescriptionFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("DescriptionFirst")));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("DescriptionFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -244,9 +243,9 @@ fn introspect_description_first() {
 #[test]
 fn introspect_fields_first() {
     run_type_info_query("FieldsFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("FieldsFirst")));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("FieldsFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -263,9 +262,9 @@ fn introspect_fields_first() {
 #[test]
 fn introspect_interfaces_first() {
     run_type_info_query("InterfacesFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("InterfacesFirst")));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("InterfacesFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -283,11 +282,11 @@ fn introspect_interfaces_first() {
 fn introspect_commas_with_trailing() {
     run_type_info_query("CommasWithTrailing", |object, fields| {
         assert_eq!(
-            object.get("name"),
+            object.get_field_value("name"),
             Some(&Value::string("CommasWithTrailing"))
         );
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -304,9 +303,9 @@ fn introspect_commas_with_trailing() {
 #[test]
 fn introspect_commas_on_meta() {
     run_type_info_query("CommasOnMeta", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("CommasOnMeta")));
+        assert_eq!(object.get_field_value("name"), Some(&Value::string("CommasOnMeta")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -324,11 +323,11 @@ fn introspect_commas_on_meta() {
 fn introspect_resolvers_with_trailing_comma() {
     run_type_info_query("ResolversWithTrailingComma", |object, fields| {
         assert_eq!(
-            object.get("name"),
+            object.get_field_value("name"),
             Some(&Value::string("ResolversWithTrailingComma"))
         );
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 

--- a/juniper/src/macros/tests/object.rs
+++ b/juniper/src/macros/tests/object.rs
@@ -1,11 +1,10 @@
-use indexmap::IndexMap;
 use std::marker::PhantomData;
 
 use ast::InputValue;
 use executor::{Context, FieldResult};
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Object, Value};
 
 /*
 
@@ -144,7 +143,7 @@ graphql_object!(<'a> Root: InnerContext as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>, &Vec<Value>) -> (),
+    F: Fn(&Object, &Vec<Value>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {
@@ -184,13 +183,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields field not a list value");
@@ -201,12 +200,18 @@ where
 #[test]
 fn introspect_custom_name() {
     run_type_info_query("ACustomNamedType", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("ACustomNamedType")));
-        assert_eq!(object.get("description"), Some(&Value::null()));
-        assert_eq!(object.get("interfaces"), Some(&Value::list(vec![])));
+        assert_eq!(
+            object.get_field_value("name"),
+            Some(&Value::string("ACustomNamedType"))
+        );
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            object.get_field_value("interfaces"),
+            Some(&Value::list(vec![]))
+        );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -215,12 +220,18 @@ fn introspect_custom_name() {
 #[test]
 fn introspect_with_lifetime() {
     run_type_info_query("WithLifetime", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("WithLifetime")));
-        assert_eq!(object.get("description"), Some(&Value::null()));
-        assert_eq!(object.get("interfaces"), Some(&Value::list(vec![])));
+        assert_eq!(
+            object.get_field_value("name"),
+            Some(&Value::string("WithLifetime"))
+        );
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            object.get_field_value("interfaces"),
+            Some(&Value::list(vec![]))
+        );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -229,12 +240,18 @@ fn introspect_with_lifetime() {
 #[test]
 fn introspect_with_generics() {
     run_type_info_query("WithGenerics", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("WithGenerics")));
-        assert_eq!(object.get("description"), Some(&Value::null()));
-        assert_eq!(object.get("interfaces"), Some(&Value::list(vec![])));
+        assert_eq!(
+            object.get_field_value("name"),
+            Some(&Value::string("WithGenerics"))
+        );
+        assert_eq!(object.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            object.get_field_value("interfaces"),
+            Some(&Value::list(vec![]))
+        );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -243,13 +260,16 @@ fn introspect_with_generics() {
 #[test]
 fn introspect_description_first() {
     run_type_info_query("DescriptionFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("DescriptionFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("name"),
+            Some(&Value::string("DescriptionFirst"))
+        );
+        assert_eq!(
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
         assert_eq!(
-            object.get("interfaces"),
+            object.get_field_value("interfaces"),
             Some(&Value::list(vec![Value::object(
                 vec![
                     ("name", Value::string("Interface")),
@@ -260,7 +280,7 @@ fn introspect_description_first() {
         );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -269,13 +289,16 @@ fn introspect_description_first() {
 #[test]
 fn introspect_fields_first() {
     run_type_info_query("FieldsFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("FieldsFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("name"),
+            Some(&Value::string("FieldsFirst"))
+        );
+        assert_eq!(
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
         assert_eq!(
-            object.get("interfaces"),
+            object.get_field_value("interfaces"),
             Some(&Value::list(vec![Value::object(
                 vec![
                     ("name", Value::string("Interface")),
@@ -286,7 +309,7 @@ fn introspect_fields_first() {
         );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -295,13 +318,16 @@ fn introspect_fields_first() {
 #[test]
 fn introspect_interfaces_first() {
     run_type_info_query("InterfacesFirst", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("InterfacesFirst")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("name"),
+            Some(&Value::string("InterfacesFirst"))
+        );
+        assert_eq!(
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
         assert_eq!(
-            object.get("interfaces"),
+            object.get_field_value("interfaces"),
             Some(&Value::list(vec![Value::object(
                 vec![
                     ("name", Value::string("Interface")),
@@ -312,7 +338,7 @@ fn introspect_interfaces_first() {
         );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -322,15 +348,15 @@ fn introspect_interfaces_first() {
 fn introspect_commas_with_trailing() {
     run_type_info_query("CommasWithTrailing", |object, fields| {
         assert_eq!(
-            object.get("name"),
+            object.get_field_value("name"),
             Some(&Value::string("CommasWithTrailing"))
         );
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
         assert_eq!(
-            object.get("interfaces"),
+            object.get_field_value("interfaces"),
             Some(&Value::list(vec![Value::object(
                 vec![
                     ("name", Value::string("Interface")),
@@ -341,7 +367,7 @@ fn introspect_commas_with_trailing() {
         );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });
@@ -350,13 +376,16 @@ fn introspect_commas_with_trailing() {
 #[test]
 fn introspect_commas_on_meta() {
     run_type_info_query("CommasOnMeta", |object, fields| {
-        assert_eq!(object.get("name"), Some(&Value::string("CommasOnMeta")));
         assert_eq!(
-            object.get("description"),
+            object.get_field_value("name"),
+            Some(&Value::string("CommasOnMeta"))
+        );
+        assert_eq!(
+            object.get_field_value("description"),
             Some(&Value::string("A description"))
         );
         assert_eq!(
-            object.get("interfaces"),
+            object.get_field_value("interfaces"),
             Some(&Value::list(vec![Value::object(
                 vec![
                     ("name", Value::string("Interface")),
@@ -367,7 +396,7 @@ fn introspect_commas_on_meta() {
         );
 
         assert!(fields.contains(&graphql_value!({
-            "name": "simple", 
+            "name": "simple",
             "type": { "kind": "NON_NULL", "name": None, "ofType": { "kind": "SCALAR", "name": "Int" } }
         })));
     });

--- a/juniper/src/macros/tests/scalar.rs
+++ b/juniper/src/macros/tests/scalar.rs
@@ -1,9 +1,7 @@
-use indexmap::IndexMap;
-
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 struct DefaultName(i32);
 struct OtherOrder(i32);
@@ -72,7 +70,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>) -> (),
+    F: Fn(&Object) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
@@ -86,7 +84,7 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
@@ -106,8 +104,8 @@ fn default_name_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("DefaultName")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("DefaultName")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
     });
 }
 
@@ -123,8 +121,8 @@ fn other_order_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("OtherOrder")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("OtherOrder")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
     });
 }
 
@@ -140,8 +138,8 @@ fn named_introspection() {
     "#;
 
     run_type_info_query(doc, |type_info| {
-        assert_eq!(type_info.get("name"), Some(&Value::string("ANamedScalar")));
-        assert_eq!(type_info.get("description"), Some(&Value::null()));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string("ANamedScalar")));
+        assert_eq!(type_info.get_field_value("description"), Some(&Value::null()));
     });
 }
 
@@ -158,11 +156,11 @@ fn scalar_description_introspection() {
 
     run_type_info_query(doc, |type_info| {
         assert_eq!(
-            type_info.get("name"),
+            type_info.get_field_value("name"),
             Some(&Value::string("ScalarDescription"))
         );
         assert_eq!(
-            type_info.get("description"),
+            type_info.get_field_value("description"),
             Some(&Value::string("A sample scalar, represented as an integer"))
         );
     });

--- a/juniper/src/macros/tests/union.rs
+++ b/juniper/src/macros/tests/union.rs
@@ -1,10 +1,9 @@
-use indexmap::IndexMap;
 use std::marker::PhantomData;
 
 use ast::InputValue;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::Value;
+use value::{Value, Object};
 
 /*
 
@@ -111,7 +110,7 @@ graphql_object!(<'a> Root: () as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&IndexMap<String, Value>, &Vec<Value>) -> (),
+    F: Fn(&Object, &Vec<Value>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {
@@ -138,13 +137,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let possible_types = type_info
-        .get("possibleTypes")
+        .get_field_value("possibleTypes")
         .expect("possibleTypes field missing")
         .as_list_value()
         .expect("possibleTypes field not a list value");
@@ -155,8 +154,8 @@ where
 #[test]
 fn introspect_custom_name() {
     run_type_info_query("ACustomNamedUnion", |union, possible_types| {
-        assert_eq!(union.get("name"), Some(&Value::string("ACustomNamedUnion")));
-        assert_eq!(union.get("description"), Some(&Value::null()));
+        assert_eq!(union.get_field_value("name"), Some(&Value::string("ACustomNamedUnion")));
+        assert_eq!(union.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             possible_types.contains(&Value::object(
@@ -171,8 +170,8 @@ fn introspect_custom_name() {
 #[test]
 fn introspect_with_lifetime() {
     run_type_info_query("WithLifetime", |union, possible_types| {
-        assert_eq!(union.get("name"), Some(&Value::string("WithLifetime")));
-        assert_eq!(union.get("description"), Some(&Value::null()));
+        assert_eq!(union.get_field_value("name"), Some(&Value::string("WithLifetime")));
+        assert_eq!(union.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             possible_types.contains(&Value::object(
@@ -187,8 +186,8 @@ fn introspect_with_lifetime() {
 #[test]
 fn introspect_with_generics() {
     run_type_info_query("WithGenerics", |union, possible_types| {
-        assert_eq!(union.get("name"), Some(&Value::string("WithGenerics")));
-        assert_eq!(union.get("description"), Some(&Value::null()));
+        assert_eq!(union.get_field_value("name"), Some(&Value::string("WithGenerics")));
+        assert_eq!(union.get_field_value("description"), Some(&Value::null()));
 
         assert!(
             possible_types.contains(&Value::object(
@@ -203,9 +202,9 @@ fn introspect_with_generics() {
 #[test]
 fn introspect_description_first() {
     run_type_info_query("DescriptionFirst", |union, possible_types| {
-        assert_eq!(union.get("name"), Some(&Value::string("DescriptionFirst")));
+        assert_eq!(union.get_field_value("name"), Some(&Value::string("DescriptionFirst")));
         assert_eq!(
-            union.get("description"),
+            union.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -222,9 +221,9 @@ fn introspect_description_first() {
 #[test]
 fn introspect_resolvers_first() {
     run_type_info_query("ResolversFirst", |union, possible_types| {
-        assert_eq!(union.get("name"), Some(&Value::string("ResolversFirst")));
+        assert_eq!(union.get_field_value("name"), Some(&Value::string("ResolversFirst")));
         assert_eq!(
-            union.get("description"),
+            union.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -242,11 +241,11 @@ fn introspect_resolvers_first() {
 fn introspect_commas_with_trailing() {
     run_type_info_query("CommasWithTrailing", |union, possible_types| {
         assert_eq!(
-            union.get("name"),
+            union.get_field_value("name"),
             Some(&Value::string("CommasWithTrailing"))
         );
         assert_eq!(
-            union.get("description"),
+            union.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 
@@ -264,11 +263,11 @@ fn introspect_commas_with_trailing() {
 fn introspect_resolvers_with_trailing_comma() {
     run_type_info_query("ResolversWithTrailingComma", |union, possible_types| {
         assert_eq!(
-            union.get("name"),
+            union.get_field_value("name"),
             Some(&Value::string("ResolversWithTrailingComma"))
         );
         assert_eq!(
-            union.get("description"),
+            union.get_field_value("description"),
             Some(&Value::string("A description"))
         );
 

--- a/juniper/src/parser/utils.rs
+++ b/juniper/src/parser/utils.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 /// A reference to a line and column in an input source file
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct SourcePosition {
     index: usize,
     line: usize,

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -319,6 +319,7 @@ impl<'a> SchemaType<'a> {
 }
 
 impl<'a> TypeType<'a> {
+    #[inline]
     pub fn to_concrete(&self) -> Option<&'a MetaType> {
         match *self {
             TypeType::Concrete(t) => Some(t),
@@ -326,6 +327,7 @@ impl<'a> TypeType<'a> {
         }
     }
 
+    #[inline]
     pub fn innermost_concrete(&self) -> &'a MetaType {
         match *self {
             TypeType::Concrete(t) => t,
@@ -333,6 +335,7 @@ impl<'a> TypeType<'a> {
         }
     }
 
+    #[inline]
     pub fn list_contents(&self) -> Option<&TypeType<'a>> {
         match *self {
             TypeType::List(ref n) => Some(n),
@@ -341,6 +344,7 @@ impl<'a> TypeType<'a> {
         }
     }
 
+    #[inline]
     pub fn is_non_null(&self) -> bool {
         match *self {
             TypeType::NonNull(_) => true,

--- a/juniper/src/tests/introspection_tests.rs
+++ b/juniper/src/tests/introspection_tests.rs
@@ -198,11 +198,11 @@ fn test_possible_types() {
     let possible_types = result
         .as_object_value()
         .expect("execution result not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("'__type' not present in result")
         .as_object_value()
         .expect("'__type' not an object")
-        .get("possibleTypes")
+        .get_field_value("possibleTypes")
         .expect("'possibleTypes' not present in '__type'")
         .as_list_value()
         .expect("'possibleTypes' not a list")
@@ -210,7 +210,7 @@ fn test_possible_types() {
         .map(|t| {
             t.as_object_value()
                 .expect("possible type not an object")
-                .get("name")
+                .get_field_value("name")
                 .expect("'name' not present in type")
                 .as_string_value()
                 .expect("'name' not a string")

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -503,7 +503,7 @@ fn is_excluded(directives: &Option<Vec<Spanning<Directive>>>, vars: &Variables) 
 }
 
 fn merge_key_into(result: &mut Object, response_name: &str, value: Value) {
-    if let Some(&mut (_, ref mut e)) = result.iter_mut().find(|&(ref key, _)| key == response_name)
+    if let Some(&mut (_, ref mut e)) = result.iter_mut().find(|&&mut (ref key, _)| key == response_name)
     {
         match *e {
             Value::Object(ref mut dest_obj) => {

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -152,18 +152,18 @@ where
     }
 }
 
-fn resolve_into_list<T: GraphQLType, I: Iterator<Item = T>>(
-    executor: &Executor<T::Context>,
-    info: &T::TypeInfo,
-    iter: I,
-) -> Value {
+fn resolve_into_list<T, I>(executor: &Executor<T::Context>, info: &T::TypeInfo, iter: I) -> Value
+where
+    I: Iterator<Item = T> + ExactSizeIterator,
+    T: GraphQLType,
+{
     let stop_on_null = executor
         .current_type()
         .list_contents()
         .expect("Current type is not a list type")
         .is_non_null();
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(iter.len());
 
     for o in iter {
         let value = executor.resolve_into_value(info, &o);

--- a/juniper/src/value.rs
+++ b/juniper/src/value.rs
@@ -48,7 +48,8 @@ impl Object {
         K: Into<String>,
         for<'a> &'a str: PartialEq<K>,
     {
-        if let Some(item) = self.key_value_list
+        if let Some(item) = self
+            .key_value_list
             .iter_mut()
             .find(|(key, _)| (key as &str) == k)
         {
@@ -68,16 +69,26 @@ impl Object {
             .any(|(key, _)| (key as &str) == f)
     }
 
-
     /// Get a iterator over all field value pairs
-    pub fn iter(&self) -> impl Iterator<Item = &(String, Value)> {
-        self.key_value_list.iter()
+    ///
+    /// This method returns a iterator over `&'a (String, Value)`
+    // TODO: change this to `-> impl Iterator<Item = &(String, Value)>`
+    // as soon as juniper bumps the minimal supported rust verion to 1.26
+    pub fn iter(&self) -> FieldIter {
+        FieldIter {
+            inner: self.key_value_list.iter(),
+        }
     }
 
-
     /// Get a iterator over all mutable field value pairs
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut (String, Value)> {
-        self.key_value_list.iter_mut()
+    ///
+    /// This method returns a iterator over `&mut 'a (String, Value)`
+    // TODO: change this to `-> impl Iterator<Item = &mut (String, Value)>`
+    // as soon as juniper bumps the minimal supported rust verion to 1.26
+    pub fn iter_mut(&mut self) -> FieldIterMut {
+        FieldIterMut {
+            inner: self.key_value_list.iter_mut(),
+        }
     }
 
     /// Get the current number of fields
@@ -131,6 +142,34 @@ where
         ret
     }
 }
+
+
+#[doc(hidden)]
+pub struct FieldIter<'a> {
+    inner: ::std::slice::Iter<'a, (String, Value)>,
+}
+
+impl<'a> Iterator for FieldIter<'a> {
+    type Item = &'a (String, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+#[doc(hidden)]
+pub struct FieldIterMut<'a> {
+    inner: ::std::slice::IterMut<'a, (String, Value)>,
+}
+
+impl<'a> Iterator for FieldIterMut<'a> {
+    type Item = &'a mut (String, Value);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
 
 impl Value {
     // CONSTRUCTORS

--- a/juniper/src/value.rs
+++ b/juniper/src/value.rs
@@ -51,7 +51,7 @@ impl Object {
         if let Some(item) = self
             .key_value_list
             .iter_mut()
-            .find(|(key, _)| (key as &str) == k)
+            .find(|&&mut (ref key, _)| (key as &str) == k)
         {
             return Some(::std::mem::replace(&mut item.1, value));
         }
@@ -66,7 +66,7 @@ impl Object {
     {
         self.key_value_list
             .iter()
-            .any(|(key, _)| (key as &str) == f)
+            .any(|&(ref key, _)| (key as &str) == f)
     }
 
     /// Get a iterator over all field value pairs
@@ -103,7 +103,7 @@ impl Object {
     {
         self.key_value_list
             .iter()
-            .find(|(k, _)| (k as &str) == key)
+            .find(|&&(ref k, _)| (k as &str) == key)
             .map(|&(_, ref value)| value)
     }
 }
@@ -143,7 +143,6 @@ where
     }
 }
 
-
 #[doc(hidden)]
 pub struct FieldIter<'a> {
     inner: ::std::slice::Iter<'a, (String, Value)>,
@@ -169,7 +168,6 @@ impl<'a> Iterator for FieldIterMut<'a> {
         self.inner.next()
     }
 }
-
 
 impl Value {
     // CONSTRUCTORS
@@ -275,7 +273,7 @@ impl ToInputValue for Value {
             ),
             Value::Object(ref o) => InputValue::Object(
                 o.iter()
-                    .map(|(k, v)| {
+                    .map(|&(ref k, ref v)| {
                         (
                             Spanning::unlocated(k.clone()),
                             Spanning::unlocated(v.to_input_value()),

--- a/juniper_tests/src/codegen/derive_object.rs
+++ b/juniper_tests/src/codegen/derive_object.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use fnv::FnvHashMap;
 #[cfg(test)]
-use indexmap::IndexMap;
+use juniper::Object;
 
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};
@@ -235,8 +235,8 @@ fn check_descriptions(
         object_name
     );
     run_type_info_query(&doc, |(type_info, values)| {
-        assert_eq!(type_info.get("name"), Some(&Value::string(object_name)));
-        assert_eq!(type_info.get("description"), Some(object_description));
+        assert_eq!(type_info.get_field_value("name"), Some(&Value::string(object_name)));
+        assert_eq!(type_info.get_field_value("description"), Some(object_description));
         assert!(
             values.contains(&Value::object(
                 vec![
@@ -252,7 +252,7 @@ fn check_descriptions(
 #[cfg(test)]
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn((&IndexMap<String, Value>, &Vec<Value>)) -> (),
+    F: Fn((&Object, &Vec<Value>)) -> (),
 {
     let schema = RootNode::new(Query, EmptyMutation::<()>::new());
 
@@ -266,13 +266,13 @@ where
     let type_info = result
         .as_object_value()
         .expect("Result is not an object")
-        .get("__type")
+        .get_field_value("__type")
         .expect("__type field missing")
         .as_object_value()
         .expect("__type field not an object value");
 
     let fields = type_info
-        .get("fields")
+        .get_field_value("fields")
         .expect("fields field missing")
         .as_list_value()
         .expect("fields not a list");


### PR DESCRIPTION
* Replace the IndexMap in the serialized object with a plain
  `Vec<(String, Value)>` because linear search is faster for few
  elements

* Some general tweaks to skip some allocations

Addresses #199 