### PR TITLE
Use raw url for Juniper logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/graphql-rust/juniper/blob/master/assets/logo/juniper-dark-word.png" alt="Juniper" width="500" />
+<img src="https://github.com/graphql-rust/juniper/raw/master/assets/logo/juniper-dark-word.png" alt="Juniper" width="500" />
 
 
 > GraphQL server library for Rust


### PR DESCRIPTION
I noticed on https://crates.io/crates/juniper that the logo is not rendering properly? I see the following warning:
`Cross-Origin Read Blocking (CORB) blocked cross-origin response https://github.com/graphql-rust/juniper/blob/master/assets/logo/juniper-dark-word.png with MIME type text/html. See https://www.chromestatus.com/feature/5629709824032768 for more details.`

When I replace the URL with `raw` the logo appears.