### PR TITLE
Upgrade `juniper_warp` to `warp` 0.1.8

### DIFF
--- a/juniper_warp/CHANGELOG.md
+++ b/juniper_warp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# [master]
+
+- **Breaking Change**: Bump required `warp` version to `0.1.8`.
+
+# juniper_warp [0.1] 2018-09-13
+
+- Initial Release

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "juniper_warp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tom Houlé <tom@tomhoule.com>"]
 description = "Juniper GraphQL integration with Warp"
 license = "BSD-2-Clause"
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/juniper_warp"
 repository = "https://github.com/graphql-rust/juniper"
 
 [dependencies]
-warp = "0.1.2"
+warp = "0.1.8"
 juniper = { path = "../juniper", version = ">=0.9, 0.10.0", default-features = false  }
 serde_json = "1.0.24"
 serde_derive = "1.0.75"

--- a/juniper_warp/examples/warp_server/src/main.rs
+++ b/juniper_warp/examples/warp_server/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let log = log("warp_server");
 
-    let homepage = warp::index().map(|| {
+    let homepage = warp::path::end().map(|| {
         Response::builder()
             .header("content-type", "text/html")
             .body(format!(

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -202,7 +202,7 @@ where
                         Ok((serde_json::to_vec(&response)?, response.is_ok()))
                     })
                 }).and_then(|result| ::futures::future::done(Ok(build_response(result))))
-                .map_err(|_: tokio_threadpool::BlockingError| warp::reject::server_error()),
+                .map_err(|e: tokio_threadpool::BlockingError| warp::reject::custom(e)),
             )
         };
 
@@ -235,7 +235,7 @@ where
                     Ok((serde_json::to_vec(&response)?, response.is_ok()))
                 })
             }).and_then(|result| ::futures::future::done(Ok(build_response(result))))
-            .map_err(|_: tokio_threadpool::BlockingError| warp::reject::server_error()),
+            .map_err(|e: tokio_threadpool::BlockingError| warp::reject::custom(e)),
         )
     };
 
@@ -434,7 +434,7 @@ mod tests_http_harness {
         let schema: Schema = RootNode::new(Database::new(), EmptyMutation::<Database>::new());
 
         let state = warp::any().map(move || Database::new());
-        let filter = warp::filters::path::index().and(make_graphql_filter(schema, state.boxed()));
+        let filter = warp::filters::path::end().and(make_graphql_filter(schema, state.boxed()));
 
         filter.boxed()
     }


### PR DESCRIPTION
This unbreaks the build, as the newer warp deprecates some of the filters we
were using and we had `deny_warnings` on.