### PR TITLE
Fix hyper examples link in README and remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 ---
 
 [GraphQL][graphql] is a data query language developed by Facebook intended to
-serve mobile and web application frontends. 
+serve mobile and web application frontends.
 
-*Juniper* makes it possible to write GraphQL servers in Rust that are 
-type-safe and blazingly fast. We also try to make declaring and resolving 
+*Juniper* makes it possible to write GraphQL servers in Rust that are
+type-safe and blazingly fast. We also try to make declaring and resolving
 GraphQL schemas as convenient as possible as Rust will allow.
 
 Juniper does not include a web server - instead it provides building blocks to
@@ -31,26 +31,26 @@ embedded [Graphiql][graphiql] for easy debugging.
 
 ## Getting Started
 
-The best place to get started is the [Juniper Book][book], which contains 
+The best place to get started is the [Juniper Book][book], which contains
 guides with plenty of examples, covering all features of Juniper. (very much WIP)
 
-To get started quickly and get a feel for Juniper, check out the 
+To get started quickly and get a feel for Juniper, check out the
 [Quickstart][book_quickstart] section.
 
-For specific information about macros, types and the Juniper api, the 
+For specific information about macros, types and the Juniper api, the
 [API Reference][docsrs] is the best place to look.
 
 You can also check out [src/tests/schema.rs][test_schema_rs] to see a complex
-schema including polymorphism with traits and interfaces.  
-For an example of web framework integration, 
+schema including polymorphism with traits and interfaces.
+For an example of web framework integration,
 see the [hyper][hyper_examples], [rocket][rocket_examples], and [iron][iron_examples] examples folders.
 
 
 ## Features
 
 Juniper supports the full GraphQL query language according to the
-[specification][graphql_spec], including interfaces, unions, schema 
-introspection, and validations.  
+[specification][graphql_spec], including interfaces, unions, schema
+introspection, and validations.
 It does not, however, support the schema language.
 
 As an exception to other GraphQL libraries for other languages, Juniper builds
@@ -91,7 +91,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 [graphql_spec]: http://facebook.github.io/graphql
 [test_schema_rs]: https://github.com/graphql-rust/juniper/blob/master/juniper/src/tests/schema.rs
 [tokio]: https://github.com/tokio-rs/tokio
-[hyper_examples]: https://github.com/graphql-rust/juniper/tree/master/hyper_rocket/examples
+[hyper_examples]: https://github.com/graphql-rust/juniper/tree/master/juniper_hyper/examples
 [rocket_examples]: https://github.com/graphql-rust/juniper/tree/master/juniper_rocket/examples
 [iron_examples]: https://github.com/graphql-rust/juniper/tree/master/juniper_iron/examples
 [Hyper]: https://hyper.rs


### PR DESCRIPTION
Hopefully the last README related fix 😉 