### PR TITLE
Implement GraphQLType for Arc

### DIFF
--- a/changelog/master.md
+++ b/changelog/master.md
@@ -34,3 +34,7 @@
   the errors into `FieldError`.
 
   [#40](https://github.com/graphql-rust/juniper/issues/40)
+  
+* `GraphQLType` and `ToInputValue` are now implemented for Arc<T>
+
+  [#212](https://github.com/graphql-rust/juniper/pull/212)

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -6,14 +6,18 @@ use std::sync::RwLock;
 
 use fnv::FnvHashMap;
 
-use ast::{Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
-          ToInputValue, Type};
-use GraphQLError;
+use ast::{
+    Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
+    ToInputValue, Type,
+};
 use parser::SourcePosition;
 use value::Value;
+use GraphQLError;
 
-use schema::meta::{Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, ListMeta,
-                   MetaType, NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta};
+use schema::meta::{
+    Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, ListMeta, MetaType,
+    NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
+};
 use schema::model::{RootNode, SchemaType, TypeType};
 
 use types::base::GraphQLType;
@@ -21,7 +25,10 @@ use types::name::Name;
 
 mod look_ahead;
 
-pub use self::look_ahead::{Applies, LookAheadArgument, LookAheadSelection, LookAheadValue, LookAheadMethods, ChildSelection, ConcreteLookAheadSelection};
+pub use self::look_ahead::{
+    Applies, ChildSelection, ConcreteLookAheadSelection, LookAheadArgument, LookAheadMethods,
+    LookAheadSelection, LookAheadValue,
+};
 
 /// A type registry used to build schemas
 ///
@@ -462,19 +469,29 @@ impl<'a, CtxT> Executor<'a, CtxT> {
     /// This allows to see the whole selection and preform operations
     /// affecting the childs
     pub fn look_ahead(&'a self) -> LookAheadSelection<'a> {
-        self.parent_selection_set.map(|p| {
-            LookAheadSelection::build_from_selection(&p[0], self.variables, self.fragments)
-        }).unwrap_or_else(||{
-            LookAheadSelection{
+        self.parent_selection_set
+            .map(|p| {
+                LookAheadSelection::build_from_selection(&p[0], self.variables, self.fragments)
+            })
+            .unwrap_or_else(|| LookAheadSelection {
                 name: self.current_type.innermost_concrete().name().unwrap_or(""),
                 alias: None,
                 arguments: Vec::new(),
-                children: self.current_selection_set.map(|s| s.iter().map(|s| ChildSelection {
-                    inner: LookAheadSelection::build_from_selection(s, self.variables, self.fragments),
-                    applies_for: Applies::All
-                }).collect()).unwrap_or_else(Vec::new)
-            }
-        })
+                children: self.current_selection_set
+                    .map(|s| {
+                        s.iter()
+                            .map(|s| ChildSelection {
+                                inner: LookAheadSelection::build_from_selection(
+                                    s,
+                                    self.variables,
+                                    self.fragments,
+                                ),
+                                applies_for: Applies::All,
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_else(Vec::new),
+            })
     }
 }
 

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -686,7 +686,7 @@ mod propagates_errors_to_nullable_fields {
     struct Inner;
 
     enum CustomError {
-        NotFound
+        NotFound,
     }
 
     impl IntoFieldError for CustomError {
@@ -696,8 +696,8 @@ mod propagates_errors_to_nullable_fields {
                     "Not Found",
                     graphql_value!({
                         "type": "NOT_FOUND"
-                    })
-                )
+                    }),
+                ),
             }
         }
     }

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -262,15 +262,19 @@ pub mod tests {
     }
 
     fn test_batched_post<T: HTTPIntegration>(integration: &T) {
-        let response = integration.post("/", r#"[{"query": "{hero{name}}"}, {"query": "{hero{name}}"}]"#);
+        let response = integration.post(
+            "/",
+            r#"[{"query": "{hero{name}}"}, {"query": "{hero{name}}"}]"#,
+        );
 
         assert_eq!(response.status_code, 200);
         assert_eq!(response.content_type, "application/json");
 
         assert_eq!(
             unwrap_json_response(&response),
-            serde_json::from_str::<Json>(r#"[{"data": {"hero": {"name": "R2-D2"}}}, {"data": {"hero": {"name": "R2-D2"}}}]"#)
-                .expect("Invalid JSON constant in test")
+            serde_json::from_str::<Json>(
+                r#"[{"data": {"hero": {"name": "R2-D2"}}}, {"data": {"hero": {"name": "R2-D2"}}}]"#
+            ).expect("Invalid JSON constant in test")
         );
     }
 }

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -49,22 +49,16 @@ impl<'a> ser::Serialize for GraphQLError<'a> {
         match *self {
             GraphQLError::ParseError(ref err) => vec![err].serialize(serializer),
             GraphQLError::ValidationError(ref errs) => errs.serialize(serializer),
-            GraphQLError::NoOperationProvided => {
-                [
-                    SerializeHelper { message: "Must provide an operation" }
-                ].serialize(serializer)
-            }
-            GraphQLError::MultipleOperationsProvided => {
-                [SerializeHelper {
-                    message: "Must provide operation name \
-                    if query contains multiple operations",
-                }].serialize(serializer)
-            }
-            GraphQLError::UnknownOperationName => {
-                [
-                    SerializeHelper { message: "Unknown operation" }
-                ].serialize(serializer)
-            }
+            GraphQLError::NoOperationProvided => [SerializeHelper {
+                message: "Must provide an operation",
+            }].serialize(serializer),
+            GraphQLError::MultipleOperationsProvided => [SerializeHelper {
+                message: "Must provide operation name \
+                          if query contains multiple operations",
+            }].serialize(serializer),
+            GraphQLError::UnknownOperationName => [SerializeHelper {
+                message: "Unknown operation",
+            }].serialize(serializer),
         }
     }
 }
@@ -275,29 +269,37 @@ impl ser::Serialize for Value {
 
 #[cfg(test)]
 mod tests {
+    use super::GraphQLError;
+    use ast::InputValue;
     use serde_json::from_str;
     use serde_json::to_string;
-    use ast::InputValue;
-    use super::GraphQLError;
 
     #[test]
     fn int() {
-        assert_eq!(from_str::<InputValue>("1235").unwrap(),
-                   InputValue::int(1235));
+        assert_eq!(
+            from_str::<InputValue>("1235").unwrap(),
+            InputValue::int(1235)
+        );
     }
 
     #[test]
     fn float() {
-        assert_eq!(from_str::<InputValue>("2.0").unwrap(),
-                   InputValue::float(2.0));
+        assert_eq!(
+            from_str::<InputValue>("2.0").unwrap(),
+            InputValue::float(2.0)
+        );
         // large value without a decimal part is also float
-        assert_eq!(from_str::<InputValue>("123567890123").unwrap(),
-                   InputValue::float(123567890123.0));
+        assert_eq!(
+            from_str::<InputValue>("123567890123").unwrap(),
+            InputValue::float(123567890123.0)
+        );
     }
 
     #[test]
     fn errors() {
-        assert_eq!(to_string(&GraphQLError::UnknownOperationName).unwrap(),
-                   r#"[{"message":"Unknown operation"}]"#);
+        assert_eq!(
+            to_string(&GraphQLError::UnknownOperationName).unwrap(),
+            r#"[{"message":"Unknown operation"}]"#
+        );
     }
 }

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -151,9 +151,13 @@ use parser::{parse_document_source, ParseError, Spanning};
 use validation::{validate_input_values, visit_all_rules, ValidatorContext};
 
 pub use ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
-pub use executor::{Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
-                   FromContext, IntoResolvable, Registry, Variables, IntoFieldError};
-pub use executor::{Applies, LookAheadArgument, LookAheadSelection, LookAheadValue, LookAheadMethods};
+pub use executor::{
+    Applies, LookAheadArgument, LookAheadMethods, LookAheadSelection, LookAheadValue,
+};
+pub use executor::{
+    Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult, FromContext,
+    IntoFieldError, IntoResolvable, Registry, Variables,
+};
 pub use schema::model::RootNode;
 pub use types::base::{Arguments, GraphQLType, TypeKind};
 pub use types::scalars::{EmptyMutation, ID};

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -1,12 +1,15 @@
 use std::borrow::Cow;
 
-use ast::{Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread,
-          InlineFragment, InputValue, Operation, OperationType, Selection, Type,
-          VariableDefinition, VariableDefinitions};
+use ast::{
+    Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread, InlineFragment,
+    InputValue, Operation, OperationType, Selection, Type, VariableDefinition, VariableDefinitions,
+};
 
 use parser::value::parse_value_literal;
-use parser::{Lexer, OptionParseResult, ParseError, ParseResult, Parser, Spanning, Token,
-             UnlocatedParseResult};
+use parser::{
+    Lexer, OptionParseResult, ParseError, ParseResult, Parser, Spanning, Token,
+    UnlocatedParseResult,
+};
 
 #[doc(hidden)]
 pub fn parse_document_source(s: &str) -> UnlocatedParseResult<Document> {

--- a/juniper/src/parser/tests/document.rs
+++ b/juniper/src/parser/tests/document.rs
@@ -1,4 +1,6 @@
-use ast::{Arguments, Definition, Document, Field, InputValue, Operation, OperationType, Selection};
+use ast::{
+    Arguments, Definition, Document, Field, InputValue, Operation, OperationType, Selection,
+};
 use parser::document::parse_document_source;
 use parser::{ParseError, SourcePosition, Spanning, Token};
 

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -1,8 +1,10 @@
 use executor::{ExecutionResult, Executor, Registry};
 use types::base::{Arguments, GraphQLType, TypeKind};
 
-use schema::meta::{Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType,
-                   ObjectMeta, UnionMeta};
+use schema::meta::{
+    Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType, ObjectMeta,
+    UnionMeta,
+};
 use schema::model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, TypeType};
 
 impl<'a, CtxT, QueryT, MutationT> GraphQLType for RootNode<'a, QueryT, MutationT>

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use ast::{FromInputValue, InputValue, Selection, ToInputValue};
+use std::sync::Arc;
 use value::Value;
 
 use executor::{ExecutionResult, Executor, Registry};

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use ast::{FromInputValue, InputValue, Selection, ToInputValue};
 use value::Value;
 
@@ -117,6 +118,60 @@ where
 }
 
 impl<'a, T> ToInputValue for &'a T
+where
+    T: ToInputValue,
+{
+    fn to_input_value(&self) -> InputValue {
+        (**self).to_input_value()
+    }
+}
+
+impl<T, CtxT> GraphQLType for Arc<T>
+where
+    T: GraphQLType<Context = CtxT>,
+{
+    type Context = CtxT;
+    type TypeInfo = T::TypeInfo;
+
+    fn name(info: &T::TypeInfo) -> Option<&str> {
+        T::name(info)
+    }
+
+    fn meta<'r>(info: &T::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r> {
+        T::meta(info, registry)
+    }
+
+    fn resolve_into_type(
+        &self,
+        info: &T::TypeInfo,
+        name: &str,
+        selection_set: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> ExecutionResult {
+        (**self).resolve_into_type(info, name, selection_set, executor)
+    }
+
+    fn resolve_field(
+        &self,
+        info: &T::TypeInfo,
+        field: &str,
+        args: &Arguments,
+        executor: &Executor<CtxT>,
+    ) -> ExecutionResult {
+        (**self).resolve_field(info, field, args, executor)
+    }
+
+    fn resolve(
+        &self,
+        info: &T::TypeInfo,
+        selection_set: Option<&[Selection]>,
+        executor: &Executor<CtxT>,
+    ) -> Value {
+        (**self).resolve(info, selection_set, executor)
+    }
+}
+
+impl<T> ToInputValue for Arc<T>
 where
     T: ToInputValue,
 {

--- a/juniper/src/validation/mod.rs
+++ b/juniper/src/validation/mod.rs
@@ -18,5 +18,7 @@ pub use self::traits::Visitor;
 pub use self::visitor::visit;
 
 #[cfg(test)]
-pub use self::test_harness::{expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
-                             expect_passes_rule_with_schema};
+pub use self::test_harness::{
+    expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
+    expect_passes_rule_with_schema,
+};

--- a/juniper/src/validation/multi_visitor.rs
+++ b/juniper/src/validation/multi_visitor.rs
@@ -1,5 +1,7 @@
-use ast::{Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue,
-          Operation, Selection, VariableDefinition};
+use ast::{
+    Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
+    Selection, VariableDefinition,
+};
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
 

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -342,7 +342,8 @@ impl<'a> OverlappingFieldsCanBeMerged<'a> {
         let AstAndDef(ref parent_type2, ast2, ref def2) = *field2;
 
         let mutually_exclusive = parents_mutually_exclusive
-            || (parent_type1 != parent_type2 && self.is_object_type(ctx, *parent_type1)
+            || (parent_type1 != parent_type2
+                && self.is_object_type(ctx, *parent_type1)
                 && self.is_object_type(ctx, *parent_type2));
 
         if !mutually_exclusive {
@@ -717,8 +718,10 @@ mod tests {
     use types::scalars::ID;
 
     use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
-                     expect_passes_rule_with_schema, RuleError};
+    use validation::{
+        expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
+        expect_passes_rule_with_schema, RuleError,
+    };
 
     #[test]
     fn unique_fields() {

--- a/juniper/src/validation/traits.rs
+++ b/juniper/src/validation/traits.rs
@@ -1,5 +1,7 @@
-use ast::{Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue,
-          Operation, Selection, VariableDefinition};
+use ast::{
+    Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
+    Selection, VariableDefinition,
+};
 use parser::Spanning;
 use validation::ValidatorContext;
 

--- a/juniper/src/validation/visitor.rs
+++ b/juniper/src/validation/visitor.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
-use ast::{Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread,
-          InlineFragment, InputValue, Operation, OperationType, Selection, Type,
-          VariableDefinitions};
+use ast::{
+    Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread, InlineFragment,
+    InputValue, Operation, OperationType, Selection, Type, VariableDefinitions,
+};
 use parser::Spanning;
 use schema::meta::Argument;
 use validation::{ValidatorContext, Visitor};

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -1,14 +1,6 @@
-use syn;
-use syn::{
-    DeriveInput,
-    Meta,
-    NestedMeta,
-    Data,
-    Fields,
-    Ident,
-    Variant,
-};
 use quote::Tokens;
+use syn;
+use syn::{Data, DeriveInput, Fields, Ident, Meta, NestedMeta, Variant};
 
 use util::*;
 
@@ -39,8 +31,10 @@ impl EnumAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                        panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                               &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {
@@ -88,8 +82,10 @@ impl EnumVariantAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                         panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                                 &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {
@@ -135,14 +131,14 @@ pub fn impl_enum(ast: &syn::DeriveInput) -> Tokens {
 
     for variant in variants {
         match variant.fields {
-            Fields::Unit => {},
+            Fields::Unit => {}
             _ => {
                 panic!(format!(
                     "Invalid enum variant {}.\nGraphQL enums may only contain unit variants.",
                     variant.ident
                 ));
             }
-        } ;
+        };
 
         let var_attrs = EnumVariantAttrs::from_input(variant);
         let var_ident = &variant.ident;

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -1,16 +1,7 @@
 use std::str::FromStr;
 
-use syn::{
-    self,
-    DeriveInput,
-    NestedMeta,
-    Meta,
-    Field,
-    Fields,
-    Data,
-    Ident,
-};
-use quote::{Tokens, ToTokens};
+use quote::{ToTokens, Tokens};
+use syn::{self, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta};
 
 use util::*;
 
@@ -36,8 +27,10 @@ impl ObjAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                         panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                                 &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {
@@ -86,8 +79,10 @@ impl ObjFieldAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                         panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                                 &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {
@@ -173,14 +168,10 @@ pub fn impl_input_object(ast: &syn::DeriveInput) -> Tokens {
             } else {
                 match field_attrs.default_expr {
                     Some(ref def) => match ::proc_macro::TokenStream::from_str(def) {
-                        Ok(t) => {
-                            match syn::parse::<syn::Expr>(t) {
-                                Ok(e) => {
-                                    Some(e.into_tokens())
-                                },
-                                Err(_) => {
-                                    panic!("#graphql(default = ?) must be a valid Rust expression inside a string");
-                                },
+                        Ok(t) => match syn::parse::<syn::Expr>(t) {
+                            Ok(e) => Some(e.into_tokens()),
+                            Err(_) => {
+                                panic!("#graphql(default = ?) must be a valid Rust expression inside a string");
                             }
                         },
                         Err(_) => {

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,11 +1,6 @@
-use syn;
-use syn::{
-    DeriveInput,
-    Data,
-    Fields,
-    Field,
-};
 use quote::Tokens;
+use syn;
+use syn::{Data, DeriveInput, Field, Fields};
 
 use util::*;
 
@@ -30,8 +25,10 @@ impl ObjAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                         panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                                 &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {
@@ -70,8 +67,10 @@ impl ObjFieldAttrs {
                         res.name = Some(val);
                         continue;
                     } else {
-                         panic!("Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
-                                 &*val);
+                        panic!(
+                            "Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \"{}\" does not",
+                            &*val
+                        );
                     }
                 }
                 if let Some(val) = keyed_item_value(&item, "description", true) {

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -14,10 +14,10 @@ extern crate syn;
 extern crate lazy_static;
 extern crate regex;
 
-mod util;
 mod derive_enum;
 mod derive_input_object;
 mod derive_object;
+mod util;
 
 use proc_macro::TokenStream;
 

--- a/juniper_codegen/src/util.rs
+++ b/juniper_codegen/src/util.rs
@@ -99,8 +99,7 @@ pub fn to_camel_case(s: &str) -> String {
         if i > 0 && part.len() == 1 {
             dest.push_str(&part.to_uppercase());
         } else if i > 0 && part.len() > 1 {
-            let first = part
-                .chars()
+            let first = part.chars()
                 .next()
                 .unwrap()
                 .to_uppercase()

--- a/juniper_iron/examples/iron_server.rs
+++ b/juniper_iron/examples/iron_server.rs
@@ -7,12 +7,12 @@ extern crate serde;
 
 use std::env;
 
-use mount::Mount;
-use logger::Logger;
 use iron::prelude::*;
+use juniper::tests::model::Database;
 use juniper::EmptyMutation;
 use juniper_iron::{GraphQLHandler, GraphiQLHandler};
-use juniper::tests::model::Database;
+use logger::Logger;
+use mount::Mount;
 
 fn context_factory(_: &mut Request) -> IronResult<Database> {
     Ok(Database::new())

--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -253,8 +253,7 @@ where
     }
 
     fn handle_get(&self, req: &mut Request) -> IronResult<GraphQLBatchRequest> {
-        let url_query_string = req
-            .get_mut::<UrlEncodedQuery>()
+        let url_query_string = req.get_mut::<UrlEncodedQuery>()
             .map_err(GraphQLIronError::Url)?;
 
         let input_query = parse_url_param(url_query_string.remove("query"))?
@@ -398,8 +397,7 @@ mod tests {
     // and newer `hyper` doesn't allow unescaped "{" or "}".
     fn fixup_url(url: &str) -> String {
         let url = Url::parse(&format!("http://localhost:3000{}", url)).expect("url to parse");
-        let path: String = url
-            .path()
+        let path: String = url.path()
             .iter()
             .map(|x| x.to_string())
             .collect::<Vec<String>>()

--- a/juniper_tests/src/codegen/derive_enum.rs
+++ b/juniper_tests/src/codegen/derive_enum.rs
@@ -8,7 +8,8 @@ use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
 #[graphql(name = "Some", description = "enum descr")]
 enum SomeEnum {
     Regular,
-    #[graphql(name = "FULL", description = "field descr", deprecated = "depr")] Full,
+    #[graphql(name = "FULL", description = "field descr", deprecated = "depr")]
+    Full,
 }
 
 /// Enum doc.
@@ -82,7 +83,10 @@ fn test_doc_comment() {
 fn test_multi_doc_comment() {
     let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = MultiDocEnum::meta(&(), &mut registry);
-    assert_eq!(meta.description(), Some(&"Doc 1. Doc 2.\nDoc 4.".to_string()));
+    assert_eq!(
+        meta.description(),
+        Some(&"Doc 1. Doc 2.\nDoc 4.".to_string())
+    );
 }
 
 #[test]
@@ -90,5 +94,4 @@ fn test_doc_comment_override() {
     let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = OverrideDocEnum::meta(&(), &mut registry);
     assert_eq!(meta.description(), Some(&"enum override".to_string()));
-
 }

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -8,9 +8,11 @@ use juniper::{self, FromInputValue, GraphQLType, InputValue};
 #[graphql(name = "MyInput", description = "input descr")]
 struct Input {
     regular_field: String,
-    #[graphql(name = "haha", default = "33", description = "haha descr")] c: i32,
+    #[graphql(name = "haha", default = "33", description = "haha descr")]
+    c: i32,
 
-    #[graphql(default)] other: Option<bool>,
+    #[graphql(default)]
+    other: Option<bool>,
 }
 
 /// Object comment.
@@ -96,7 +98,10 @@ fn test_doc_comment() {
 fn test_multi_doc_comment() {
     let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = MultiDocComment::meta(&(), &mut registry);
-    assert_eq!(meta.description(), Some(&"Doc 1. Doc 2.\nDoc 4.".to_string()));
+    assert_eq!(
+        meta.description(),
+        Some(&"Doc 1. Doc 2.\nDoc 4.".to_string())
+    );
 }
 
 #[test]

--- a/juniper_tests/src/codegen/derive_object.rs
+++ b/juniper_tests/src/codegen/derive_object.rs
@@ -10,7 +10,8 @@ use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variab
 #[graphql(name = "MyObj", description = "obj descr")]
 struct Obj {
     regular_field: bool,
-    #[graphql(name = "renamedField", description = "descr", deprecation = "field descr")] c: i32,
+    #[graphql(name = "renamedField", description = "descr", deprecation = "field descr")]
+    c: i32,
 }
 
 #[derive(GraphQLObject, Debug, PartialEq)]
@@ -101,7 +102,10 @@ fn test_doc_comment() {
 fn test_multi_doc_comment() {
     let mut registry = juniper::Registry::new(FnvHashMap::default());
     let meta = MultiDocComment::meta(&(), &mut registry);
-    assert_eq!(meta.description(), Some(&"Doc 1. Doc 2.\nDoc 4.".to_string()));
+    assert_eq!(
+        meta.description(),
+        Some(&"Doc 1. Doc 2.\nDoc 4.".to_string())
+    );
 
     check_descriptions(
         "MultiDocComment",
@@ -150,18 +154,16 @@ fn test_derived_object() {
         execute(doc, None, &schema, &Variables::new(), &()),
         Ok((
             Value::object(
-                vec![
-                    (
-                        "obj",
-                        Value::object(
-                            vec![
-                                ("regularField", Value::boolean(true)),
-                                ("renamedField", Value::int(22)),
-                            ].into_iter()
-                                .collect(),
-                        ),
+                vec![(
+                    "obj",
+                    Value::object(
+                        vec![
+                            ("regularField", Value::boolean(true)),
+                            ("renamedField", Value::int(22)),
+                        ].into_iter()
+                            .collect(),
                     ),
-                ].into_iter()
+                )].into_iter()
                     .collect()
             ),
             vec![]
@@ -187,26 +189,22 @@ fn test_derived_object_nested() {
         execute(doc, None, &schema, &Variables::new(), &()),
         Ok((
             Value::object(
-                vec![
-                    (
-                        "nested",
-                        Value::object(
-                            vec![
-                                (
-                                    "obj",
-                                    Value::object(
-                                        vec![
-                                            ("regularField", Value::boolean(false)),
-                                            ("renamedField", Value::int(333)),
-                                        ].into_iter()
-                                            .collect(),
-                                    ),
-                                ),
-                            ].into_iter()
-                                .collect(),
-                        ),
+                vec![(
+                    "nested",
+                    Value::object(
+                        vec![(
+                            "obj",
+                            Value::object(
+                                vec![
+                                    ("regularField", Value::boolean(false)),
+                                    ("renamedField", Value::int(333)),
+                                ].into_iter()
+                                    .collect(),
+                            ),
+                        )].into_iter()
+                            .collect(),
                     ),
-                ].into_iter()
+                )].into_iter()
                     .collect()
             ),
             vec![]
@@ -215,8 +213,14 @@ fn test_derived_object_nested() {
 }
 
 #[cfg(test)]
-fn check_descriptions(object_name: &str, object_description: &Value, field_name: &str, field_value: &Value ) {
-    let doc = format!(r#"
+fn check_descriptions(
+    object_name: &str,
+    object_description: &Value,
+    field_name: &str,
+    field_value: &Value,
+) {
+    let doc = format!(
+        r#"
     {{
         __type(name: "{}") {{
             name,
@@ -227,7 +231,9 @@ fn check_descriptions(object_name: &str, object_description: &Value, field_name:
             }}
         }}
     }}
-    "#, object_name);
+    "#,
+        object_name
+    );
     run_type_info_query(&doc, |(type_info, values)| {
         assert_eq!(type_info.get("name"), Some(&Value::string(object_name)));
         assert_eq!(type_info.get("description"), Some(object_description));


### PR DESCRIPTION
I don't see any reasons why GraphQLType is implemented for Box bot not implemented for Arc. Also added ToInputValue.

I don't add `FromInputValue` for same reason that serde is not implemented for `Rc` and `Arc` by default: one my expect same objects to be deserialized to the same Arc which isn't true. I'm not entirely sure of whether this precaution is still useful for graphql though.