### PR TITLE
Escape urls in iron integration tests

### DIFF
--- a/juniper_iron/Cargo.toml
+++ b/juniper_iron/Cargo.toml
@@ -24,6 +24,7 @@ iron-test = "0.6"
 router = "0.6"
 mount = "0.4"
 logger = "0.4"
+url = "1.7.1"
 
 [dev-dependencies.juniper]
 version = "0.9.2"


### PR DESCRIPTION
It appears with newer 0.10.x hyper it no longer takes "{" or "}" in the
query string unescaped.

When I tried to set `juniper_iron` to an older hyper it complained that it
couldn't resolve due to `juniper_rocket` needing a newer version.
This was the path of least resistance. Note that we are still testing the same
thing, this change is needed as a consequence of how `iron_test` creates mock
requests.

Fixes https://github.com/graphql-rust/juniper/issues/206