### PR TITLE
Infer graphql "deprecation" from #[deprecated(note = "...")] in derive (and macros)

### DIFF
--- a/changelog/master.md
+++ b/changelog/master.md
@@ -14,3 +14,54 @@
   generic code. To retain the current behaviour use `DefaultScalarValue` as scalar value type
 
   [#251](https://github.com/graphql-rust/juniper/pull/251)
+
+- The `GraphQLObject` and `GraphQLEnum` derives will mark graphql fields as
+  `@deprecated` when struct fields or enum variants are marked with the
+  builtin `#[deprecated]` attribute.
+
+  The deprecation reason can be set using the `note = ...` meta item
+  (e.g. `#[deprecated(note = "Replaced by betterField")]`).
+  The `since` attribute is ignored.
+
+  [#269](https://github.com/graphql-rust/juniper/pull/269)
+
+
+- There is an alternative syntax for setting a field's _description_ and
+  _deprecation reason_ in the `graphql_object!` and `graphql_interface!` macros.
+
+  To __deprecate__ a graphql field:
+    ```rust
+    // Original syntax for setting deprecation reason
+    field deprecated "Reason" my_field() -> { ... }
+
+    // New alternative syntax for deprecated
+    #[deprecated(note = "Reason")]
+    field my_field() -> { ... }
+
+    // You can now also deprecate without a reason.
+    #[deprecated]
+    field my_field() -> { ... }
+    ```
+
+  To set the __description__ of a graphql field:
+    ```rust
+    // Original syntax for setting deprecation reason
+    field my_field() as "Description" -> { ... }
+
+    // New alternative syntax for deprecated
+    #[doc = "Description"]
+    field my_field() -> { ... }
+
+    // You can now also use raw strings, const str, and
+    // combine multiple docstrings into one.
+    #[doc = r#"
+        This is my field.
+
+        Make sure not to flitz the bitlet.
+        Flitzing without a bitlet has undefined behaviour.
+    "]
+    #[doc = my_consts::ADDED_IN_VERSION_XYZ]
+    field my_field() -> { ... }
+    ```
+
+  [#269](https://github.com/graphql-rust/juniper/pull/269)

--- a/changelog/master.md
+++ b/changelog/master.md
@@ -34,7 +34,7 @@
     // Original syntax for setting deprecation reason
     field deprecated "Reason" my_field() -> { ... }
 
-    // New alternative syntax for deprecated
+    // New alternative syntax for deprecation reason.
     #[deprecated(note = "Reason")]
     field my_field() -> { ... }
 
@@ -45,15 +45,34 @@
 
   To set the __description__ of a graphql field:
     ```rust
-    // Original syntax for setting deprecation reason
+    // Original syntax for field descriptions
     field my_field() as "Description" -> { ... }
 
-    // New alternative syntax for deprecated
+    // Original syntax for argument descriptions
+    field my_field(
+      floops: i32 as "The number of starfish to be returned. \
+                      Can't be more than 100.",
+    ) -> {
+      ...
+    }
+
+    // New alternative syntax for field descriptions
     #[doc = "Description"]
     field my_field() -> { ... }
 
-    // You can now also use raw strings, const str, and
-    // combine multiple docstrings into one.
+    // New alternative syntax for argument descriptions
+    field my_field(
+      #[doc = "The number of starfish to be returned. \
+               Can't be more than 100."]
+      arg: i32,
+    ) -> {
+      ...
+    }
+
+    // You can also use raw strings and const &'static str.
+    //
+    // Multiple docstrings will be collapsed into a single
+    // description separated by newlines.
     #[doc = r#"
         This is my field.
 

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -15,8 +15,8 @@ use value::Value;
 use GraphQLError;
 
 use schema::meta::{
-    Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, ListMeta, MetaType,
-    NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
+    Argument, DeprecationStatus, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta,
+    ListMeta, MetaType, NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
 };
 use schema::model::{RootNode, SchemaType, TypeType};
 
@@ -729,7 +729,7 @@ where
             description: None,
             arguments: None,
             field_type: self.get_type::<T>(info),
-            deprecation_reason: None,
+            deprecation_status: DeprecationStatus::Current,
         }
     }
 
@@ -748,7 +748,7 @@ where
             description: None,
             arguments: None,
             field_type: self.get_type::<I>(info),
-            deprecation_reason: None,
+            deprecation_status: DeprecationStatus::Current,
         }
     }
 

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -398,7 +398,74 @@ macro_rules! __juniper_parse_field_list {
         );
     };
 
-
+    (
+        success_callback = $success_callback: ident,
+        additional_parser = {$($additional:tt)*},
+        meta = {$($meta:tt)*},
+        items = [$({$($items: tt)*},)*],
+        rest = $(#[doc = $desc: tt])*
+        #[deprecated($(since = $since: tt,)* note = $reason: tt)]
+        field $name: ident (
+            $(&$executor: tt)* $(,)*
+            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty),* $(,)*
+        ) -> $return_ty: ty $body: block
+            $($rest:tt)*
+    ) => {
+        __juniper_parse_field_list!(
+            success_callback = $success_callback,
+            additional_parser = {$($additional)*},
+            meta = {$($meta)*},
+            items = [$({$($items)*},)* {
+                name = $name,
+                body = $body,
+                return_ty = $return_ty,
+                args = [
+                    $({
+                        arg_name = $arg_name,
+                        arg_ty = $arg_ty,
+                        $(arg_default = $default_value,)*
+                    },)*
+                ],
+                $(decs_line = $desc,)*
+                deprecated = $reason,
+                $(executor_var = $executor,)*
+            },],
+            rest = $($rest)*
+        );
+    };
+    (
+        success_callback = $success_callback: ident,
+        additional_parser = {$($additional:tt)*},
+        meta = {$($meta:tt)*},
+        items = [$({$($items: tt)*},)*],
+        rest = $(#[doc = $desc: tt])*
+        field $name: ident (
+            $(&$executor: ident)* $(,)*
+            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty),* $(,)*
+        ) -> $return_ty: ty $body: block
+            $($rest:tt)*
+    ) => {
+        __juniper_parse_field_list!(
+            success_callback = $success_callback,
+            additional_parser = {$($additional)*},
+            meta = {$($meta)*},
+            items = [$({$($items)*},)* {
+                name = $name,
+                body = $body,
+                return_ty = $return_ty,
+                args = [
+                    $({
+                        arg_name = $arg_name,
+                        arg_ty = $arg_ty,
+                        $(arg_default = $default_value,)*
+                    },)*
+                ],
+                $(decs_line = $desc,)*
+                $(executor_var = $executor,)*
+            },],
+            rest = $($rest)*
+        );
+    };
     (
         success_callback = $success_callback: ident,
         additional_parser = {$($additional:tt)*},

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -407,7 +407,7 @@ macro_rules! __juniper_parse_field_list {
         #[deprecated($(since = $since: tt,)* $(note = $reason: tt),*)]
         field $name: ident (
             $(&$executor: tt)* $(,)*
-            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty),* $(,)*
+            $($(#[doc = $arg_desc: expr])* $arg_name:ident $(= $arg_default: tt)* : $arg_ty: ty),* $(,)*
         ) -> $return_ty: ty $body: block
             $($rest:tt)*
     ) => {
@@ -423,7 +423,8 @@ macro_rules! __juniper_parse_field_list {
                     $({
                         arg_name = $arg_name,
                         arg_ty = $arg_ty,
-                        $(arg_default = $default_value,)*
+                        $(arg_default = $arg_default,)*
+                        $(arg_docstring = $arg_desc,)*
                     },)*
                 ],
                 $(docstring = $desc,)*
@@ -441,7 +442,7 @@ macro_rules! __juniper_parse_field_list {
         rest = $(#[doc = $desc: tt])*
         field $name: ident (
             $(&$executor: ident)* $(,)*
-            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty),* $(,)*
+            $($(#[doc = $arg_desc: expr])* $arg_name:ident $(= $arg_default: tt)* : $arg_ty: ty),* $(,)*
         ) -> $return_ty: ty $body: block
             $($rest:tt)*
     ) => {
@@ -457,7 +458,8 @@ macro_rules! __juniper_parse_field_list {
                     $({
                         arg_name = $arg_name,
                         arg_ty = $arg_ty,
-                        $(arg_default = $default_value,)*
+                        $(arg_default = $arg_default,)*
+                        $(arg_docstring = $arg_desc,)*
                     },)*
                 ],
                 $(docstring = $desc,)*
@@ -473,7 +475,7 @@ macro_rules! __juniper_parse_field_list {
         items = [$({$($items: tt)*},)*],
         rest = field deprecated $reason:tt $name: ident (
             $(&$executor: tt)* $(,)*
-            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty $(as $arg_des: expr)*),* $(,)*
+            $($arg_name:ident $(= $arg_default: tt)* : $arg_ty: ty $(as $arg_desc: expr)*),* $(,)*
         ) -> $return_ty: ty $(as $desc: tt)* $body: block
             $($rest:tt)*
     ) => {
@@ -489,8 +491,8 @@ macro_rules! __juniper_parse_field_list {
                     $({
                         arg_name = $arg_name,
                         arg_ty = $arg_ty,
+                        $(arg_default = $arg_default,)*
                         $(arg_description = $arg_desc,)*
-                        $(arg_default = $default_value,)*
                     },)*
                 ],
                 $(decs = $desc,)*
@@ -507,7 +509,7 @@ macro_rules! __juniper_parse_field_list {
         items = [$({$($items: tt)*},)*],
         rest = field $name: ident (
             $(&$executor: ident)* $(,)*
-            $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty $(as $arg_desc: expr)*),* $(,)*
+            $($arg_name:ident $(= $arg_default: tt)* : $arg_ty: ty $(as $arg_desc: expr)*),* $(,)*
         ) -> $return_ty: ty $(as $desc: tt)* $body: block
             $($rest:tt)*
     ) => {
@@ -523,8 +525,8 @@ macro_rules! __juniper_parse_field_list {
                     $({
                         arg_name = $arg_name,
                         arg_ty = $arg_ty,
+                        $(arg_default = $arg_default,)*
                         $(arg_description = $arg_desc,)*
-                        $(arg_default = $default_value,)*
                     },)*
                 ],
                 $(decs = $desc,)*
@@ -668,12 +670,14 @@ macro_rules! __juniper_create_arg {
         arg_ty = $arg_ty: ty,
         arg_name = $arg_name: ident,
         $(description = $arg_description: expr,)*
+        $(docstring = $arg_docstring: expr,)*
     ) => {
         $reg.arg::<$arg_ty>(
             &$crate::to_camel_case(stringify!($arg_name)),
             $info,
         )
         $(.description($arg_description))*
+        $(.push_docstring($arg_docstring))*
     };
 
     (
@@ -681,8 +685,9 @@ macro_rules! __juniper_create_arg {
         info = $info: ident,
         arg_ty = $arg_ty: ty,
         arg_name = $arg_name: ident,
-        $(description = $arg_description: expr,)*
         default = $arg_default: expr,
+        $(description = $arg_description: expr,)*
+        $(docstring = $arg_docstring: expr,)*
     ) => {
         $reg.arg_with_default::<$arg_ty>(
             &$crate::to_camel_case(stringify!($arg_name)),
@@ -690,5 +695,6 @@ macro_rules! __juniper_create_arg {
             $info,
         )
         $(.description($arg_description))*
+        $(.push_docstring($arg_docstring))*
     };
 }

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -404,7 +404,7 @@ macro_rules! __juniper_parse_field_list {
         meta = {$($meta:tt)*},
         items = [$({$($items: tt)*},)*],
         rest = $(#[doc = $desc: tt])*
-        #[deprecated($(since = $since: tt,)* $(note = $reason: tt),*)]
+        #[deprecated $(( $(since = $since: tt,)* note = $reason: tt ))* ]
         field $name: ident (
             $(&$executor: tt)* $(,)*
             $($(#[doc = $arg_desc: expr])* $arg_name:ident $(= $arg_default: tt)* : $arg_ty: ty),* $(,)*

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -404,7 +404,7 @@ macro_rules! __juniper_parse_field_list {
         meta = {$($meta:tt)*},
         items = [$({$($items: tt)*},)*],
         rest = $(#[doc = $desc: tt])*
-        #[deprecated($(since = $since: tt,)* note = $reason: tt)]
+        #[deprecated($(since = $since: tt,)* $(note = $reason: tt),*)]
         field $name: ident (
             $(&$executor: tt)* $(,)*
             $($arg_name:ident $(= $default_value: tt)* : $arg_ty: ty),* $(,)*
@@ -427,7 +427,7 @@ macro_rules! __juniper_parse_field_list {
                     },)*
                 ],
                 $(docstring = $desc,)*
-                deprecated = $reason,
+                deprecated = None$(.unwrap_or(Some($reason)))*,
                 $(executor_var = $executor,)*
             },],
             rest = $($rest)*
@@ -494,7 +494,7 @@ macro_rules! __juniper_parse_field_list {
                     },)*
                 ],
                 $(decs = $desc,)*
-                deprecated = $reason,
+                deprecated = Some($reason),
                 $(executor_var = $executor,)*
             },],
             rest = $($rest)*

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -426,7 +426,7 @@ macro_rules! __juniper_parse_field_list {
                         $(arg_default = $default_value,)*
                     },)*
                 ],
-                $(decs_line = $desc,)*
+                $(docstring = $desc,)*
                 deprecated = $reason,
                 $(executor_var = $executor,)*
             },],
@@ -460,7 +460,7 @@ macro_rules! __juniper_parse_field_list {
                         $(arg_default = $default_value,)*
                     },)*
                 ],
-                $(decs_line = $desc,)*
+                $(docstring = $desc,)*
                 $(executor_var = $executor,)*
             },],
             rest = $($rest)*

--- a/juniper/src/macros/interface.rs
+++ b/juniper/src/macros/interface.rs
@@ -121,7 +121,7 @@ macro_rules! graphql_interface {
                 $(arg_default = $arg_default: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
-            $(decs_line = $fn_description_line: expr,)*
+            $(docstring = $docstring: expr,)*
             $(deprecated = $deprecated: expr,)*
             $(executor_var = $executor: ident,)*
         },)*],
@@ -152,7 +152,7 @@ macro_rules! graphql_interface {
                             info
                         )
                             $(.description($fn_description))*
-                            $(.description_line($fn_description_line))*
+                            $(.push_docstring($docstring))*
                             $(.deprecated($deprecated))*
                             $(.argument(
                                 __juniper_create_arg!(

--- a/juniper/src/macros/interface.rs
+++ b/juniper/src/macros/interface.rs
@@ -117,8 +117,9 @@ macro_rules! graphql_interface {
             args = [$({
                 arg_name = $arg_name : ident,
                 arg_ty = $arg_ty: ty,
-                $(arg_description = $arg_description: expr,)*
                 $(arg_default = $arg_default: expr,)*
+                $(arg_description = $arg_description: expr,)*
+                $(arg_docstring = $arg_docstring: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
             $(docstring = $docstring: expr,)*
@@ -160,8 +161,9 @@ macro_rules! graphql_interface {
                                     info = info,
                                     arg_ty = $arg_ty,
                                     arg_name = $arg_name,
-                                    $(description = $arg_description,)*
                                     $(default = $arg_default,)*
+                                    $(description = $arg_description,)*
+                                    $(docstring = $arg_docstring,)*
                                 )
                             ))*,
                     )*];

--- a/juniper/src/macros/interface.rs
+++ b/juniper/src/macros/interface.rs
@@ -121,6 +121,7 @@ macro_rules! graphql_interface {
                 $(arg_default = $arg_default: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
+            $(decs_line = $fn_description_line: expr,)*
             $(deprecated = $deprecated: expr,)*
             $(executor_var = $executor: ident,)*
         },)*],
@@ -151,6 +152,7 @@ macro_rules! graphql_interface {
                             info
                         )
                             $(.description($fn_description))*
+                            $(.description_line($fn_description_line))*
                             $(.deprecated($deprecated))*
                             $(.argument(
                                 __juniper_create_arg!(

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -299,6 +299,7 @@ macro_rules! graphql_object {
                 $(arg_default = $arg_default: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
+            $(decs_line = $fn_description_line: expr,)*
             $(deprecated = $deprecated: expr,)*
             $(executor_var = $executor: ident,)*
         },)*],
@@ -325,6 +326,7 @@ macro_rules! graphql_object {
                             info
                         )
                             $(.description($fn_description))*
+                            $(.description_line($fn_description_line))*
                             $(.deprecated($deprecated))*
                             $(.argument(
                                 __juniper_create_arg!(

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -66,6 +66,7 @@ graphql_object!(User: () |&self| {
 **Alternatively,** descriptions can be added with the builtin `doc` attribute.
 Consecutive `#[doc = "..."]` attributes will be collapsed into a single description
 where the docstrings are separated by newlines.
+
 ```
 # #[macro_use] extern crate juniper;
 struct User { id: String, name: String, group_ids: Vec<String> }

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -63,6 +63,44 @@ graphql_object!(User: () |&self| {
 # fn main() { }
 ```
 
+**Alternatively,** descriptions can be added with the builtin `doc` attribute.
+Consecutive `#[doc = "..."]` attributes will be collapsed into a single description
+where the docstrings are separated by newlines.
+```
+# #[macro_use] extern crate juniper;
+struct User { id: String, name: String, group_ids: Vec<String> }
+
+graphql_object!(User: () |&self| {
+    description: "A user in the database"
+
+    #[doc = "The user's unique identifier"]
+    field id() -> &String {
+        &self.id
+    }
+
+    #[doc = "The user's name"]
+    field name() -> &String {
+        &self.name
+    }
+
+    #[doc = r#"
+        Test if a user is member of a group.
+
+        This may return a flitzbit if the floop is twizled.
+        Make sure not to rumblejumble the cog-rotater.
+    "#]
+    #[doc = "Added in vX.Y.44"]
+    field member_of_group(
+        #[doc = "The group id you want to test membership against"]
+        group_id: String,
+    ) -> bool {
+        self.group_ids.iter().any(|gid| gid == &group_id)
+    }
+});
+
+# fn main() { }
+```
+
 ## Generics and lifetimes
 
 You can expose generic or pointer types by prefixing the type with the necessary
@@ -232,6 +270,24 @@ Defines a field on the object. The name is converted to camel case, e.g.
 `user_name` is exposed as `userName`. The `as "Field description"` adds the
 string as documentation on the field.
 
+A field's description and deprecation can also be set using the
+builtin `doc` and `deprecated` attributes.
+
+```text
+#[doc = "Field description"]
+field name(args...) -> Type { }
+
+#[deprecated] // no reason required
+field name(args...) -> Type { }
+
+#[deprecated(note = "Reason")]
+field name(args...) -> Type { }
+
+#[doc = "Field description"]
+#[deprecated(note = "Reason")] // deprecated must come after doc
+field deprecated "Reason" name(args...) -> Type { }
+```
+
 ### Field arguments
 
 ```text
@@ -267,6 +323,13 @@ complex default value expressions:
 ```text
 arg_name = (Point { x: 1, y: 2 }): Point
 arg_name = ("default".to_owned()): String
+```
+
+A description can also be provided using the builtin `doc` attribute.
+
+```text
+#[doc = "Argument description"]
+arg_name: ArgType
 ```
 
 [1]: struct.Executor.html

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -299,7 +299,7 @@ macro_rules! graphql_object {
                 $(arg_default = $arg_default: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
-            $(decs_line = $fn_description_line: expr,)*
+            $(docstring = $docstring: expr,)*
             $(deprecated = $deprecated: expr,)*
             $(executor_var = $executor: ident,)*
         },)*],
@@ -326,7 +326,7 @@ macro_rules! graphql_object {
                             info
                         )
                             $(.description($fn_description))*
-                            $(.description_line($fn_description_line))*
+                            $(.push_docstring($docstring))*
                             $(.deprecated($deprecated))*
                             $(.argument(
                                 __juniper_create_arg!(

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -67,7 +67,7 @@ graphql_object!(User: () |&self| {
 Consecutive `#[doc = "..."]` attributes will be collapsed into a single description
 where the docstrings are separated by newlines.
 
-```
+```rust
 # #[macro_use] extern crate juniper;
 struct User { id: String, name: String, group_ids: Vec<String> }
 

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -295,8 +295,9 @@ macro_rules! graphql_object {
             args = [$({
                 arg_name = $arg_name : ident,
                 arg_ty = $arg_ty: ty,
-                $(arg_description = $arg_description: expr,)*
                 $(arg_default = $arg_default: expr,)*
+                $(arg_description = $arg_description: expr,)*
+                $(arg_docstring = $arg_docstring: expr,)*
             },)*],
             $(decs = $fn_description: expr,)*
             $(docstring = $docstring: expr,)*
@@ -334,8 +335,9 @@ macro_rules! graphql_object {
                                     info = info,
                                     arg_ty = $arg_ty,
                                     arg_name = $arg_name,
-                                    $(description = $arg_description,)*
                                     $(default = $arg_default,)*
+                                    $(description = $arg_description,)*
+                                    $(docstring = $arg_docstring,)*
                                 )
                             ))*,
                     )*];

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -49,6 +49,13 @@ graphql_object!(Root: () |&self| {
         arg2: i32 as "The second arg",
     ) -> i32 { 0 }
 
+    field attr_arg_descr(#[doc = "The arg"] arg: i32) -> i32 { 0 }
+    field attr_arg_descr_collapse(
+        #[doc = "The arg"]
+        #[doc = "and more details"]
+        arg: i32,
+    ) -> i32 { 0 }
+
     field arg_with_default(arg = 123: i32) -> i32 { 0 }
     field multi_args_with_default(
         arg1 = 123: i32,
@@ -476,6 +483,72 @@ fn introspect_field_multi_args_descr_trailing_comma() {
                 vec![
                     ("name", Value::scalar("arg2")),
                     ("description", Value::scalar("The second arg")),
+                    ("defaultValue", Value::null()),
+                    (
+                        "type",
+                        Value::object(
+                            vec![
+                                ("name", Value::null()),
+                                (
+                                    "ofType",
+                                    Value::object(
+                                        vec![("name", Value::scalar("Int"))].into_iter().collect(),
+                                    ),
+                                ),
+                            ].into_iter()
+                            .collect(),
+                        ),
+                    ),
+                ].into_iter()
+                .collect(),
+            ))
+        );
+    });
+}
+
+#[test]
+fn introspect_field_attr_arg_descr() {
+    run_args_info_query("attrArgDescr", |args| {
+        assert_eq!(args.len(), 1);
+
+        assert!(
+            args.contains(&Value::object(
+                vec![
+                    ("name", Value::scalar("arg")),
+                    ("description", Value::scalar("The arg")),
+                    ("defaultValue", Value::null()),
+                    (
+                        "type",
+                        Value::object(
+                            vec![
+                                ("name", Value::null()),
+                                (
+                                    "ofType",
+                                    Value::object(
+                                        vec![("name", Value::scalar("Int"))].into_iter().collect(),
+                                    ),
+                                ),
+                            ].into_iter()
+                            .collect(),
+                        ),
+                    ),
+                ].into_iter()
+                .collect(),
+            ))
+        );
+    });
+}
+
+#[test]
+fn introspect_field_attr_arg_descr_collapse() {
+    run_args_info_query("attrArgDescrCollapse", |args| {
+        assert_eq!(args.len(), 1);
+
+        assert!(
+            args.contains(&Value::object(
+                vec![
+                    ("name", Value::scalar("arg")),
+                    ("description", Value::scalar("The arg\nand more details")),
                     ("defaultValue", Value::null()),
                     (
                         "type",

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -46,8 +46,11 @@ graphql_object!(Root: () |&self| {
     "#]
     field attr_description_long() -> i32 { 0 }
 
-    #[deprecated(note = "Deprecation reason")]
+    #[deprecated]
     field attr_deprecated() -> i32 { 0 }
+
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated_reason() -> i32 { 0 }
 
     #[doc = "Field description"]
     #[deprecated(note = "Deprecation reason")]
@@ -88,8 +91,11 @@ graphql_interface!(Interface: () |&self| {
     "#]
     field attr_description_long() -> i32 { 0 }
 
-    #[deprecated(note = "Deprecation reason")]
+    #[deprecated]
     field attr_deprecated() -> i32 { 0 }
+
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated_reason() -> i32 { 0 }
 
     #[doc = "Field description"]
     #[deprecated(note = "Deprecation reason")]
@@ -471,7 +477,7 @@ fn introspect_object_field_attr_deprecated() {
         );
         assert_eq!(
             field.get_field_value("deprecationReason"),
-            Some(&Value::scalar("Deprecation reason"))
+            Some(&Value::null())
         );
     });
 }
@@ -482,6 +488,44 @@ fn introspect_interface_field_attr_deprecated() {
         assert_eq!(
             field.get_field_value("name"),
             Some(&Value::scalar("attrDeprecated"))
+        );
+        assert_eq!(field.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_deprecated_reason() {
+    run_field_info_query("Root", "attrDeprecatedReason", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecatedReason"))
+        );
+        assert_eq!(field.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::scalar("Deprecation reason"))
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_deprecated_reason() {
+    run_field_info_query("Interface", "attrDeprecatedReason", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecatedReason"))
         );
         assert_eq!(field.get_field_value("description"), Some(&Value::null()));
         assert_eq!(

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -31,6 +31,20 @@ graphql_object!(Root: () |&self| {
     field deprecated "Deprecation reason"
         deprecated_descr() -> i32 as "Field description" { 0 }
 
+    #[doc = "Field description"]
+    field attr_description() -> i32 { 0 }
+
+    #[doc = "Field description"]
+    #[doc = "with `collapse_docs` behavior"] // https://doc.rust-lang.org/rustdoc/the-doc-attribute.html
+    field attr_description_collapse() -> i32 { 0 }
+
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated() -> i32 { 0 }
+
+    #[doc = "Field description"]
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated_descr() -> i32 { 0 }
+
     field with_field_result() -> FieldResult<i32> { Ok(0) }
 
     field with_return() -> i32 { return 0; }
@@ -50,6 +64,20 @@ graphql_interface!(Interface: () |&self| {
 
     field deprecated "Deprecation reason"
         deprecated_descr() -> i32 as "Field description" { 0 }
+
+    #[doc = "Field description"]
+    field attr_description() -> i32 { 0 }
+
+    #[doc = "Field description"]
+    #[doc = "with `collapse_docs` behavior"] // https://doc.rust-lang.org/rustdoc/the-doc-attribute.html
+    field attr_description_collapse() -> i32 { 0 }
+
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated() -> i32 { 0 }
+
+    #[doc = "Field description"]
+    #[deprecated(note = "Deprecation reason")]
+    field attr_deprecated_descr() -> i32 { 0 }
 
     instance_resolvers: |&_| {
         Root => Some(Root {}),
@@ -265,6 +293,176 @@ fn introspect_interface_field_deprecated_descr() {
         assert_eq!(
             field.get_field_value("name"),
             Some(&Value::scalar("deprecatedDescr"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::scalar("Deprecation reason"))
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_description() {
+    run_field_info_query("Root", "attrDescription", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescription"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_description() {
+    run_field_info_query("Interface", "attrDescription", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescription"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_description_collapse() {
+    run_field_info_query("Root", "attrDescriptionCollapse", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescriptionCollapse"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description\nwith `collapse_docs` behavior"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_description_collapse() {
+    run_field_info_query("Interface", "attrDescriptionCollapse", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescriptionCollapse"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description\nwith `collapse_docs` behavior"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_deprecated() {
+    run_field_info_query("Root", "attrDeprecated", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecated"))
+        );
+        assert_eq!(field.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::scalar("Deprecation reason"))
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_deprecated() {
+    run_field_info_query("Interface", "attrDeprecated", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecated"))
+        );
+        assert_eq!(field.get_field_value("description"), Some(&Value::null()));
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::scalar("Deprecation reason"))
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_deprecated_descr() {
+    run_field_info_query("Root", "attrDeprecatedDescr", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecatedDescr"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Field description"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(true))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::scalar("Deprecation reason"))
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_deprecated_descr() {
+    run_field_info_query("Interface", "attrDeprecatedDescr", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDeprecatedDescr"))
         );
         assert_eq!(
             field.get_field_value("description"),

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -80,7 +80,7 @@ graphql_interface!(Interface: () |&self| {
     #[doc = "with `collapse_docs` behavior"] // https://doc.rust-lang.org/rustdoc/the-doc-attribute.html
     field attr_description_collapse() -> i32 { 0 }
 
-    #[doc = r#"\
+    #[doc = r#"
         Get the i32 representation of 0.
 
         - This comment is longer.

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -38,6 +38,14 @@ graphql_object!(Root: () |&self| {
     #[doc = "with `collapse_docs` behavior"] // https://doc.rust-lang.org/rustdoc/the-doc-attribute.html
     field attr_description_collapse() -> i32 { 0 }
 
+    #[doc = r#"
+        Get the i32 representation of 0.
+
+        - This comment is longer.
+        - These two lines are rendered as bullets by GraphiQL.
+    "#]
+    field attr_description_long() -> i32 { 0 }
+
     #[deprecated(note = "Deprecation reason")]
     field attr_deprecated() -> i32 { 0 }
 
@@ -71,6 +79,14 @@ graphql_interface!(Interface: () |&self| {
     #[doc = "Field description"]
     #[doc = "with `collapse_docs` behavior"] // https://doc.rust-lang.org/rustdoc/the-doc-attribute.html
     field attr_description_collapse() -> i32 { 0 }
+
+    #[doc = r#"\
+        Get the i32 representation of 0.
+
+        - This comment is longer.
+        - These two lines are rendered as bullets by GraphiQL.
+    "#]
+    field attr_description_long() -> i32 { 0 }
 
     #[deprecated(note = "Deprecation reason")]
     field attr_deprecated() -> i32 { 0 }
@@ -341,6 +357,50 @@ fn introspect_interface_field_attr_description() {
         assert_eq!(
             field.get_field_value("description"),
             Some(&Value::scalar("Field description"))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_object_field_attr_description_long() {
+    run_field_info_query("Root", "attrDescriptionLong", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescriptionLong"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Get the i32 representation of 0.\n\n- This comment is longer.\n- These two lines are rendered as bullets by GraphiQL."))
+        );
+        assert_eq!(
+            field.get_field_value("isDeprecated"),
+            Some(&Value::scalar(false))
+        );
+        assert_eq!(
+            field.get_field_value("deprecationReason"),
+            Some(&Value::null())
+        );
+    });
+}
+
+#[test]
+fn introspect_interface_field_attr_description_long() {
+    run_field_info_query("Interface", "attrDescriptionLong", |field| {
+        assert_eq!(
+            field.get_field_value("name"),
+            Some(&Value::scalar("attrDescriptionLong"))
+        );
+        assert_eq!(
+            field.get_field_value("description"),
+            Some(&Value::scalar("Get the i32 representation of 0.\n\n- This comment is longer.\n- These two lines are rendered as bullets by GraphiQL."))
         );
         assert_eq!(
             field.get_field_value("isDeprecated"),

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -580,6 +580,23 @@ impl<'a, S> Field<'a, S> {
         self
     }
 
+    /// Add a line to the description of the field
+    ///
+    /// If the description hasn't been set, the description is set to the provided line.
+    /// Otherwise, a newline is appended before appending the line.
+    pub fn description_line(mut self, line: &str) -> Field<'a, S> {
+        match &mut self.description {
+            Some(desc) => {
+                desc.push('\n');
+                desc.push_str(line);
+            }
+            desc @ None => {
+                *desc = Some(line.to_owned());
+            }
+        }
+        self
+    }
+
     /// Add an argument to the field
     ///
     /// Arguments are unordered and can't contain duplicates by name.

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -586,11 +586,11 @@ impl<'a, S> Field<'a, S> {
     /// Otherwise, a newline is appended before appending the line.
     pub fn description_line(mut self, line: &str) -> Field<'a, S> {
         match &mut self.description {
-            Some(desc) => {
+            &mut Some(ref mut desc) => {
                 desc.push('\n');
                 desc.push_str(line);
             }
-            desc @ None => {
+            desc @ &mut None => {
                 *desc = Some(line.to_owned());
             }
         }

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -132,7 +132,7 @@ graphql_object!(<'a> TypeType<'a, S>: SchemaType<'a, S> as "__Type"
             TypeType::Concrete(&MetaType::Object(ObjectMeta { ref fields, .. })) =>
                 Some(fields
                     .iter()
-                    .filter(|f| include_deprecated || f.deprecation_reason.is_none())
+                    .filter(|f| include_deprecated || !f.deprecation_status.is_deprecated())
                     .filter(|f| !f.name.starts_with("__"))
                     .collect()),
             _ => None,
@@ -201,7 +201,7 @@ graphql_object!(<'a> TypeType<'a, S>: SchemaType<'a, S> as "__Type"
             TypeType::Concrete(&MetaType::Enum(EnumMeta { ref values, .. })) =>
                 Some(values
                     .iter()
-                    .filter(|f| include_deprecated || f.deprecation_reason.is_none())
+                    .filter(|f| include_deprecated || !f.deprecation_status.is_deprecated())
                     .collect()),
             _ => None,
         }
@@ -228,11 +228,11 @@ graphql_object!(<'a> Field<'a, S>: SchemaType<'a, S> as "__Field"
     }
 
     field is_deprecated() -> bool {
-        self.deprecation_reason.is_some()
+        self.deprecation_status.is_deprecated()
     }
 
-    field deprecation_reason() -> &Option<String> {
-        &self.deprecation_reason
+    field deprecation_reason() -> Option<&String> {
+        self.deprecation_status.reason()
     }
 });
 
@@ -266,11 +266,11 @@ graphql_object!(EnumValue: () as "__EnumValue" where Scalar = <S> |&self| {
     }
 
     field is_deprecated() -> bool {
-        self.deprecation_reason.is_some()
+        self.deprecation_status.is_deprecated()
     }
 
-    field deprecation_reason() -> &Option<String> {
-        &self.deprecation_reason
+    field deprecation_reason() -> Option<&String> {
+        self.deprecation_status.reason()
     }
 });
 

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -67,6 +67,9 @@ impl EnumVariantAttrs {
         // Check doc comments for description.
         res.description = get_doc_comment(&variant.attrs);
 
+        // Check rust "deprecated" for deprecation.
+        res.deprecation = get_deprecated_note(&variant.attrs);
+
         // Check attributes for name and description.
         if let Some(items) = get_graphql_attr(&variant.attrs) {
             for item in items {

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -44,7 +44,7 @@ impl EnumAttrs {
                     continue;
                 }
                 panic!(format!(
-                    "Unknown attribute for #[derive(GraphQLEnum)]: {:?}",
+                    "Unknown enum attribute for #[derive(GraphQLEnum)]: {:?}",
                     item
                 ));
             }
@@ -57,7 +57,7 @@ impl EnumAttrs {
 struct EnumVariantAttrs {
     name: Option<String>,
     description: Option<String>,
-    deprecation: Option<String>,
+    deprecation: Option<DeprecationAttr>,
 }
 
 impl EnumVariantAttrs {
@@ -67,8 +67,8 @@ impl EnumVariantAttrs {
         // Check doc comments for description.
         res.description = get_doc_comment(&variant.attrs);
 
-        // Check rust "deprecated" for deprecation.
-        res.deprecation = get_deprecated_note(&variant.attrs);
+        // Check builtin deprecated attribute for deprecation.
+        res.deprecation = get_deprecated(&variant.attrs);
 
         // Check attributes for name and description.
         if let Some(items) = get_graphql_attr(&variant.attrs) {
@@ -93,13 +93,24 @@ impl EnumVariantAttrs {
                     continue;
                 }
                 if let Some(AttributeValue::String(val)) =
-                    keyed_item_value(&item, "deprecated", AttributeValidation::String)
+                    keyed_item_value(&item, "deprecation", AttributeValidation::String)
                 {
-                    res.deprecation = Some(val);
+                    res.deprecation = Some(DeprecationAttr { reason: Some(val) });
                     continue;
                 }
+                match keyed_item_value(&item, "deprecated", AttributeValidation::String) {
+                    Some(AttributeValue::String(val)) => {
+                        res.deprecation = Some(DeprecationAttr { reason: Some(val) });
+                        continue;
+                    }
+                    Some(AttributeValue::Bare) => {
+                        res.deprecation = Some(DeprecationAttr { reason: None });
+                        continue;
+                    }
+                    None => {}
+                }
                 panic!(format!(
-                    "Unknown attribute for #[derive(GraphQLEnum)]: {:?}",
+                    "Unknown variant attribute for #[derive(GraphQLEnum)]: {:?}",
                     item
                 ));
             }
@@ -154,14 +165,21 @@ pub fn impl_enum(ast: &syn::DeriveInput) -> TokenStream {
             None => quote!{ None },
         };
         let depr = match var_attrs.deprecation {
-            Some(s) => quote!{ Some(#s.to_string())  },
-            None => quote!{ None },
+            Some(DeprecationAttr { reason: Some(s) }) => quote!{
+                _juniper::meta::DeprecationStatus::Deprecated(Some(#s.to_string()))
+            },
+            Some(DeprecationAttr { reason: None }) => quote!{
+                _juniper::meta::DeprecationStatus::Deprecated(None)
+            },
+            None => quote!{
+                _juniper::meta::DeprecationStatus::Current
+            },
         };
         values.extend(quote!{
             _juniper::meta::EnumValue{
                 name: #name.to_string(),
                 description: #descr,
-                deprecation_reason: #depr,
+                deprecation_status: #depr,
             },
         });
 

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -47,7 +47,7 @@ impl ObjAttrs {
                     continue;
                 }
                 panic!(format!(
-                    "Unknown object attribute for #[derive(GraphQLObject)]: {:?}",
+                    "Unknown struct attribute for #[derive(GraphQLObject)]: {:?}",
                     item
                 ));
             }
@@ -60,7 +60,7 @@ impl ObjAttrs {
 struct ObjFieldAttrs {
     name: Option<String>,
     description: Option<String>,
-    deprecation: Option<String>,
+    deprecation: Option<DeprecationAttr>,
     skip: bool,
 }
 
@@ -71,8 +71,8 @@ impl ObjFieldAttrs {
         // Check doc comments for description.
         res.description = get_doc_comment(&variant.attrs);
 
-        // Check rust "deprecated" for deprecation.
-        res.deprecation = get_deprecated_note(&variant.attrs);
+        // Check builtin deprecated attribute for deprecation.
+        res.deprecation = get_deprecated(&variant.attrs);
 
         // Check attributes.
         if let Some(items) = get_graphql_attr(&variant.attrs) {
@@ -99,8 +99,19 @@ impl ObjFieldAttrs {
                 if let Some(AttributeValue::String(val)) =
                     keyed_item_value(&item, "deprecation", AttributeValidation::String)
                 {
-                    res.deprecation = Some(val);
+                    res.deprecation = Some(DeprecationAttr { reason: Some(val) });
                     continue;
+                }
+                match keyed_item_value(&item, "deprecated", AttributeValidation::String) {
+                    Some(AttributeValue::String(val)) => {
+                        res.deprecation = Some(DeprecationAttr { reason: Some(val) });
+                        continue;
+                    }
+                    Some(AttributeValue::Bare) => {
+                        res.deprecation = Some(DeprecationAttr { reason: None });
+                        continue;
+                    }
+                    None => {}
                 }
                 if let Some(_) = keyed_item_value(&item, "skip", AttributeValidation::Bare) {
                     res.skip = true;
@@ -170,7 +181,8 @@ pub fn impl_object(ast: &syn::DeriveInput) -> TokenStream {
         };
 
         let build_deprecation = match field_attrs.deprecation {
-            Some(s) => quote!{ field.deprecated(#s)  },
+            Some(DeprecationAttr { reason: Some(s) }) => quote!{ field.deprecated(Some(#s)) },
+            Some(DeprecationAttr { reason: None }) => quote!{ field.deprecated(None) },
             None => quote!{ field },
         };
 

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -71,6 +71,9 @@ impl ObjFieldAttrs {
         // Check doc comments for description.
         res.description = get_doc_comment(&variant.attrs);
 
+        // Check rust "deprecated" for deprecation.
+        res.deprecation = get_deprecated_note(&variant.attrs);
+
         // Check attributes.
         if let Some(items) = get_graphql_attr(&variant.attrs) {
             for item in items {

--- a/juniper_tests/src/codegen/derive_input_object.rs
+++ b/juniper_tests/src/codegen/derive_input_object.rs
@@ -78,7 +78,7 @@ impl<'a> GraphQLType for &'a Fake {
             &[juniper::meta::EnumValue {
                 name: "fake".to_string(),
                 description: None,
-                deprecation_reason: None,
+                deprecation_status: juniper::meta::DeprecationStatus::Current,
             }],
         );
         meta.into_meta()


### PR DESCRIPTION
Follow on to https://github.com/graphql-rust/juniper/issues/194.

### Derive
Updates the `GraphQLObject` and `GraphQLEnum` derives to use the first `#[deprecated]` annotation with a `note = ...` to supply the deprecation text, which can still be overridden with `#[graphql(deprecation = ...)]` like in https://github.com/graphql-rust/juniper/pull/195.

### Macros
Additionally, this PR adds support for `#[doc = ...]` and `#[deprecated(note = ...)]` to the `graphql_object!` and `graphql_interface!` macros, which has some benefits:

  * Lets your `field name(args...)` line-up so that they're easier to scan (even with a deprecation)`
  * Allows mutliple doc strings be combined akin to the [collapse_docs](https://doc.rust-lang.org/rustdoc/the-doc-attribute.html) behavior.
    (including any `const SOME_DESC: &'static str` if you want w/ `#[doc = SOME_DESC]`) 
  * Makes it easier to refactor a `#[derive(GraphQLObject)]` into a `graphql_object!`, e.g. a contrived example

    ```rust
    #[derive(GraphQLObject)]
    struct Plus {
         left: i32,
         right: i32,

         #[deprecated(note = "This has been deprecated because it doesn't handle overflow")]
         result: i32,
     }

    // after converting to use macro
    graphql_object!(Plus: () |&self| {
         field left() -> i32 { self.left }
         field right() -> i32 { self.right }

         #[deprecated(note = "This has been deprecated because it doesn't handle overflow")]
         field result() -> i32 { self.result }
         field checked_sum() -> Option<i32> { self.left.checked_sum(self.right) }
    })
    ```