### PR TITLE
Build wasm32-unknown-unknown in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ rust:
   - 1.23.0
   - 1.22.0
 
+matrix:
+  include:
+    - language: rust
+      rust: stable
+      name: "check wasm32 support"
+      install: rustup target add wasm32-unknown-unknown
+      script: cargo check --target wasm32-unknown-unknown --package juniper --package juniper_codegen
+
 env:
   global:
     - secure: "SsepHEYRmW9ee3RhxPpqGuPigZINFfA/yOwUJFseQt4t+Zs90r1xdl3Q8eDfPlnvBsL7Rd0QQrFDO7JUaimVLlgQkUnrl62o0CYzkodp+qtocyAHS00W6WTqi8Y6E6KBxPshCl03dRLaySUfx5TqTLTIHkJ0G6vDW35k7hRrA3221lRphs5rrpvAZ21pqsDsNLH3HVo792L6A0kOtBa3ocw1pgHLxnBbArIViu2htUuFvY/TgsmVbAdlow0efw/xkcJ/p0/r5q7igLek6Iqk8udfRc7CktvoiFQ2vUnhtNtQu/zYll3Q7OUx5d+w5lhbzz2QINmsezBEisH9k1haL7dMviLPp0pn4WZed60KovO0Iqfgjy1utTaKvJVfNWYsgkfU8c9a/z2rcZOKwXNKQW2ptBrtVjaB9dk7eMoyuFCDZwNtKqvG+ZKmvMpun+R8mmx+buOmN8Vlf5ygIoGxz3nbEtlLYGVTXHfdXXqRkFIwtiYVJEO7SLRKT9pbx1E++ARsi2+y8bXJT4e4z0osYMq9EsiFUpw3J2gcshrgseqkB7UgCZ3SXuitJnJNfDAU3a3nwwS/JiAunZMNnC4rKUBbl7WbTB4Cpw7EgVOlCqcyyzlkNl3xabLzTFzLOfSHLTVX5FmGNsD21vBoS5/8ejftx9wuV3rGHxuO3i3+A3k="

--- a/_build/azure-pipelines-template.yml
+++ b/_build/azure-pipelines-template.yml
@@ -39,3 +39,8 @@ jobs:
   - script: cargo make workspace-ci-flow --no-workspace
     env: { CARGO_MAKE_RUN_CODECOV: true }
     displayName: Build and run tests
+  - script: |
+      rustup target add wasm32-unknown-unknown
+      cargo check --target wasm32-unknown-unknown --package juniper --package juniper_codegen
+    displayName: Check WebAssembly target
+    condition: eq(variables['rustup_toolchain'], 'stable')


### PR DESCRIPTION
`cargo check --wasm32-unknown-unknown` is sufficient to demonstrate that the `juniper` and `juniper_codegen` crates can compile for WebAssembly, which should help avoid accidental regressions.

This is a small step towards the goals in #218.