### PR TITLE
Bump min rust version to 1.30.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ rust:
   - nightly
 
   # Prevent accidentally breaking older Rust versions
-  - 1.29.0
-  - 1.28.0
+  - 1.31.0
+  - 1.30.0
 
 matrix:
   include:

--- a/_build/azure-pipelines-template.yml
+++ b/_build/azure-pipelines-template.yml
@@ -11,9 +11,9 @@ jobs:
       nightly:
         rustup_toolchain: nightly
       minimum_supported_version_plus_one:
-        rustup_toolchain: 1.29.0
+        rustup_toolchain: 1.31.0
       minimum_supported_version:
-        rustup_toolchain: 1.28.0
+        rustup_toolchain: 1.30.0
   steps:
   - ${{ if ne(parameters.name, 'Windows') }}:
     # Linux and macOS.

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-- No changes yet
+- The minimum required Rust version is now `1.30.0`.
 
 # [0.11.0] 2018-12-17
 


### PR DESCRIPTION
Some dependiencies rely on cc, which after
https://github.com/alexcrichton/cc-rs/commit/228513449f3e2674cdce0f53206c9449af9d3778
requires 1.30.0.