### PR TITLE
Add `local_inner_macros` to all helper macros

### DIFF
--- a/juniper/src/macros/args.rs
+++ b/juniper/src/macros/args.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! __graphql__args {
     // Internal type conversion
     ( @as_expr, $e:expr) => { $e };
@@ -27,7 +27,7 @@ macro_rules! __graphql__args {
         $name:ident $(= $default:tt)* : $ty:ty $(as $desc:tt)*, $($rest:tt)*
     ) => {
         let $name: $ty = $args
-            .get(&$crate::to_camel_case(stringify!($name)))
+            .get(&$crate::to_camel_case(__graphql__stringify!($name)))
             .expect("Argument missing - validation must have failed");
         __graphql__args!(@assign_arg_vars, $args, $executorvar, $($rest)*);
     };
@@ -38,7 +38,7 @@ macro_rules! __graphql__args {
         $name:ident  $(= $default:tt)* : $ty:ty $(as $desc:expr)*
     ) => {
         let $name: $ty = $args
-            .get(&$crate::to_camel_case(stringify!($name)))
+            .get(&$crate::to_camel_case(__graphql__stringify!($name)))
             .expect("Argument missing - validation must have failed");
     };
 
@@ -75,7 +75,7 @@ macro_rules! __graphql__args {
         $reg:expr, $base:expr, $info:expr, ( $name:ident = $default:tt : $t:ty )
     ) => {
         $base.argument($reg.arg_with_default::<$t>(
-            &$crate::to_camel_case(stringify!($name)),
+            &$crate::to_camel_case(__graphql__stringify!($name)),
             &__graphql__args!(@as_expr, $default), $info))
     };
 
@@ -87,7 +87,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
-                &$crate::to_camel_case(stringify!($name)),
+                &$crate::to_camel_case(__graphql__stringify!($name)),
                 &__graphql__args!(@as_expr, $default), $info)),
             $info,
             ( $($rest)* ))
@@ -102,7 +102,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg_with_default::<$t>(
-                &$crate::to_camel_case(stringify!($name)),
+                &$crate::to_camel_case(__graphql__stringify!($name)),
                 &__graphql__args!(@as_expr, $default), $info)
                 .description($desc)),
             $info,
@@ -114,7 +114,7 @@ macro_rules! __graphql__args {
         $reg:expr, $base:expr, $info:expr, ( $name:ident : $t:ty )
     ) => {
         $base.argument($reg.arg::<$t>(
-            &$crate::to_camel_case(stringify!($name)), $info))
+            &$crate::to_camel_case(__graphql__stringify!($name)), $info))
     };
 
     (
@@ -125,7 +125,7 @@ macro_rules! __graphql__args {
             @apply_args,
             $reg,
             $base.argument($reg.arg::<$t>(
-                &$crate::to_camel_case(stringify!($name)), $info)),
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)),
             $info,
             ( $($rest)* ))
     };
@@ -139,7 +139,7 @@ macro_rules! __graphql__args {
             $reg,
             $base.argument(
                 $reg.arg::<$t>(
-                    &$crate::to_camel_case(stringify!($name)), $info)
+                    &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .description($desc)),
             $info,
             ( $($rest)* ))

--- a/juniper/src/macros/field.rs
+++ b/juniper/src/macros/field.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! __graphql__build_field_matches {
     // field deprecated <reason> <name>(...) -> <type> as <description> { ... }
     (
@@ -81,7 +81,7 @@ macro_rules! __graphql__build_field_matches {
         ( $( ( $name:ident; ( $($args:tt)* ); $t:ty; $body:block ) )* ),
     ) => {
         $(
-            if $fieldvar == &$crate::to_camel_case(stringify!($name)) {
+            if $fieldvar == &$crate::to_camel_case(__graphql__stringify!($name)) {
                 let result: $t = (||{
                     __graphql__args!(
                         @assign_arg_vars,
@@ -98,6 +98,6 @@ macro_rules! __graphql__build_field_matches {
                     })
             }
         )*
-        panic!("Field {} not found on type {}", $fieldvar, $outname);
+        __graphql__panic!("Field {} not found on type {}", $fieldvar, $outname);
     };
 }

--- a/juniper/src/macros/interface.rs
+++ b/juniper/src/macros/interface.rs
@@ -85,7 +85,7 @@ graphql_interface!(<'a> &'a Character: Database as "Character" |&self| {
 [1]: macro.graphql_object!.html
 
 */
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! graphql_interface {
     ( @as_item, $i:item) => { $i };
     ( @as_expr, $e:expr) => { $e };
@@ -104,7 +104,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .description($desc)
                 .deprecated($reason),
             $info,
@@ -123,7 +123,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .deprecated($reason),
             $info,
             $args));
@@ -141,7 +141,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .description($desc),
             $info,
             $args));
@@ -159,7 +159,7 @@ macro_rules! graphql_interface {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info),
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info),
             $info,
             $args));
 
@@ -206,7 +206,7 @@ macro_rules! graphql_interface {
             }
         )*
 
-            panic!("Concrete type not handled by instance resolvers on {}", $outname);
+            __graphql__panic!("Concrete type not handled by instance resolvers on {}", $outname);
     };
 
     // instance_resolvers: | <ctxtvar> |
@@ -224,7 +224,7 @@ macro_rules! graphql_interface {
             }
         )*
 
-            panic!("Concrete type not handled by instance resolvers on {}", $outname);
+            __graphql__panic!("Concrete type not handled by instance resolvers on {}", $outname);
     };
 
     ( @ $mfn:ident, $args:tt, $first:tt $($rest:tt)* ) => {
@@ -327,6 +327,6 @@ macro_rules! graphql_interface {
             $( $items:tt )*
         }
     ) => {
-        graphql_interface!(() $name : $ctxt as (stringify!($name)) | &$mainself | { $( $items )* });
+        graphql_interface!(() $name : $ctxt as (__graphql__stringify!($name)) | &$mainself | { $( $items )* });
     };
 }

--- a/juniper/src/macros/mod.rs
+++ b/juniper/src/macros/mod.rs
@@ -1,3 +1,23 @@
+// Wrapper macros which allows built-in macros to be recognized as "crate-local".
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __graphql__panic {
+    ($($t:tt)*) => ( panic!($($t)*) );
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __graphql__stringify {
+    ($($t:tt)*) => ( stringify!($($t)*) );
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __graphql__vec {
+    ($($t:tt)*) => ( vec!($($t)*) );
+}
+
 #[macro_use]
 mod object;
 #[macro_use]

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -237,7 +237,7 @@ arg_name = ("default".to_owned()): String
 [1]: struct.Executor.html
 
 */
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! graphql_object {
     ( @as_item, $i:item) => { $i };
     ( @as_expr, $e:expr) => { $e };
@@ -258,7 +258,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .description($desc)
                 .deprecated($reason),
             $info,
@@ -277,7 +277,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .deprecated($reason),
             $info,
             $args));
@@ -295,7 +295,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info)
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info)
                 .description($desc),
             $info,
             $args));
@@ -313,7 +313,7 @@ macro_rules! graphql_object {
             @apply_args,
             $reg,
             $reg.field_convert::<$t, _, Self::Context>(
-                &$crate::to_camel_case(stringify!($name)), $info),
+                &$crate::to_camel_case(__graphql__stringify!($name)), $info),
             $info,
             $args));
 
@@ -357,13 +357,13 @@ macro_rules! graphql_object {
     ) => {};
 
     ( @assign_interfaces, $reg:expr, $tgt:expr, [ $($t:ty,)* ] ) => {
-        $tgt = Some(vec![
+        $tgt = Some(__graphql__vec![
             $($reg.get_type::<$t>(&())),*
         ]);
     };
 
     ( @assign_interfaces, $reg:expr, $tgt:expr, [ $($t:ty),* ] ) => {
-        $tgt = Some(vec![
+        $tgt = Some(__graphql__vec![
             $($reg.get_type::<$t>(&())),*
         ]);
     };
@@ -453,6 +453,6 @@ macro_rules! graphql_object {
         }
     ) => {
         graphql_object!(
-            ( ); $name; $ctxt; (stringify!($name)); $mainself; $( $items )*);
+            ( ); $name; $ctxt; (__graphql__stringify!($name)); $mainself; $( $items )*);
     };
 }

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -36,7 +36,7 @@ In addition to implementing `GraphQLType` for the type in question,
 usable as arguments and default values.
 
 */
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! graphql_scalar {
     ( @as_expr, $e:expr) => { $e };
 
@@ -151,6 +151,6 @@ macro_rules! graphql_scalar {
     // Entry point
     // RustName { ... }
     ( $name:ty { $( $items:tt )* }) => {
-        graphql_scalar!( @parse, ( $name, stringify!($name), None ), ( None, None ), $($items)* );
+        graphql_scalar!( @parse, ( $name, __graphql__stringify!($name), None ), ( None, None ), $($items)* );
     };
 }

--- a/juniper/src/macros/union.rs
+++ b/juniper/src/macros/union.rs
@@ -17,7 +17,7 @@ resolvers.
 [1]: macro.graphql_object!.html
 [2]: macro.graphql_interface!.html
 */
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! graphql_union {
     ( @as_item, $i:item) => { $i };
     ( @as_expr, $e:expr) => { $e };
@@ -43,7 +43,7 @@ macro_rules! graphql_union {
         instance_resolvers: | $ctxtvar:pat
                             | { $( $srctype:ty => $resolver:expr ),* $(,)* } $( $rest:tt )*
     ) => {
-        $acc = vec![
+        $acc = __graphql__vec![
             $(
                 $reg.get_type::<$srctype>(&())
             ),*
@@ -68,7 +68,7 @@ macro_rules! graphql_union {
             }
         )*
 
-            panic!("Concrete type not handled by instance resolvers on {}", $outname);
+            __graphql__panic!("Concrete type not handled by instance resolvers on {}", $outname);
     };
 
     // To generate the "resolve into type" resolver, syntax case:
@@ -87,7 +87,7 @@ macro_rules! graphql_union {
             }
         )*
 
-            panic!("Concrete type not handled by instance resolvers on {}", $outname);
+           __graphql__panic!("Concrete type not handled by instance resolvers on {}", $outname);
     };
 
     // eat commas
@@ -177,6 +177,6 @@ macro_rules! graphql_union {
             $( $items:tt )*
         }
     ) => {
-        graphql_union!(() $name : $ctxt as (stringify!($name)) | &$mainself | { $( $items )* });
+        graphql_union!(() $name : $ctxt as (__graphql__stringify!($name)) | &$mainself | { $( $items )* });
     };
 }


### PR DESCRIPTION
It allows to use the Rust2018-style macro imports correctly:

```rust
use juniper::graphql_object;

graphql_object!(User: () |&self| { ... });
```

In the future when dropping compatibility with pre-2018 compilers, it is able to be replaced with the explicit `$crate` prefixes instead of `local_inner_macros`.

### Notes
In `macro_rules!` with the annotation `local_inner_macros`, all of macro calls are transformed into `$crate::builtin!(...)` (https://github.com/rust-lang/rust/issues/53464#issuecomment-414049821).  Therefore, name resolutions of built-in macros are not perfomed correctly.
To avoid such situation, some helper macros are introduced to make built-in macros be interpreted as crate-local macros.