### PR TITLE
Use 'extensions' as field for error details

### DIFF
--- a/changelog/master.md
+++ b/changelog/master.md
@@ -38,3 +38,9 @@
 * `GraphQLType` and `ToInputValue` are now implemented for Arc<T>
 
   [#212](https://github.com/graphql-rust/juniper/pull/212)
+
+* Error responses no longer have a *data* field, instead, error details are stored in the *extensions* field
+
+  **Note:** while this is a breaking change, it is a necessary one to better align with the latest [GraphQL June 2018](https://facebook.github.io/graphql/June2018/#sec-Errors) specification, which defines the reserved *extensions* field for error details.  
+
+  [#219](https://github.com/graphql-rust/juniper/pull/219)

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -127,14 +127,14 @@ impl Ord for ExecutionError {
 #[derive(Debug, PartialEq)]
 pub struct FieldError {
     message: String,
-    data: Value,
+    extensions: Value,
 }
 
 impl<T: Display> From<T> for FieldError {
     fn from(e: T) -> FieldError {
         FieldError {
             message: format!("{}", e),
-            data: Value::null(),
+            extensions: Value::null(),
         }
     }
 }
@@ -157,7 +157,7 @@ impl FieldError {
     /// # fn main() { }
     /// ```
     ///
-    /// The `data` parameter will be added to the `"data"` field of the error
+    /// The `extensions` parameter will be added to the `"extensions"` field of the error
     /// object in the JSON response:
     ///
     /// ```json
@@ -165,7 +165,7 @@ impl FieldError {
     ///   "errors": [
     ///     "message": "Could not open connection to the database",
     ///     "locations": [{"line": 2, "column": 4}],
-    ///     "data": {
+    ///     "extensions": {
     ///       "internal_error": "Connection refused"
     ///     }
     ///   ]
@@ -173,10 +173,10 @@ impl FieldError {
     /// ```
     ///
     /// If the argument is `Value::null()`, no extra data will be included.
-    pub fn new<T: Display>(e: T, data: Value) -> FieldError {
+    pub fn new<T: Display>(e: T, extensions: Value) -> FieldError {
         FieldError {
             message: format!("{}", e),
-            data: data,
+            extensions,
         }
     }
 
@@ -186,8 +186,8 @@ impl FieldError {
     }
 
     #[doc(hidden)]
-    pub fn data(&self) -> &Value {
-        &self.data
+    pub fn extensions(&self) -> &Value {
+        &self.extensions
     }
 }
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -98,6 +98,8 @@ extern crate serde_derive;
 extern crate serde_json;
 
 extern crate fnv;
+
+#[cfg_attr(test, macro_use)]
 extern crate indexmap;
 
 #[cfg(any(test, feature = "chrono"))]


### PR DESCRIPTION
The June 2018 spec has reserved `extensions` as the field for error details. This PR updates the serializer to use this name.

From http://facebook.github.io/graphql/June2018/#sec-Errors:


> GraphQL may provide an additional entry to errors with key *extensions*. This entry, if set, must have a map as its value. This entry is reserved for implementors to add additional information to errors however they see fit, and there are no additional restrictions on its contents.