### PR TITLE
Edit: WIP - run CI without cargo-make

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ rust:
   - nightly
 
   # Prevent accidentally breaking older Rust versions
-  - 1.23.0
-  - 1.22.0
+  - 1.28.0
+  - 1.27.0
 
 env:
   global:

--- a/_build/azure-pipelines-template.yml
+++ b/_build/azure-pipelines-template.yml
@@ -11,9 +11,9 @@ jobs:
       nightly:
         rustup_toolchain: nightly
       minimum_supported_version_plus_one:
-        rustup_toolchain: 1.23.0
+        rustup_toolchain: 1.29.0
       minimum_supported_version:
-        rustup_toolchain: 1.22.0
+        rustup_toolchain: 1.28.0
   steps:
   - ${{ if ne(parameters.name, 'Windows') }}:
     # Linux and macOS.


### PR DESCRIPTION
While cargo-make is a cool project for more complicated build setups, 
 at this point I don't really think it provides much of a benefit for us.

Also it requires 1.30 now so we'd need to install stable in addition to the tested version in all tests.

All we really need to do is (in the workspace root):

```bash
cargo check --verbose --all-features
cargo test --verbose --all-features
+ code coverage
```

The only moderately complicated part is code coverage so I'd vote for just dropping cargo-make.

(haven't pushed yet)