### PR TITLE
Allow custom errors to be returned from queries, mutations

### DIFF
--- a/changelog/master.md
+++ b/changelog/master.md
@@ -28,3 +28,9 @@
   `#[graphql(description = "my description")]`.
 
   [#194](https://github.com/graphql-rust/juniper/issues/194)
+
+* Introduced `IntoFieldError` trait to allow custom error handling
+  i.e. custom result type. The error type must implement this trait resolving
+  the errors into `FieldError`.
+
+  [#40](https://github.com/graphql-rust/juniper/issues/40)

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -193,6 +193,21 @@ pub type ExecutionResult = Result<Value, FieldError>;
 /// The map of variables used for substitution during query execution
 pub type Variables = HashMap<String, InputValue>;
 
+/// Custom error handling trait to enable Error types other than `FieldError` to be specified
+/// as return value.
+///
+/// Any custom error type should implement this trait to convert it to `FieldError`.
+pub trait IntoFieldError {
+    #[doc(hidden)]
+    fn into_field_error(self) -> FieldError;
+}
+
+impl IntoFieldError for FieldError {
+    fn into_field_error(self) -> FieldError {
+        self
+    }
+}
+
 #[doc(hidden)]
 pub trait IntoResolvable<'a, T: GraphQLType, C>: Sized {
     #[doc(hidden)]

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -223,12 +223,13 @@ where
     }
 }
 
-impl<'a, T: GraphQLType, C> IntoResolvable<'a, T, C> for FieldResult<T>
+impl<'a, T: GraphQLType, C, E: IntoFieldError> IntoResolvable<'a, T, C> for Result<T, E>
 where
     T::Context: FromContext<C>,
 {
     fn into(self, ctx: &'a C) -> FieldResult<Option<(&'a T::Context, T)>> {
         self.map(|v| Some((FromContext::from(ctx), v)))
+            .map_err(|e| e.into_field_error())
     }
 }
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -152,7 +152,7 @@ use validation::{validate_input_values, visit_all_rules, ValidatorContext};
 
 pub use ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
 pub use executor::{Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
-                   FromContext, IntoResolvable, Registry, Variables};
+                   FromContext, IntoResolvable, Registry, Variables, IntoFieldError};
 pub use executor::{Applies, LookAheadArgument, LookAheadSelection, LookAheadValue, LookAheadMethods};
 pub use schema::model::RootNode;
 pub use types::base::{Arguments, GraphQLType, TypeKind};


### PR DESCRIPTION
Fixes #40.

This is not a breaking change, as `FieldResult` still works. For use cases which desire for custom error handling that return additional response fields ergnomically, those error types should implement `IntoFieldError` trait which converts your error type to the FieldError. This maintains that in the response, `message` field is always returned along with other optional user desired metadata.

You may implement your error as:
```
enum CustomError {
  NotFound
}

impl IntoFieldError for CustomError {
  fn into_field_error(self) -> FieldError {
    FieldError::new("Not Found", graphql_value!({ "type": "NOT_FOUND" })
  }
}
```

And use it likewise:
```
field add_likes(&executor, id: i32) -> Result<Like, CustomError> {
  Err(CustomError::NotFound)
}
```