### PR TITLE
Allow crate type paths in `resolve` for `graphql_scalar!`

### DIFF
--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -59,7 +59,7 @@ macro_rules! graphql_scalar {
         @generate,
         ( $name:ty, $outname:expr, $descr:tt ),
         (
-            ( $resolve_selfvar:ident, $resolve_body:block ),
+            ( $resolve_selfvar:ident, $resolve_retval:ty, $resolve_body:block ),
             ( $fiv_arg:ident, $fiv_result:ty, $fiv_body:block )
         )
     ) => {
@@ -85,7 +85,7 @@ macro_rules! graphql_scalar {
                 &$resolve_selfvar,
                 _: &(),
                 _: Option<&[$crate::Selection]>,
-                _: &$crate::Executor<Self::Context>) -> $crate::Value {
+                _: &$crate::Executor<Self::Context>) -> $resolve_retval {
                 $resolve_body
             }
         }
@@ -117,9 +117,9 @@ macro_rules! graphql_scalar {
         @parse,
         $meta:tt,
         ( $_ignored:tt, $fiv:tt ),
-        resolve(&$selfvar:ident) -> Value $body:block $($rest:tt)*
+        resolve(&$selfvar:ident) -> $retval:ty $body:block $($rest:tt)*
     ) => {
-        graphql_scalar!( @parse, $meta, ( ($selfvar, $body), $fiv ), $($rest)* );
+        graphql_scalar!( @parse, $meta, ( ($selfvar, $retval, $body), $fiv ), $($rest)* );
     };
 
     // from_input_value(arg: &InputValue) -> ... { ... }

--- a/juniper/src/macros/tests/scalar.rs
+++ b/juniper/src/macros/tests/scalar.rs
@@ -93,6 +93,20 @@ where
 }
 
 #[test]
+fn path_in_resolve_return_type() {
+    struct ResolvePath(i32);
+    graphql_scalar!(ResolvePath {
+        resolve(&self) -> self::Value {
+            Value::int(self.0)
+        }
+
+        from_input_value(v: &InputValue) -> Option<ResolvePath> {
+            v.as_int_value().map(|i| ResolvePath(i))
+        }
+    });
+}
+
+#[test]
 fn default_name_introspection() {
     let doc = r#"
     {


### PR DESCRIPTION
Fixes https://github.com/graphql-rust/juniper/issues/227.