### PR TITLE
[juniper_rocket] Expose GraphQLResponse fields

### DIFF
--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -121,7 +121,7 @@ impl<'a> GraphQLBatchResponse<'a> {
 pub struct GraphQLRequest(GraphQLBatchRequest);
 
 /// Simple wrapper around the result of executing a GraphQL query
-pub struct GraphQLResponse(Status, String);
+pub struct GraphQLResponse(pub Status, pub String);
 
 /// Generate an HTML page containing GraphiQL
 pub fn graphiql_source(graphql_endpoint_url: &str) -> content::Html<String> {

--- a/juniper_rocket/tests/custom_response_tests.rs
+++ b/juniper_rocket/tests/custom_response_tests.rs
@@ -1,0 +1,107 @@
+#![feature(plugin)]
+#![plugin(rocket_codegen)]
+
+extern crate juniper;
+extern crate juniper_rocket;
+extern crate rocket;
+
+use std::io::Cursor;
+
+use rocket::http::ContentType;
+use rocket::local::{Client, LocalRequest};
+use rocket::Response;
+use rocket::Rocket;
+use rocket::State;
+
+use juniper::http::tests as http_tests;
+use juniper::tests::model::Database;
+use juniper::EmptyMutation;
+use juniper::RootNode;
+
+use juniper_rocket::GraphQLRequest;
+use juniper_rocket::GraphQLResponse;
+
+type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
+
+#[get("/?<request>")]
+fn get_graphql_handler<'a>(
+    context: State<Database>,
+    request: GraphQLRequest,
+    schema: State<Schema>,
+) -> Response<'a> {
+    let GraphQLResponse(status, json) = request.execute(&schema, &context);
+    Response::build()
+        .raw_header("X-Custom-Rocket-Response", "It works!")
+        .header(ContentType::new("application", "json"))
+        .status(status)
+        .sized_body(Cursor::new(json))
+        .finalize()
+}
+
+#[post("/", data = "<request>")]
+fn post_graphql_handler<'a>(
+    context: State<Database>,
+    request: GraphQLRequest,
+    schema: State<Schema>,
+) -> Response<'a> {
+    let GraphQLResponse(status, json) = request.execute(&schema, &context);
+    Response::build()
+        .raw_header("X-Custom-Rocket-Response", "It works!")
+        .header(ContentType::new("application", "json"))
+        .status(status)
+        .sized_body(Cursor::new(json))
+        .finalize()
+}
+
+struct TestRocketIntegration {
+    client: Client,
+}
+
+impl http_tests::HTTPIntegration for TestRocketIntegration {
+    fn get(&self, url: &str) -> http_tests::TestResponse {
+        let req = &self.client.get(url);
+        make_test_response(req)
+    }
+
+    fn post(&self, url: &str, body: &str) -> http_tests::TestResponse {
+        let req = &self.client.post(url).header(ContentType::JSON).body(body);
+        make_test_response(req)
+    }
+}
+
+#[test]
+fn test_rocket_integration() {
+    let rocket = make_rocket();
+    let client = Client::new(rocket).expect("valid rocket");
+    let integration = TestRocketIntegration { client };
+
+    http_tests::run_http_test_suite(&integration);
+}
+
+fn make_rocket() -> Rocket {
+    rocket::ignite()
+        .manage(Database::new())
+        .manage(Schema::new(
+            Database::new(),
+            EmptyMutation::<Database>::new(),
+        )).mount("/", routes![post_graphql_handler, get_graphql_handler])
+}
+
+fn make_test_response<'r>(request: &LocalRequest<'r>) -> http_tests::TestResponse {
+    let mut response = request.cloned_dispatch();
+    let status_code = response.status().code as i32;
+    let content_type = response
+        .content_type()
+        .expect("No content type header from handler")
+        .to_string();
+    let body = response
+        .body()
+        .expect("No body returned from GraphQL handler")
+        .into_string();
+
+    http_tests::TestResponse {
+        status_code: status_code,
+        body: body,
+        content_type: content_type,
+    }
+}

--- a/juniper_rocket/tests/custom_response_tests.rs
+++ b/juniper_rocket/tests/custom_response_tests.rs
@@ -1,107 +1,11 @@
-#![feature(plugin)]
-#![plugin(rocket_codegen)]
-
-extern crate juniper;
 extern crate juniper_rocket;
 extern crate rocket;
 
-use std::io::Cursor;
+use rocket::http::Status;
 
-use rocket::http::ContentType;
-use rocket::local::{Client, LocalRequest};
-use rocket::Response;
-use rocket::Rocket;
-use rocket::State;
-
-use juniper::http::tests as http_tests;
-use juniper::tests::model::Database;
-use juniper::EmptyMutation;
-use juniper::RootNode;
-
-use juniper_rocket::GraphQLRequest;
 use juniper_rocket::GraphQLResponse;
 
-type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
-
-#[get("/?<request>")]
-fn get_graphql_handler<'a>(
-    context: State<Database>,
-    request: GraphQLRequest,
-    schema: State<Schema>,
-) -> Response<'a> {
-    let GraphQLResponse(status, json) = request.execute(&schema, &context);
-    Response::build()
-        .raw_header("X-Custom-Rocket-Response", "It works!")
-        .header(ContentType::new("application", "json"))
-        .status(status)
-        .sized_body(Cursor::new(json))
-        .finalize()
-}
-
-#[post("/", data = "<request>")]
-fn post_graphql_handler<'a>(
-    context: State<Database>,
-    request: GraphQLRequest,
-    schema: State<Schema>,
-) -> Response<'a> {
-    let GraphQLResponse(status, json) = request.execute(&schema, &context);
-    Response::build()
-        .raw_header("X-Custom-Rocket-Response", "It works!")
-        .header(ContentType::new("application", "json"))
-        .status(status)
-        .sized_body(Cursor::new(json))
-        .finalize()
-}
-
-struct TestRocketIntegration {
-    client: Client,
-}
-
-impl http_tests::HTTPIntegration for TestRocketIntegration {
-    fn get(&self, url: &str) -> http_tests::TestResponse {
-        let req = &self.client.get(url);
-        make_test_response(req)
-    }
-
-    fn post(&self, url: &str, body: &str) -> http_tests::TestResponse {
-        let req = &self.client.post(url).header(ContentType::JSON).body(body);
-        make_test_response(req)
-    }
-}
-
 #[test]
-fn test_rocket_integration() {
-    let rocket = make_rocket();
-    let client = Client::new(rocket).expect("valid rocket");
-    let integration = TestRocketIntegration { client };
-
-    http_tests::run_http_test_suite(&integration);
-}
-
-fn make_rocket() -> Rocket {
-    rocket::ignite()
-        .manage(Database::new())
-        .manage(Schema::new(
-            Database::new(),
-            EmptyMutation::<Database>::new(),
-        )).mount("/", routes![post_graphql_handler, get_graphql_handler])
-}
-
-fn make_test_response<'r>(request: &LocalRequest<'r>) -> http_tests::TestResponse {
-    let mut response = request.cloned_dispatch();
-    let status_code = response.status().code as i32;
-    let content_type = response
-        .content_type()
-        .expect("No content type header from handler")
-        .to_string();
-    let body = response
-        .body()
-        .expect("No body returned from GraphQL handler")
-        .into_string();
-
-    http_tests::TestResponse {
-        status_code: status_code,
-        body: body,
-        content_type: content_type,
-    }
+fn test_graphql_response_is_public() {
+    let _ = GraphQLResponse(Status::Unauthorized, "Unauthorized".to_string());
 }


### PR DESCRIPTION
This PR exposes the fields of `GraphQLResponse` to make it easier to create custom responses.

##### Example

Here we're building a custom Rocket response so we can set some `Access-Control-*` headers:

```rust
fn execute_graphql_request<'a>(
    connection: DatabaseConnection,
    request: GraphQLRequest,
) -> Response<'a> {
    let context = Database::new(connection);
    let schema = Schema::new(Query, Mutation);
    // Prior to this change, this fails to compile with an error:
    // "constructor is not visible here due to private fields".
    let GraphQLResponse(status, json) = request.execute(&schema, &context);
    Response::build()
        .raw_header("Access-Control-Allow-Origin", "*")
        .raw_header("Access-Control-Allow-Methods", "OPTIONS, GET, POST")
        .raw_header("Access-Control-Allow-Headers", "Content-Type")
        .header(ContentType::new("application", "json"))
        .status(status)
        .sized_body(Cursor::new(json))
        .finalize()
}
```
