### PR TITLE
Update juniper_rocket for Rocket 0.4-rc.1

### DIFF
--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [master]
 
+### Rocket updated to v0.4
+
+[Rocket](https://rocket.rs) integration now requires Rocket `0.4.0`. This is due
+to changes with the way Rocket handles form parsing. Before this update, it was
+impossible to leverage Rocket integration with Rocket beyond 0.3.x.
+
+Check out [Rocket's Changelog](https://github.com/SergioBenitez/Rocket/blob/v0.4/CHANGELOG.md)
+for more details on the 0.4 release.
+
 # juniper_rocket [0.1.3] 2018-09-13
 
 - Add `juniper-0.10.0` compatibility.

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -16,8 +16,7 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = ">=0.9, 0.10.0" , default-features = false, path = "../juniper"}
 
-rocket = { version = "0.3.9" }
-rocket_codegen = { version = "0.3.9" }
+rocket = { version = "0.4.0" }
 
 [dev-dependencies.juniper]
 version = "0.10.0"

--- a/juniper_rocket/examples/rocket_server.rs
+++ b/juniper_rocket/examples/rocket_server.rs
@@ -1,9 +1,8 @@
-#![feature(plugin)]
-#![plugin(rocket_codegen)]
+#![feature(decl_macro, proc_macro_hygiene)]
 
 extern crate juniper;
 extern crate juniper_rocket;
-extern crate rocket;
+#[macro_use] extern crate rocket;
 
 use rocket::response::content;
 use rocket::State;


### PR DESCRIPTION
Path handling changed in Rocket 0.4 and this commit updates the way
those paths are handled. It adds an implementation of the
`FromFormValue` trait to the `GraphQLRequest` object. It also changes
the documentation to use the multi-segement query string syntax.

All existing tests pass as expected.

Let me know if you have any questions or concerns!