### PR TITLE
Use only a single thread pool for juniper_hyper

### DIFF
--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -15,13 +15,13 @@ url = "1.7"
 juniper = { version = ">=0.9, 0.10.0" , default-features = false, path = "../juniper"}
 
 futures = "0.1"
-futures-cpupool = "0.1"
+tokio = "0.1.8"
 hyper = "0.12"
+tokio-threadpool = "0.1.7"
 
 [dev-dependencies]
 pretty_env_logger = "0.2"
-tokio = "0.1.8"
-reqwest = "0.8"
+reqwest = "0.9"
 
 [dev-dependencies.juniper]
 version = "0.10.0"


### PR DESCRIPTION
The previous implementation used a `futures_cpupool` for executing blocking juniper operations. This pool comes in addition to the thread pool started by hyper through tokio for executing hyper's futures. This patch uses [`tokio::blocking`](https://docs.rs/tokio-threadpool/0.1.7/tokio_threadpool/fn.blocking.html) to perform the blocking juniper operations while re-using the same thread pool as hyper, which simplifies the API.