### PR TITLE
Change name of ScalarValue

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/derive_enum.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_enum.rs
@@ -2,7 +2,7 @@
 use fnv::FnvHashMap;
 
 #[cfg(test)]
-use juniper::{self, DefaultScalarValue, FromInputValue, GraphQLType, InputValue, ToInputValue};
+use juniper::{self, DefaultGraphQLScalarValue, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
 #[derive(GraphQLEnum, Debug, PartialEq)]
 #[graphql(name = "Some", description = "enum descr")]
@@ -61,7 +61,7 @@ fn test_derived_enum() {
         InputValue::scalar("REGULAR")
     );
     assert_eq!(
-        FromInputValue::<DefaultScalarValue>::from_input_value(&InputValue::scalar("REGULAR")),
+        FromInputValue::<DefaultGraphQLScalarValue>::from_input_value(&InputValue::scalar("REGULAR")),
         Some(SomeEnum::Regular)
     );
 
@@ -71,7 +71,7 @@ fn test_derived_enum() {
         InputValue::scalar("FULL")
     );
     assert_eq!(
-        FromInputValue::<DefaultScalarValue>::from_input_value(&InputValue::scalar("FULL")),
+        FromInputValue::<DefaultGraphQLScalarValue>::from_input_value(&InputValue::scalar("FULL")),
         Some(SomeEnum::Full)
     );
 }

--- a/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
@@ -3,13 +3,13 @@ use fnv::FnvHashMap;
 
 use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
-use juniper::DefaultScalarValue;
+use juniper::DefaultGraphQLScalarValue;
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
 #[graphql(
     name = "MyInput",
     description = "input descr",
-    scalar = "DefaultScalarValue"
+    scalar = "DefaultGraphQLScalarValue"
 )]
 struct Input {
     regular_field: String,
@@ -71,7 +71,7 @@ impl<'a> GraphQLType for &'a Fake {
     }
     fn meta<'r>(_: &(), registry: &mut juniper::Registry<'r>) -> juniper::meta::MetaType<'r>
     where
-        DefaultScalarValue: 'r,
+        DefaultGraphQLScalarValue: 'r,
     {
         let meta = registry.build_enum_type::<&'a Fake>(
             &(),
@@ -86,7 +86,7 @@ impl<'a> GraphQLType for &'a Fake {
 }
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
-#[graphql(scalar = "DefaultScalarValue")]
+#[graphql(scalar = "DefaultGraphQLScalarValue")]
 struct WithLifetime<'a> {
     regular_field: &'a Fake,
 }

--- a/integration_tests/juniper_tests/src/codegen/derive_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 use fnv::FnvHashMap;
-use juniper::DefaultScalarValue;
+use juniper::DefaultGraphQLScalarValue;
 #[cfg(test)]
 use juniper::Object;
 
@@ -11,7 +11,7 @@ use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variab
 #[graphql(
     name = "MyObj",
     description = "obj descr",
-    scalar = "DefaultScalarValue"
+    scalar = "DefaultGraphQLScalarValue"
 )]
 struct Obj {
     regular_field: bool,
@@ -24,7 +24,7 @@ struct Obj {
 }
 
 #[derive(GraphQLObject, Debug, PartialEq)]
-#[graphql(scalar = "DefaultScalarValue")]
+#[graphql(scalar = "DefaultGraphQLScalarValue")]
 struct Nested {
     obj: Obj,
 }
@@ -312,7 +312,7 @@ fn check_descriptions(
 #[cfg(test)]
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn((&Object<DefaultScalarValue>, &Vec<Value>)) -> (),
+    F: Fn((&Object<DefaultGraphQLScalarValue>, &Vec<Value>)) -> (),
 {
     let schema = RootNode::new(Query, EmptyMutation::<()>::new());
 

--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -6,10 +6,10 @@ use juniper::parser::{ParseError, ScalarToken, Token};
 use juniper::serde::de;
 #[cfg(test)]
 use juniper::{execute, EmptyMutation, Object, RootNode, Variables};
-use juniper::{InputValue, ParseScalarResult, ScalarValue, Value};
+use juniper::{InputValue, ParseScalarResult, GraphQLScalarValue, Value};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, ScalarValue)]
+#[derive(Debug, Clone, PartialEq, GraphQLScalarValue)]
 enum MyScalarValue {
     Int(i32),
     Long(i64),
@@ -18,7 +18,7 @@ enum MyScalarValue {
     Boolean(bool),
 }
 
-impl ScalarValue for MyScalarValue {
+impl GraphQLScalarValue for MyScalarValue {
     type Visitor = MyScalarValueVisitor;
 
     fn as_int(&self) -> Option<i32> {

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,8 @@
 # master
 
 - The minimum required Rust version is now `1.30.0`.
+- The `ScalarValue` derive has been renamed to `GraphQLScalarValue`.
+- The `DefaultScalarValue` enum has been renamed to `DefaultGraphQLScalarValue`.
 
 # [0.11.1] 2018-12-19
 

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 
 use executor::Variables;
 use parser::Spanning;
-use value::{ScalarRefValue, ScalarValue, DefaultScalarValue};
+use value::{ScalarRefValue, GraphQLScalarValue, DefaultGraphQLScalarValue};
 
 /// A type literal in the syntax tree
 ///
@@ -38,7 +38,7 @@ pub enum Type<'a> {
 /// their position in the source file, if available.
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)]
-pub enum InputValue<S = DefaultScalarValue> {
+pub enum InputValue<S = DefaultGraphQLScalarValue> {
     Null,
     Scalar(S),
     Enum(String),
@@ -102,7 +102,7 @@ pub struct InlineFragment<'a, S> {
 /// ```
 #[derive(Clone, PartialEq, Debug)]
 #[allow(missing_docs)]
-pub enum Selection<'a, S = DefaultScalarValue> {
+pub enum Selection<'a, S = DefaultGraphQLScalarValue> {
     Field(Spanning<Field<'a, S>>),
     FragmentSpread(Spanning<FragmentSpread<'a, S>>),
     InlineFragment(Spanning<InlineFragment<'a, S>>),
@@ -151,7 +151,7 @@ pub type Document<'a, S> = Vec<Definition<'a, S>>;
 /// automatically by the convenience macro `graphql_scalar!` or by deriving GraphQLEnum.
 ///
 /// Must be implemented manually when manually exposing new enums or scalars.
-pub trait FromInputValue<S = DefaultScalarValue>: Sized {
+pub trait FromInputValue<S = DefaultGraphQLScalarValue>: Sized {
     /// Performs the conversion.
     fn from_input_value(v: &InputValue<S>) -> Option<Self>
     where
@@ -159,7 +159,7 @@ pub trait FromInputValue<S = DefaultScalarValue>: Sized {
 }
 
 /// Losslessly clones a Rust data type into an InputValue.
-pub trait ToInputValue<S = DefaultScalarValue>: Sized {
+pub trait ToInputValue<S = DefaultGraphQLScalarValue>: Sized {
     /// Performs the conversion.
     fn to_input_value(&self) -> InputValue<S>;
 }
@@ -207,7 +207,7 @@ impl<'a> fmt::Display for Type<'a> {
 
 impl<S> InputValue<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     /// Construct a null value.
     pub fn null() -> Self {
@@ -466,7 +466,7 @@ where
 
 impl<S> fmt::Display for InputValue<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -1,6 +1,6 @@
 use ast::{Directive, Fragment, InputValue, Selection};
 use parser::Spanning;
-use value::{ScalarRefValue, ScalarValue};
+use value::{ScalarRefValue, GraphQLScalarValue};
 
 use std::collections::HashMap;
 
@@ -32,7 +32,7 @@ pub enum LookAheadValue<'a, S: 'a> {
 
 impl<'a, S> LookAheadValue<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value(input_value: &'a InputValue<S>, vars: &'a Variables<S>) -> Self {
         match *input_value {
@@ -67,7 +67,7 @@ pub struct LookAheadArgument<'a, S: 'a> {
 
 impl<'a, S> LookAheadArgument<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     pub(super) fn new(
         &(ref name, ref value): &'a (Spanning<&'a str>, Spanning<InputValue<S>>),
@@ -102,7 +102,7 @@ pub struct LookAheadSelection<'a, S: 'a> {
 
 impl<'a, S> LookAheadSelection<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     &'a S: ScalarRefValue<'a>,
 {
     fn should_include<'b, 'c>(
@@ -358,11 +358,11 @@ mod tests {
     use schema::model::SchemaType;
     use std::collections::HashMap;
     use validation::test_harness::{MutationRoot, QueryRoot};
-    use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use value::{DefaultGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue};
 
     fn parse_document_source<S>(q: &str) -> UnlocatedParseResult<Document<S>>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         ::parse_document_source(q, &SchemaType::new::<QueryRoot, MutationRoot>(&(), &()))
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn check_simple_query() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -433,7 +433,7 @@ query Hero {
 
     #[test]
     fn check_query_with_alias() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     custom_hero: hero {
@@ -485,7 +485,7 @@ query Hero {
 
     #[test]
     fn check_query_with_child() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -611,7 +611,7 @@ query Hero {
                             alias: None,
                             arguments: vec![LookAheadArgument {
                                 name: "uppercase",
-                                value: LookAheadValue::Scalar(&DefaultScalarValue::Boolean(true)),
+                                value: LookAheadValue::Scalar(&DefaultGraphQLScalarValue::Boolean(true)),
                             }],
                             children: Vec::new(),
                         },
@@ -627,7 +627,7 @@ query Hero {
 
     #[test]
     fn check_query_with_variable() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero($episode: Episode) {
     hero(episode: $episode) {
@@ -683,7 +683,7 @@ query Hero($episode: Episode) {
 
     #[test]
     fn check_query_with_fragment() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -749,7 +749,7 @@ fragment commonFields on Character {
 
     #[test]
     fn check_query_with_directives() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -802,7 +802,7 @@ query Hero {
 
     #[test]
     fn check_query_with_inline_fragments() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -892,11 +892,11 @@ fragment comparisonFields on Character {
 
         if let ::ast::Definition::Operation(ref op) = docs[0] {
             let mut vars = Variables::default();
-            vars.insert("id".into(), InputValue::Scalar(DefaultScalarValue::Int(42)));
+            vars.insert("id".into(), InputValue::Scalar(DefaultGraphQLScalarValue::Int(42)));
             // This will normally be there
             vars.insert(
                 "withFriends".into(),
-                InputValue::Scalar(DefaultScalarValue::Boolean(true)),
+                InputValue::Scalar(DefaultGraphQLScalarValue::Boolean(true)),
             );
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -908,7 +908,7 @@ fragment comparisonFields on Character {
                 alias: None,
                 arguments: vec![LookAheadArgument {
                     name: "id",
-                    value: LookAheadValue::Scalar(&DefaultScalarValue::Int(42)),
+                    value: LookAheadValue::Scalar(&DefaultGraphQLScalarValue::Int(42)),
                 }],
                 children: vec![
                     ChildSelection {
@@ -1030,7 +1030,7 @@ fragment comparisonFields on Character {
 
     #[test]
     fn check_resolve_concrete_type() {
-        let docs = parse_document_source::<DefaultScalarValue>(
+        let docs = parse_document_source::<DefaultGraphQLScalarValue>(
             "
 query Hero {
     hero {
@@ -1080,7 +1080,7 @@ query Hero {
 
     #[test]
     fn check_select_child() {
-        let lookahead: LookAheadSelection<DefaultScalarValue> = LookAheadSelection {
+        let lookahead: LookAheadSelection<DefaultGraphQLScalarValue> = LookAheadSelection {
             name: "hero",
             alias: None,
             arguments: Vec::new(),

--- a/juniper/src/executor_tests/directives.rs
+++ b/juniper/src/executor_tests/directives.rs
@@ -1,7 +1,7 @@
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{Value, Object, DefaultScalarValue};
+use value::{Value, Object, DefaultGraphQLScalarValue};
 
 struct TestType;
 
@@ -15,9 +15,9 @@ graphql_object!(TestType: () |&self| {
     }
 });
 
-fn run_variable_query<F>(query: &str, vars: Variables<DefaultScalarValue>, f: F)
+fn run_variable_query<F>(query: &str, vars: Variables<DefaultGraphQLScalarValue>, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
@@ -34,7 +34,7 @@ where
 
 fn run_query<F>(query: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     run_variable_query(query, Variables::new(), f);
 }

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -4,7 +4,7 @@ use parser::SourcePosition;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
 use validation::RuleError;
-use value::{DefaultScalarValue, Object, Value};
+use value::{DefaultGraphQLScalarValue, Object, Value};
 use GraphQLError::ValidationError;
 
 #[derive(GraphQLEnumInternal, Debug)]
@@ -25,9 +25,9 @@ graphql_object!(TestType: () |&self| {
     }
 });
 
-fn run_variable_query<F>(query: &str, vars: Variables<DefaultScalarValue>, f: F)
+fn run_variable_query<F>(query: &str, vars: Variables<DefaultGraphQLScalarValue>, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
@@ -44,7 +44,7 @@ where
 
 fn run_query<F>(query: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     run_variable_query(query, Variables::new(), f);
 }

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -680,7 +680,7 @@ mod propagates_errors_to_nullable_fields {
     use parser::SourcePosition;
     use schema::model::RootNode;
     use types::scalars::EmptyMutation;
-    use value::{ScalarValue, Value};
+    use value::{GraphQLScalarValue, Value};
 
     struct Schema;
     struct Inner;
@@ -691,7 +691,7 @@ mod propagates_errors_to_nullable_fields {
 
     impl<S> IntoFieldError<S> for CustomError
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         fn into_field_error(self) -> FieldError<S> {
             match self {

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,7 +1,7 @@
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{Value, Object, DefaultScalarValue};
+use value::{Value, Object, DefaultGraphQLScalarValue};
 
 /*
 
@@ -70,7 +70,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn((&Object<DefaultScalarValue>, &Vec<Value<DefaultScalarValue>>)) -> (),
+    F: Fn((&Object<DefaultGraphQLScalarValue>, &Vec<Value<DefaultGraphQLScalarValue>>)) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -2,7 +2,7 @@ use ast::{FromInputValue, InputValue};
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use value::{DefaultGraphQLScalarValue, Object, Value};
 
 struct Root;
 
@@ -97,7 +97,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>, &Vec<Value<DefaultScalarValue>>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>, &Vec<Value<DefaultGraphQLScalarValue>>) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
@@ -212,7 +212,7 @@ fn default_name_introspection() {
 
 #[test]
 fn default_name_input_value() {
-    let iv: InputValue<DefaultScalarValue> = InputValue::object(
+    let iv: InputValue<DefaultGraphQLScalarValue> = InputValue::object(
         vec![
             ("fieldOne", InputValue::scalar("number one")),
             ("fieldTwo", InputValue::scalar("number two")),

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -8,7 +8,7 @@ use self::input_object::{NamedPublic, NamedPublicWithDescription};
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{ParseScalarResult, ParseScalarValue, Value};
+use value::{ParseScalarResult, ParseGraphQLScalarValue, Value};
 
 #[derive(GraphQLEnumInternal)]
 #[graphql(name = "SampleEnum")]
@@ -33,7 +33,7 @@ graphql_scalar!(Scalar as "SampleScalar" {
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a> {
-        <i32 as ParseScalarValue>::from_str(value)
+        <i32 as ParseGraphQLScalarValue>::from_str(value)
     }
 });
 

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -7,7 +7,7 @@ use serde::ser::{self, Serialize, SerializeMap};
 
 use ast::InputValue;
 use executor::ExecutionError;
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use value::{DefaultGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue};
 use {FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
 
 /// The expected structure of the decoded JSON document for either POST or GET requests.
@@ -18,9 +18,9 @@ use {FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
 /// For GET, you will need to parse the query string and extract "query",
 /// "operationName", and "variables" manually.
 #[derive(Deserialize, Clone, Serialize, PartialEq, Debug)]
-pub struct GraphQLRequest<S = DefaultScalarValue>
+pub struct GraphQLRequest<S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     query: String,
     #[serde(rename = "operationName")]
@@ -31,7 +31,7 @@ where
 
 impl<S> GraphQLRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
      /// Returns the `operation_name` associated with this request.
     fn operation_name(&self) -> Option<&str> {
@@ -73,7 +73,7 @@ where
         context: &CtxT,
     ) -> GraphQLResponse<'a, S>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         QueryT: GraphQLType<S, Context = CtxT>,
         MutationT: GraphQLType<S, Context = CtxT>,
         for<'b> &'b S: ScalarRefValue<'b>,
@@ -93,13 +93,13 @@ where
 /// This struct implements Serialize, so you can simply serialize this
 /// to JSON and send it over the wire. Use the `is_ok` method to determine
 /// whether to send a 200 or 400 HTTP status code.
-pub struct GraphQLResponse<'a, S = DefaultScalarValue>(
+pub struct GraphQLResponse<'a, S = DefaultGraphQLScalarValue>(
     Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError<'a>>,
 );
 
 impl<'a, S> GraphQLResponse<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     /// Constructs an error response outside of the normal execution flow
     pub fn error(error: FieldError<S>) -> Self {
@@ -117,7 +117,7 @@ where
 
 impl<'a, T> Serialize for GraphQLResponse<'a, T>
 where
-    T: Serialize + ScalarValue,
+    T: Serialize + GraphQLScalarValue,
     Value<T>: Serialize,
     ExecutionError<T>: Serialize,
     GraphQLError<'a>: Serialize,

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -16,7 +16,7 @@
 use chrono::prelude::*;
 
 use parser::{ParseError, ScalarToken, Token};
-use value::{ParseScalarResult, ParseScalarValue};
+use value::{ParseScalarResult, ParseGraphQLScalarValue};
 use Value;
 
 #[doc(hidden)]
@@ -105,17 +105,17 @@ graphql_scalar!(NaiveDateTime where Scalar = <S> {
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
-        <f64 as ParseScalarValue<S>>::from_str(value)
+        <f64 as ParseGraphQLScalarValue<S>>::from_str(value)
     }
 });
 
 #[cfg(test)]
 mod test {
     use chrono::prelude::*;
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     fn datetime_fixedoffset_test(raw: &'static str) {
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: ::InputValue<DefaultGraphQLScalarValue> = ::InputValue::scalar(raw.to_string());
 
         let parsed: DateTime<FixedOffset> = ::FromInputValue::from_input_value(&input).unwrap();
         let expected = DateTime::parse_from_rfc3339(raw).unwrap();
@@ -139,7 +139,7 @@ mod test {
     }
 
     fn datetime_utc_test(raw: &'static str) {
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: ::InputValue<DefaultGraphQLScalarValue> = ::InputValue::scalar(raw.to_string());
 
         let parsed: DateTime<Utc> = ::FromInputValue::from_input_value(&input).unwrap();
         let expected = DateTime::parse_from_rfc3339(raw)
@@ -166,7 +166,7 @@ mod test {
 
     #[test]
     fn naivedate_from_input_value() {
-        let input: ::InputValue<DefaultScalarValue> =
+        let input: ::InputValue<DefaultGraphQLScalarValue> =
             ::InputValue::scalar("1996-12-19".to_string());
         let y = 1996;
         let m = 12;
@@ -185,7 +185,7 @@ mod test {
     #[test]
     fn naivedatetime_from_input_value() {
         let raw = 1_000_000_000_f64;
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw);
+        let input: ::InputValue<DefaultGraphQLScalarValue> = ::InputValue::scalar(raw);
 
         let parsed: NaiveDateTime = ::FromInputValue::from_input_value(&input).unwrap();
         let expected = NaiveDateTime::from_timestamp_opt(raw as i64, 0).unwrap();

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -1,6 +1,6 @@
 use url::Url;
 
-use value::{ParseScalarResult, ParseScalarValue};
+use value::{ParseScalarResult, ParseGraphQLScalarValue};
 use Value;
 
 graphql_scalar!(Url where Scalar = <S>{
@@ -16,7 +16,7 @@ graphql_scalar!(Url where Scalar = <S>{
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
-        <String as ParseScalarValue<S>>::from_str(value)
+        <String as ParseGraphQLScalarValue<S>>::from_str(value)
     }
 });
 

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -28,12 +28,12 @@ graphql_scalar!(Uuid where Scalar = <S> {
 #[cfg(test)]
 mod test {
     use uuid::Uuid;
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn uuid_from_input_value() {
         let raw = "123e4567-e89b-12d3-a456-426655440000";
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: ::InputValue<DefaultGraphQLScalarValue> = ::InputValue::scalar(raw.to_string());
 
         let parsed: Uuid = ::FromInputValue::from_input_value(&input).unwrap();
         let id = Uuid::parse_str(raw).unwrap();

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -168,7 +168,7 @@ pub use types::base::{Arguments, GraphQLType, TypeKind};
 pub use types::scalars::{EmptyMutation, ID};
 pub use validation::RuleError;
 pub use value::{
-    DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue,
+    DefaultGraphQLScalarValue, Object, ParseScalarResult, ParseGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue,
     Value,
 };
 
@@ -192,7 +192,7 @@ pub fn execute<'a, S, CtxT, QueryT, MutationT>(
     context: &CtxT,
 ) -> Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError<'a>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
     QueryT: GraphQLType<S, Context = CtxT>,
     MutationT: GraphQLType<S, Context = CtxT>,

--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -2,11 +2,11 @@
 #[macro_export]
 macro_rules! __juniper_impl_trait {
     (
-        impl< < DefaultScalarValue > $(, $other: tt)* > $impl_trait:tt for $name:ty {
+        impl< < DefaultGraphQLScalarValue > $(, $other: tt)* > $impl_trait:tt for $name:ty {
             $($body:tt)+
         }
     ) => {
-        impl<$($other,)*> $crate::$impl_trait<$crate::DefaultScalarValue> for $name {
+        impl<$($other,)*> $crate::$impl_trait<$crate::DefaultGraphQLScalarValue> for $name {
             $($body)+
         }
     };
@@ -17,7 +17,7 @@ macro_rules! __juniper_impl_trait {
     ) => {
        impl<$($other,)* $generic $(: $bound)*> $crate::$impl_trait<$generic> for $name
         where
-            $generic: $crate::ScalarValue,
+            $generic: $crate::GraphQLScalarValue,
             for<'__b> &'__b $generic: $crate::ScalarRefValue<'__b>,
        {
            $($body)+
@@ -37,7 +37,7 @@ macro_rules! __juniper_impl_trait {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __juniper_insert_generic {
-    (<DefaultScalarValue>) => {$crate::DefaultScalarValue};
+    (<DefaultGraphQLScalarValue>) => {$crate::DefaultGraphQLScalarValue};
     (
         <$generic:tt $(: $bound: tt)*>
     ) => {
@@ -110,7 +110,7 @@ macro_rules! __juniper_parse_object_header {
                 $(ctx = $ctxt,)*
                 $(main_self = $mainself,)*
                 outname = {$outname},
-                scalar = {<DefaultScalarValue>},
+                scalar = {<DefaultGraphQLScalarValue>},
             },
             rest = $($items)*
         );
@@ -173,7 +173,7 @@ macro_rules! __juniper_parse_object_header {
                 $(ctx = $ctxt,)*
                 $(main_self = $mainself,)*
                 outname = {$outname},
-                scalar = {<DefaultScalarValue>},
+                scalar = {<DefaultGraphQLScalarValue>},
             },
             rest = $($items)*
         );
@@ -235,7 +235,7 @@ macro_rules! __juniper_parse_object_header {
                 $(ctx = $ctxt,)*
                 $(main_self = $mainself,)*
                 outname = {stringify!($name)},
-                scalar = {<DefaultScalarValue>},
+                scalar = {<DefaultGraphQLScalarValue>},
             },
             rest = $($items)*
         );
@@ -298,7 +298,7 @@ macro_rules! __juniper_parse_object_header {
                 $(ctx = $ctxt,)*
                 $(main_self = $mainself,)*
                 outname = {stringify!($name)},
-                scalar = {<DefaultScalarValue>},
+                scalar = {<DefaultGraphQLScalarValue>},
             },
             rest = $($items)*
         );

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -128,7 +128,7 @@ even have to be backed by a trait!
 
 ## Emitting errors
 
-`FieldResult<T, S = DefaultScalarValue>` is a type alias for `Result<T, FieldError<S>>`, where
+`FieldResult<T, S = DefaultGraphQLScalarValue>` is a type alias for `Result<T, FieldError<S>>`, where
 `FieldError` is a tuple that contains an error message and optionally a
 JSON-like data structure. In the end, errors that fields emit are serialized
 into strings in the response. However, the execution system will keep track of
@@ -160,7 +160,7 @@ graphql_object!(User: () |&self| {
 ## Specify scalar value representation
 
 Sometimes it is necessary to use a other scalar value representation as the default
-one provided by `DefaultScalarValue`.
+one provided by `DefaultGraphQLScalarValue`.
 It is possible to specify a specific scalar value type using the `where Scalar = Type`
 syntax.
 Additionally it is possible to use a generic parameter for the scalar value type
@@ -200,7 +200,7 @@ following form:
 The following parts are optional:
 * `<Generics>`, if not set no generics are defined
 * `as "ExposedName"`, if not set `ExposedType` is used as name
-* `where Scalar = <S>` / `where Scalar = SpecificType` if not set `DefaultScalarValue`
+* `where Scalar = <S>` / `where Scalar = SpecificType` if not set `DefaultGraphQLScalarValue`
 is used as scalar value
 
 ## Items

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -18,7 +18,7 @@ representation.
 
 ```rust
 # #[macro_use] extern crate juniper;
-# use juniper::{Value, FieldResult, ParseScalarValue, ParseScalarResult};
+# use juniper::{Value, FieldResult, ParseGraphQLScalarValue, ParseScalarResult};
 struct UserID(String);
 
 graphql_scalar!(UserID {
@@ -33,7 +33,7 @@ graphql_scalar!(UserID {
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a> {
-        <String as ParseScalarValue>::from_str(value)
+        <String as ParseGraphQLScalarValue>::from_str(value)
     }
 });
 
@@ -129,7 +129,7 @@ macro_rules! graphql_scalar {
         );
 
         $crate::__juniper_impl_trait!(
-            impl<$($scalar)+> ParseScalarValue for $name {
+            impl<$($scalar)+> ParseGraphQLScalarValue for $name {
                 fn from_str<$from_str_lt>($from_str_arg: $crate::parser::ScalarToken<$from_str_lt>) -> $from_str_result {
                     $from_str_body
                 }

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -1,7 +1,7 @@
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Value};
+use value::{DefaultGraphQLScalarValue, Value};
 
 struct Root;
 
@@ -84,7 +84,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_args_info_query<F>(field_name: &str, f: F)
 where
-    F: Fn(&Vec<Value<DefaultScalarValue>>) -> (),
+    F: Fn(&Vec<Value<DefaultGraphQLScalarValue>>) -> (),
 {
     let doc = r#"
     {

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -2,7 +2,7 @@ use ast::InputValue;
 use executor::FieldResult;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use value::{DefaultGraphQLScalarValue, Object, Value};
 
 struct Interface;
 #[derive(Debug)]
@@ -105,7 +105,7 @@ graphql_interface!(Interface: () |&self| {
 
 fn run_field_info_query<F>(type_name: &str, field_name: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {

--- a/juniper/src/macros/tests/interface.rs
+++ b/juniper/src/macros/tests/interface.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use ast::InputValue;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{Value, Object, DefaultScalarValue};
+use value::{Value, Object, DefaultGraphQLScalarValue};
 
 /*
 
@@ -129,7 +129,7 @@ graphql_object!(<'a> Root: () as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>, &Vec<Value<DefaultScalarValue>>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>, &Vec<Value<DefaultGraphQLScalarValue>>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {

--- a/juniper/src/macros/tests/object.rs
+++ b/juniper/src/macros/tests/object.rs
@@ -4,7 +4,7 @@ use ast::InputValue;
 use executor::{Context, FieldResult};
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use value::{DefaultGraphQLScalarValue, Object, Value};
 
 /*
 
@@ -143,7 +143,7 @@ graphql_object!(<'a> Root: InnerContext as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>, &Vec<Value<DefaultScalarValue>>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>, &Vec<Value<DefaultGraphQLScalarValue>>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {

--- a/juniper/src/macros/tests/scalar.rs
+++ b/juniper/src/macros/tests/scalar.rs
@@ -1,7 +1,7 @@
 use executor::Variables;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{Value, Object, DefaultScalarValue, ParseScalarValue, ParseScalarResult};
+use value::{Value, Object, DefaultGraphQLScalarValue, ParseGraphQLScalarValue, ParseScalarResult};
 
 struct DefaultName(i32);
 struct OtherOrder(i32);
@@ -29,7 +29,7 @@ graphql_scalar!(DefaultName where Scalar = <S> {
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
-        <i32 as ParseScalarValue<S>>::from_str(value)
+        <i32 as ParseGraphQLScalarValue<S>>::from_str(value)
     }
 });
 
@@ -43,12 +43,12 @@ graphql_scalar!(OtherOrder {
     }
 
 
-    from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, DefaultScalarValue> {
-        <i32 as ParseScalarValue>::from_str(value)
+    from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, DefaultGraphQLScalarValue> {
+        <i32 as ParseGraphQLScalarValue>::from_str(value)
     }
 });
 
-graphql_scalar!(Named as "ANamedScalar" where Scalar = DefaultScalarValue {
+graphql_scalar!(Named as "ANamedScalar" where Scalar = DefaultGraphQLScalarValue {
     resolve(&self) -> Value {
         Value::scalar(self.0)
     }
@@ -57,8 +57,8 @@ graphql_scalar!(Named as "ANamedScalar" where Scalar = DefaultScalarValue {
         v.as_scalar_value::<i32>().map(|i| Named(*i))
     }
 
-    from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, DefaultScalarValue> {
-        <i32 as ParseScalarValue>::from_str(value)
+    from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, DefaultGraphQLScalarValue> {
+        <i32 as ParseGraphQLScalarValue>::from_str(value)
     }
 });
 
@@ -74,7 +74,7 @@ graphql_scalar!(ScalarDescription  {
     }
 
     from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a> {
-        <i32 as ParseScalarValue>::from_str(value)
+        <i32 as ParseGraphQLScalarValue>::from_str(value)
     }
 });
 
@@ -87,7 +87,7 @@ graphql_object!(Root: () |&self| {
 
 fn run_type_info_query<F>(doc: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>) -> (),
 {
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
@@ -123,7 +123,7 @@ fn path_in_resolve_return_type() {
         }
 
         from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a> {
-            <i32 as ParseScalarValue>::from_str(value)
+            <i32 as ParseGraphQLScalarValue>::from_str(value)
         }
     });
 }

--- a/juniper/src/macros/tests/union.rs
+++ b/juniper/src/macros/tests/union.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use ast::InputValue;
 use schema::model::RootNode;
 use types::scalars::EmptyMutation;
-use value::{Value, Object, DefaultScalarValue};
+use value::{Value, Object, DefaultGraphQLScalarValue};
 
 /*
 
@@ -110,7 +110,7 @@ graphql_object!(<'a> Root: () as "Root" |&self| {
 
 fn run_type_info_query<F>(type_name: &str, f: F)
 where
-    F: Fn(&Object<DefaultScalarValue>, &Vec<Value<DefaultScalarValue>>) -> (),
+    F: Fn(&Object<DefaultGraphQLScalarValue>, &Vec<Value<DefaultGraphQLScalarValue>>) -> (),
 {
     let doc = r#"
     query ($typeName: String!) {

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -12,7 +12,7 @@ use parser::{
 };
 use schema::meta::{Argument, Field as MetaField};
 use schema::model::SchemaType;
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[doc(hidden)]
 pub fn parse_document_source<'a, 'b, S>(
@@ -20,7 +20,7 @@ pub fn parse_document_source<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> UnlocatedParseResult<'a, Document<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let mut lexer = Lexer::new(s);
     let mut parser = Parser::new(&mut lexer).map_err(|s| s.map(ParseError::LexerError))?;
@@ -32,7 +32,7 @@ fn parse_document<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> UnlocatedParseResult<'a, Document<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let mut defs = Vec::new();
 
@@ -50,7 +50,7 @@ fn parse_definition<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> UnlocatedParseResult<'a, Definition<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     match parser.peek().item {
         Token::CurlyOpen | Token::Name("query") | Token::Name("mutation") => Ok(
@@ -68,7 +68,7 @@ fn parse_operation_definition<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> ParseResult<'a, Operation<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if parser.peek().item == Token::CurlyOpen {
         let fields = schema.concrete_query_type().fields(schema);
@@ -123,7 +123,7 @@ fn parse_fragment_definition<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> ParseResult<'a, Fragment<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let Spanning {
         start: start_pos, ..
@@ -166,7 +166,7 @@ fn parse_optional_selection_set<'a, 'b, S>(
     fields: Option<&[&MetaField<'b, S>]>,
 ) -> OptionParseResult<'a, Vec<Selection<'a, S>>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if parser.peek().item == Token::CurlyOpen {
         Ok(Some(parse_selection_set(parser, schema, fields)?))
@@ -181,7 +181,7 @@ fn parse_selection_set<'a, 'b, S>(
     fields: Option<&[&MetaField<'b, S>]>,
 ) -> ParseResult<'a, Vec<Selection<'a, S>>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     parser.unlocated_delimited_nonempty_list(
         &Token::CurlyOpen,
@@ -196,7 +196,7 @@ fn parse_selection<'a, 'b, S>(
     fields: Option<&[&MetaField<'b, S>]>,
 ) -> UnlocatedParseResult<'a, Selection<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     match parser.peek().item {
         Token::Ellipsis => parse_fragment(parser, schema, fields),
@@ -210,7 +210,7 @@ fn parse_fragment<'a, 'b, S>(
     fields: Option<&[&MetaField<'b, S>]>,
 ) -> UnlocatedParseResult<'a, Selection<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let Spanning {
         start: ref start_pos,
@@ -292,7 +292,7 @@ fn parse_field<'a, 'b, S>(
     fields: Option<&[&MetaField<'b, S>]>,
 ) -> ParseResult<'a, Field<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let mut alias = Some(parser.expect_name()?);
 
@@ -343,7 +343,7 @@ fn parse_arguments<'a, 'b, S>(
     arguments: Option<&[Argument<'b, S>]>,
 ) -> OptionParseResult<'a, Arguments<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if parser.peek().item != Token::ParenOpen {
         Ok(None)
@@ -367,7 +367,7 @@ fn parse_argument<'a, 'b, S>(
     arguments: Option<&[Argument<'b, S>]>,
 ) -> ParseResult<'a, (Spanning<&'a str>, Spanning<InputValue<S>>)>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let name = parser.expect_name()?;
     let tpe = arguments
@@ -397,7 +397,7 @@ fn parse_variable_definitions<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> OptionParseResult<'a, VariableDefinitions<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if parser.peek().item != Token::ParenOpen {
         Ok(None)
@@ -420,7 +420,7 @@ fn parse_variable_definition<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> ParseResult<'a, (Spanning<&'a str>, VariableDefinition<'a, S>)>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let Spanning {
         start: start_pos, ..
@@ -457,7 +457,7 @@ fn parse_directives<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> OptionParseResult<'a, Vec<Spanning<Directive<'a, S>>>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if parser.peek().item != Token::At {
         Ok(None)
@@ -476,7 +476,7 @@ fn parse_directive<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> ParseResult<'a, Directive<'a, S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let Spanning {
         start: start_pos, ..

--- a/juniper/src/parser/tests/document.rs
+++ b/juniper/src/parser/tests/document.rs
@@ -5,11 +5,11 @@ use parser::document::parse_document_source;
 use parser::{ParseError, SourcePosition, Spanning, Token};
 use schema::model::SchemaType;
 use validation::test_harness::{MutationRoot, QueryRoot};
-use value::{ScalarRefValue, ScalarValue, DefaultScalarValue};
+use value::{ScalarRefValue, GraphQLScalarValue, DefaultGraphQLScalarValue};
 
 fn parse_document<S>(s: &str) -> Document<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     parse_document_source(s, &SchemaType::new::<QueryRoot, MutationRoot>(&(), &()))
@@ -18,7 +18,7 @@ where
 
 fn parse_document_error<'a, S>(s: &'a str) -> Spanning<ParseError<'a>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     match parse_document_source::<S>(s, &SchemaType::new::<QueryRoot, MutationRoot>(&(), &())) {
@@ -30,7 +30,7 @@ where
 #[test]
 fn simple_ast() {
     assert_eq!(
-        parse_document::<DefaultScalarValue>(
+        parse_document::<DefaultGraphQLScalarValue>(
             r#"
             {
                 node(id: 4) {
@@ -119,7 +119,7 @@ fn simple_ast() {
 #[test]
 fn errors() {
     assert_eq!(
-        parse_document_error::<DefaultScalarValue>("{"),
+        parse_document_error::<DefaultGraphQLScalarValue>("{"),
         Spanning::zero_width(
             &SourcePosition::new(1, 0, 1),
             ParseError::UnexpectedEndOfFile
@@ -127,7 +127,7 @@ fn errors() {
     );
 
     assert_eq!(
-        parse_document_error::<DefaultScalarValue>("{ ...MissingOn }\nfragment MissingOn Type"),
+        parse_document_error::<DefaultGraphQLScalarValue>("{ ...MissingOn }\nfragment MissingOn Type"),
         Spanning::start_end(
             &SourcePosition::new(36, 1, 19),
             &SourcePosition::new(40, 1, 23),
@@ -136,7 +136,7 @@ fn errors() {
     );
 
     assert_eq!(
-        parse_document_error::<DefaultScalarValue>("{ ...on }"),
+        parse_document_error::<DefaultGraphQLScalarValue>("{ ...on }"),
         Spanning::start_end(
             &SourcePosition::new(8, 0, 8),
             &SourcePosition::new(9, 0, 9),

--- a/juniper/src/parser/value.rs
+++ b/juniper/src/parser/value.rs
@@ -3,7 +3,7 @@ use ast::InputValue;
 use parser::{ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token};
 use schema::meta::{InputObjectMeta, MetaType};
 use schema::model::SchemaType;
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub fn parse_value_literal<'a, 'b, S>(
     parser: &mut Parser<'a>,
@@ -12,7 +12,7 @@ pub fn parse_value_literal<'a, 'b, S>(
     tpe: Option<&MetaType<'b, S>>,
 ) -> ParseResult<'a, InputValue<S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     match (parser.peek(), tpe) {
         (
@@ -126,7 +126,7 @@ fn parse_list_literal<'a, 'b, S>(
     tpe: Option<&MetaType<'b, S>>,
 ) -> ParseResult<'a, InputValue<S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Ok(parser
         .delimited_list(
@@ -143,7 +143,7 @@ fn parse_object_literal<'a, 'b, S>(
     object_tpe: Option<&InputObjectMeta<'b, S>>,
 ) -> ParseResult<'a, InputValue<S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Ok(parser
         .delimited_list(
@@ -160,7 +160,7 @@ fn parse_object_field<'a, 'b, S>(
     object_meta: Option<&InputObjectMeta<'b, S>>,
 ) -> ParseResult<'a, (Spanning<String>, Spanning<InputValue<S>>)>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let key = parser.expect_name()?;
 
@@ -181,7 +181,7 @@ where
 
 fn parse_variable_literal<'a, S>(parser: &mut Parser<'a>) -> ParseResult<'a, InputValue<S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let Spanning {
         start: start_pos, ..
@@ -206,7 +206,7 @@ fn parse_scalar_literal_by_infered_type<'a, 'b, S>(
     schema: &'b SchemaType<'b, S>,
 ) -> ParseResult<'a, InputValue<S>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     match token {
         ScalarToken::String(_) => {

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -7,7 +7,7 @@ use ast::{FromInputValue, InputValue, Type};
 use parser::{ParseError, ScalarToken};
 use schema::model::SchemaType;
 use types::base::TypeKind;
-use value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use value::{DefaultGraphQLScalarValue, ParseGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue};
 
 /// Whether an item is deprecated, with context.
 #[derive(Debug, PartialEq, Hash, Clone)]
@@ -129,7 +129,7 @@ pub struct PlaceholderMeta<'a> {
 
 /// Generic type metadata
 #[derive(Debug)]
-pub enum MetaType<'a, S = DefaultScalarValue> {
+pub enum MetaType<'a, S = DefaultGraphQLScalarValue> {
     #[doc(hidden)]
     Scalar(ScalarMeta<'a, S>),
     #[doc(hidden)]
@@ -385,19 +385,19 @@ impl<'a, S> MetaType<'a, S> {
 
 impl<'a, S> ScalarMeta<'a, S>
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
 {
     /// Build a new scalar type metadata with the specified name
     pub fn new<T>(name: Cow<'a, str>) -> Self
     where
-        T: FromInputValue<S> + ParseScalarValue<S> + 'a,
+        T: FromInputValue<S> + ParseGraphQLScalarValue<S> + 'a,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         ScalarMeta {
             name: name,
             description: None,
             try_parse_fn: try_parse_fn::<S, T>,
-            parse_fn: <T as ParseScalarValue<S>>::from_str,
+            parse_fn: <T as ParseGraphQLScalarValue<S>>::from_str,
         }
     }
 
@@ -441,7 +441,7 @@ impl<'a> NullableMeta<'a> {
 
 impl<'a, S> ObjectMeta<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     /// Build a new object type with the specified name and fields
     pub fn new(name: Cow<'a, str>, fields: &[Field<'a, S>]) -> Self {
@@ -481,7 +481,7 @@ where
 
 impl<'a, S> EnumMeta<'a, S>
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
 {
     /// Build a new enum type with the specified name and possible values
     pub fn new<T>(name: Cow<'a, str>, values: &[EnumValue]) -> Self
@@ -513,7 +513,7 @@ where
 
 impl<'a, S> InterfaceMeta<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     /// Build a new interface type with the specified name and fields
     pub fn new(name: Cow<'a, str>, fields: &[Field<'a, S>]) -> InterfaceMeta<'a, S> {
@@ -567,7 +567,7 @@ impl<'a> UnionMeta<'a> {
 
 impl<'a, S> InputObjectMeta<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     /// Build a new input type with the specified name and input fields
     pub fn new<T: FromInputValue<S>>(name: Cow<'a, str>, input_fields: &[Argument<'a, S>]) -> Self

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -7,16 +7,16 @@ use executor::{Context, Registry};
 use schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
 use types::base::GraphQLType;
 use types::name::Name;
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use value::{DefaultGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue};
 
 /// Root query node of a schema
 ///
 /// This brings the mutation and query types together, and provides the
 /// predefined metadata fields.
 #[derive(Debug)]
-pub struct RootNode<'a, QueryT: GraphQLType<S>, MutationT: GraphQLType<S>, S = DefaultScalarValue>
+pub struct RootNode<'a, QueryT: GraphQLType<S>, MutationT: GraphQLType<S>, S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     #[doc(hidden)]
@@ -73,7 +73,7 @@ pub enum DirectiveLocation {
 
 impl<'a, QueryT, MutationT, S> RootNode<'a, QueryT, MutationT, S>
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     QueryT: GraphQLType<S, TypeInfo = ()>,
     MutationT: GraphQLType<S, TypeInfo = ()>,
     for<'b> &'b S: ScalarRefValue<'b>,
@@ -94,7 +94,7 @@ impl<'a, S, QueryT, MutationT> RootNode<'a, QueryT, MutationT, S>
 where
     QueryT: GraphQLType<S>,
     MutationT: GraphQLType<S>,
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     /// Construct a new root node from query and mutation nodes,
@@ -125,7 +125,7 @@ impl<'a, S> SchemaType<'a, S> {
         mutation_info: &MutationT::TypeInfo,
     ) -> Self
     where
-        S: ScalarValue + 'a,
+        S: GraphQLScalarValue + 'a,
         QueryT: GraphQLType<S>,
         MutationT: GraphQLType<S>,
         for<'b> &'b S: ScalarRefValue<'b>,
@@ -390,7 +390,7 @@ impl<'a, S> TypeType<'a, S> {
 
 impl<'a, S> DirectiveType<'a, S>
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
 {
     pub fn new(
         name: &str,
@@ -407,7 +407,7 @@ where
 
     fn new_skip(registry: &mut Registry<'a, S>) -> DirectiveType<'a, S>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         Self::new(
@@ -423,7 +423,7 @@ where
 
     fn new_include(registry: &mut Registry<'a, S>) -> DirectiveType<'a, S>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         Self::new(

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -1,7 +1,7 @@
 use ast::Selection;
 use executor::{ExecutionResult, Executor, Registry};
 use types::base::{Arguments, GraphQLType, TypeKind};
-use value::{ScalarRefValue, ScalarValue, Value};
+use value::{ScalarRefValue, GraphQLScalarValue, Value};
 
 use schema::meta::{
     Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType, ObjectMeta,
@@ -11,7 +11,7 @@ use schema::model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, Type
 
 impl<'a, CtxT, S, QueryT, MutationT> GraphQLType<S> for RootNode<'a, QueryT, MutationT, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     QueryT: GraphQLType<S, Context = CtxT>,
     MutationT: GraphQLType<S, Context = CtxT>,
     for<'b> &'b S: ScalarRefValue<'b>,

--- a/juniper/src/tests/type_info_tests.rs
+++ b/juniper/src/tests/type_info_tests.rs
@@ -5,7 +5,7 @@ use schema::meta::MetaType;
 use schema::model::RootNode;
 use types::base::{Arguments, GraphQLType};
 use types::scalars::EmptyMutation;
-use value::{ScalarRefValue, ScalarValue, Value};
+use value::{ScalarRefValue, GraphQLScalarValue, Value};
 
 pub struct NodeTypeInfo {
     name: String,
@@ -18,7 +18,7 @@ pub struct Node {
 
 impl<S> GraphQLType<S> for Node
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 
 use ast::{Directive, FromInputValue, InputValue, Selection};
 use executor::Variables;
-use value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value};
+use value::{DefaultGraphQLScalarValue, Object, ScalarRefValue, GraphQLScalarValue, Value};
 
 use executor::{ExecutionResult, Executor, Registry};
 use parser::Spanning;
@@ -68,13 +68,13 @@ pub enum TypeKind {
 
 /// Field argument container
 #[derive(Debug)]
-pub struct Arguments<'a, S = DefaultScalarValue> {
+pub struct Arguments<'a, S = DefaultGraphQLScalarValue> {
     args: Option<IndexMap<&'a str, InputValue<S>>>,
 }
 
 impl<'a, S> Arguments<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     #[doc(hidden)]
     pub fn new(
@@ -149,7 +149,7 @@ root:
 ```rust
 use juniper::{GraphQLType, Registry, FieldResult, Context,
               Arguments, Executor, ExecutionResult,
-              DefaultScalarValue};
+              DefaultGraphQLScalarValue};
 use juniper::meta::MetaType;
 # use std::collections::HashMap;
 
@@ -170,7 +170,7 @@ impl GraphQLType for User
     }
 
     fn meta<'r>(_: &(), registry: &mut Registry<'r>) -> MetaType<'r>
-    where DefaultScalarValue: 'r,
+    where DefaultGraphQLScalarValue: 'r,
     {
         // First, we need to define all fields and their types on this type.
         //
@@ -229,9 +229,9 @@ impl GraphQLType for User
 ```
 
 */
-pub trait GraphQLType<S = DefaultScalarValue>: Sized
+pub trait GraphQLType<S = DefaultGraphQLScalarValue>: Sized
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     /// The expected context type for this GraphQL type
@@ -346,7 +346,7 @@ pub(crate) fn resolve_selection_set_into<T, CtxT, S>(
 ) -> bool
 where
     T: GraphQLType<S, Context = CtxT>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     let meta_type = executor
@@ -495,7 +495,7 @@ where
 
 fn is_excluded<S>(directives: &Option<Vec<Spanning<Directive<S>>>>, vars: &Variables<S>) -> bool
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     if let Some(ref directives) = *directives {

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -1,13 +1,13 @@
 use ast::{FromInputValue, InputValue, Selection, ToInputValue};
 use schema::meta::MetaType;
-use value::{ScalarRefValue, ScalarValue, Value};
+use value::{ScalarRefValue, GraphQLScalarValue, Value};
 
 use executor::{Executor, Registry};
 use types::base::GraphQLType;
 
 impl<S, T, CtxT> GraphQLType<S> for Option<T>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: GraphQLType<S, Context = CtxT>,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
@@ -42,7 +42,7 @@ where
 impl<S, T> FromInputValue<S> for Option<T>
 where
     T: FromInputValue<S>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value<'a>(v: &'a InputValue<S>) -> Option<Option<T>>
     where
@@ -61,7 +61,7 @@ where
 impl<S, T> ToInputValue<S> for Option<T>
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         match *self {
@@ -74,7 +74,7 @@ where
 impl<S, T, CtxT> GraphQLType<S> for Vec<T>
 where
     T: GraphQLType<S, Context = CtxT>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = CtxT;
@@ -105,7 +105,7 @@ where
 impl<T, S> FromInputValue<S> for Vec<T>
 where
     T: FromInputValue<S>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value<'a>(v: &'a InputValue<S>) -> Option<Vec<T>>
     where
@@ -133,7 +133,7 @@ where
 impl<T, S> ToInputValue<S> for Vec<T>
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::list(self.iter().map(|v| v.to_input_value()).collect())
@@ -142,7 +142,7 @@ where
 
 impl<'a, S, T, CtxT> GraphQLType<S> for &'a [T]
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: GraphQLType<S, Context = CtxT>,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
@@ -174,7 +174,7 @@ where
 impl<'a, T, S> ToInputValue<S> for &'a [T]
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::list(self.iter().map(|v| v.to_input_value()).collect())
@@ -187,7 +187,7 @@ fn resolve_into_list<S, T, I>(
     iter: I,
 ) -> Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     I: Iterator<Item = T> + ExactSizeIterator,
     T: GraphQLType<S>,
     for<'b> &'b S: ScalarRefValue<'b>,

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use executor::{ExecutionResult, Executor, Registry};
 use schema::meta::MetaType;
 use types::base::{Arguments, GraphQLType};
-use value::{ScalarRefValue, ScalarValue, Value};
+use value::{ScalarRefValue, GraphQLScalarValue, Value};
 
 impl<S, T, CtxT> GraphQLType<S> for Box<T>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: GraphQLType<S, Context = CtxT>,
     for<'b> &'b S: ScalarRefValue<'b>
 {
@@ -60,7 +60,7 @@ where
 
 impl<T, S> FromInputValue<S> for Box<T>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: FromInputValue<S>,
 {
     fn from_input_value<'a>(v: &'a InputValue<S>) -> Option<Box<T>>
@@ -86,7 +86,7 @@ where
 
 impl<'a, S, T, CtxT> GraphQLType<S> for &'a T
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: GraphQLType<S, Context = CtxT>,
     for<'b> &'b S: ScalarRefValue<'b>
 {
@@ -147,7 +147,7 @@ where
 
 impl<S, T> GraphQLType<S> for Arc<T>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     T: GraphQLType<S>,
     for<'b> &'b S: ScalarRefValue<'b>
 {

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -9,7 +9,7 @@ use executor::{Executor, Registry};
 use parser::{LexerError, ParseError, ScalarToken, Token};
 use schema::meta::MetaType;
 use types::base::GraphQLType;
-use value::{ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue, Value};
+use value::{ParseScalarResult, ParseGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue, Value};
 
 /// An ID as defined by the GraphQL specification
 ///
@@ -164,7 +164,7 @@ where
 
 impl<'a, S> GraphQLType<S> for &'a str
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -194,7 +194,7 @@ where
 
 impl<'a, S> ToInputValue<S> for &'a str
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::scalar(String::from(*self))
@@ -271,7 +271,7 @@ graphql_scalar!(f64 as "Float" where Scalar = <S>{
 
 impl<S> GraphQLType<S> for ()
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -290,9 +290,9 @@ where
     }
 }
 
-impl<S> ParseScalarValue<S> for ()
+impl<S> ParseGraphQLScalarValue<S> for ()
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_str<'a>(_value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
         Ok(S::from(0))
@@ -328,7 +328,7 @@ impl<T> EmptyMutation<T> {
 
 impl<S, T> GraphQLType<S> for EmptyMutation<T>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = T;
@@ -351,7 +351,7 @@ where
 mod tests {
     use super::ID;
     use parser::ScalarToken;
-    use value::{DefaultScalarValue, ParseScalarValue};
+    use value::{DefaultGraphQLScalarValue, ParseGraphQLScalarValue};
 
     #[test]
     fn test_id_from_string() {
@@ -377,7 +377,7 @@ mod tests {
     fn parse_strings() {
         fn parse_string(s: &str, expected: &str) {
             let s =
-                <String as ParseScalarValue<DefaultScalarValue>>::from_str(ScalarToken::String(s));
+                <String as ParseGraphQLScalarValue<DefaultGraphQLScalarValue>>::from_str(ScalarToken::String(s));
             assert!(s.is_ok(), "A parsing error occurred: {:?}", s);
             let s: Option<String> = s.unwrap().into();
             assert!(s.is_some(), "No string returned");

--- a/juniper/src/types/utilities.rs
+++ b/juniper/src/types/utilities.rs
@@ -2,7 +2,7 @@ use ast::InputValue;
 use schema::meta::{EnumMeta, InputObjectMeta, MetaType};
 use schema::model::{SchemaType, TypeType};
 use std::collections::HashSet;
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub fn is_valid_literal_value<S>(
     schema: &SchemaType<S>,
@@ -10,7 +10,7 @@ pub fn is_valid_literal_value<S>(
     arg_value: &InputValue<S>,
 ) -> bool
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     match *arg_type {
         TypeType::NonNull(ref inner) => if arg_value.is_null() {

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -7,7 +7,7 @@ use parser::SourcePosition;
 use schema::meta::{EnumMeta, InputObjectMeta, MetaType, ScalarMeta};
 use schema::model::{SchemaType, TypeType};
 use validation::RuleError;
-use value::{ScalarRefValue, ScalarValue};
+use value::{ScalarRefValue, GraphQLScalarValue};
 
 #[derive(Debug)]
 enum Path<'a> {
@@ -22,7 +22,7 @@ pub fn validate_input_values<S>(
     schema: &SchemaType<S>,
 ) -> Vec<RuleError>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     let mut errs = vec![];
@@ -45,7 +45,7 @@ fn validate_var_defs<S>(
     schema: &SchemaType<S>,
     errors: &mut Vec<RuleError>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     for &(ref name, ref def) in var_defs.iter() {
@@ -87,7 +87,7 @@ fn unify_value<'a, S>(
     path: Path<'a>,
 ) -> Vec<RuleError>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     let mut errors: Vec<RuleError> = vec![];
@@ -214,7 +214,7 @@ fn unify_enum<'a, S>(
     path: &Path<'a>,
 ) -> Vec<RuleError>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     let mut errors: Vec<RuleError> = vec![];
@@ -260,7 +260,7 @@ fn unify_input_object<'a, S>(
     path: &Path<'a>,
 ) -> Vec<RuleError>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     let mut errors: Vec<RuleError> = vec![];
@@ -318,7 +318,7 @@ where
 
 fn is_absent_or_null<S>(v: Option<&InputValue<S>>) -> bool
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     v.map_or(true, InputValue::is_null)
 }

--- a/juniper/src/validation/multi_visitor.rs
+++ b/juniper/src/validation/multi_visitor.rs
@@ -4,7 +4,7 @@ use ast::{
 };
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[doc(hidden)]
 pub struct MultiVisitorNil;
@@ -24,11 +24,11 @@ impl<A, B> MultiVisitorCons<A, B> {
     }
 }
 
-impl<'a, S> Visitor<'a, S> for MultiVisitorNil where S: ScalarValue {}
+impl<'a, S> Visitor<'a, S> for MultiVisitorNil where S: GraphQLScalarValue {}
 
 impl<'a, A, B, S> Visitor<'a, S> for MultiVisitorCons<A, B>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     A: Visitor<'a, S> + 'a,
     B: Visitor<'a, S> + 'a,
 {

--- a/juniper/src/validation/rules/arguments_of_correct_type.rs
+++ b/juniper/src/validation/rules/arguments_of_correct_type.rs
@@ -4,7 +4,7 @@ use schema::meta::Argument;
 use std::fmt::Debug;
 use types::utilities::is_valid_literal_value;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct ArgumentsOfCorrectType<'a, S: Debug + 'a> {
     current_args: Option<&'a Vec<Argument<'a, S>>>,
@@ -16,7 +16,7 @@ pub fn factory<'a, S: Debug>() -> ArgumentsOfCorrectType<'a, S> {
 
 impl<'a, S> Visitor<'a, S> for ArgumentsOfCorrectType<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_directive(
         &mut self,
@@ -78,11 +78,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn good_null_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn null_into_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn good_int_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn good_boolean_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn good_string_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn good_float_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn int_into_float() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn int_into_id() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn string_into_id() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn good_enum_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn int_into_string() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn float_into_string() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn boolean_into_string() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn unquoted_string_into_string() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn string_into_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn unquoted_string_into_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn simple_float_into_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn float_into_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn string_into_float() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn boolean_into_float() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn unquoted_into_float() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn int_into_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -442,7 +442,7 @@ mod tests {
 
     #[test]
     fn float_into_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn string_into_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn unquoted_into_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn float_into_id() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -514,7 +514,7 @@ mod tests {
 
     #[test]
     fn boolean_into_id() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -532,7 +532,7 @@ mod tests {
 
     #[test]
     fn unquoted_into_id() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -550,7 +550,7 @@ mod tests {
 
     #[test]
     fn int_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn float_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -586,7 +586,7 @@ mod tests {
 
     #[test]
     fn string_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn boolean_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn unknown_enum_value_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn different_case_enum_value_into_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn good_list_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -672,7 +672,7 @@ mod tests {
 
     #[test]
     fn empty_list_value() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -686,7 +686,7 @@ mod tests {
 
     #[test]
     fn single_value_into_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn incorrect_item_type() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -718,7 +718,7 @@ mod tests {
 
     #[test]
     fn single_value_of_incorrect_type() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -736,7 +736,7 @@ mod tests {
 
     #[test]
     fn arg_on_optional_arg() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -750,7 +750,7 @@ mod tests {
 
     #[test]
     fn no_arg_on_optional_arg() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -764,7 +764,7 @@ mod tests {
 
     #[test]
     fn multiple_args() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn multiple_args_reverse_order() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -792,7 +792,7 @@ mod tests {
 
     #[test]
     fn no_args_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn one_arg_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -820,7 +820,7 @@ mod tests {
 
     #[test]
     fn second_arg_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -834,7 +834,7 @@ mod tests {
 
     #[test]
     fn multiple_reqs_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -848,7 +848,7 @@ mod tests {
 
     #[test]
     fn multiple_reqs_and_one_opt_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -862,7 +862,7 @@ mod tests {
 
     #[test]
     fn all_reqs_and_opts_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn incorrect_value_type() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -900,7 +900,7 @@ mod tests {
 
     #[test]
     fn incorrect_value_and_missing_argument() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -918,7 +918,7 @@ mod tests {
 
     #[test]
     fn optional_arg_despite_required_field_in_type() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -932,7 +932,7 @@ mod tests {
 
     #[test]
     fn partial_object_only_required() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn partial_object_required_field_can_be_falsy() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -960,7 +960,7 @@ mod tests {
 
     #[test]
     fn partial_object_including_required() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -974,7 +974,7 @@ mod tests {
 
     #[test]
     fn full_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -994,7 +994,7 @@ mod tests {
 
     #[test]
     fn full_object_with_fields_in_different_order() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -1014,7 +1014,7 @@ mod tests {
 
     #[test]
     fn partial_object_missing_required() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[test]
     fn partial_object_invalid_field_type() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -1053,7 +1053,7 @@ mod tests {
 
     #[test]
     fn partial_object_unknown_field_arg() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     fn directive_with_valid_types() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn directive_with_incorrect_types() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
         {

--- a/juniper/src/validation/rules/default_values_of_correct_type.rs
+++ b/juniper/src/validation/rules/default_values_of_correct_type.rs
@@ -2,7 +2,7 @@ use ast::VariableDefinition;
 use parser::Spanning;
 use types::utilities::is_valid_literal_value;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct DefaultValuesOfCorrectType;
 
@@ -12,7 +12,7 @@ pub fn factory() -> DefaultValuesOfCorrectType {
 
 impl<'a, S> Visitor<'a, S> for DefaultValuesOfCorrectType
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_variable_definition(
         &mut self,
@@ -64,11 +64,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn variables_with_no_default_values() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query NullableValues($a: Int, $b: String, $c: ComplexInput) {
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn required_variables_without_default_values() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query RequiredValues($a: Int!, $b: String!) {
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn variables_with_valid_default_values() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query WithDefaultValues(
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn no_required_variables_with_default_values() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query UnreachableDefaultValues($a: Int! = 3, $b: String! = "default") {
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn variables_with_invalid_default_values() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query InvalidDefaultValues(
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn complex_variables_missing_required_field() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query MissingRequiredField($a: ComplexInput = {intField: 3}) {
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn list_variables_with_invalid_item() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query InvalidItem($a: [String] = ["one", 2]) {

--- a/juniper/src/validation/rules/fields_on_correct_type.rs
+++ b/juniper/src/validation/rules/fields_on_correct_type.rs
@@ -2,7 +2,7 @@ use ast::Field;
 use parser::Spanning;
 use schema::meta::MetaType;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct FieldsOnCorrectType;
 
@@ -12,7 +12,7 @@ pub fn factory() -> FieldsOnCorrectType {
 
 impl<'a, S> Visitor<'a, S> for FieldsOnCorrectType
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_field(
@@ -58,11 +58,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn selection_on_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectFieldSelection on Dog {
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn aliased_selection_on_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment aliasedObjectFieldSelection on Dog {
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn selection_on_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceFieldSelection on Pet {
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn aliased_selection_on_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceFieldSelection on Pet {
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn lying_alias_selection() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment lyingAliasSelection on Dog {
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn ignores_unknown_type() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment unknownSelection on UnknownType {
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn nested_unknown_fields() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment typeKnownAgain on Pet {
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn unknown_field_on_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fieldNotDefined on Dog {
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn ignores_deeply_unknown_field() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment deepFieldNotDefined on Dog {
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn unknown_subfield() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment subFieldNotDefined on Human {
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn unknown_field_on_inline_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fieldNotDefined on Pet {
@@ -233,7 +233,7 @@ mod tests {
 
     #[test]
     fn unknown_aliased_target() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment aliasedFieldTargetNotDefined on Dog {
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn unknown_aliased_lying_field_target() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment aliasedLyingFieldTargetNotDefined on Dog {
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn not_defined_on_interface() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment notDefinedOnInterface on Pet {
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn defined_in_concrete_types_but_not_interface() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment definedOnImplementorsButNotInterface on Pet {
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn meta_field_on_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment definedOnImplementorsButNotInterface on Pet {
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn fields_on_union() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn typename_on_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectFieldSelection on Pet {
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn valid_field_in_inline_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectFieldSelection on Pet {

--- a/juniper/src/validation/rules/fragments_on_composite_types.rs
+++ b/juniper/src/validation/rules/fragments_on_composite_types.rs
@@ -1,7 +1,7 @@
 use ast::{Fragment, InlineFragment};
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct FragmentsOnCompositeTypes;
 
@@ -11,7 +11,7 @@ pub fn factory() -> FragmentsOnCompositeTypes {
 
 impl<'a, S> Visitor<'a, S> for FragmentsOnCompositeTypes
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_fragment_definition(
         &mut self,
@@ -75,11 +75,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn on_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment validFragment on Dog {
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn on_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment validFragment on Pet {
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn on_object_inline() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment validFragment on Pet {
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn on_inline_without_type_cond() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment validFragment on Pet {
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn on_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment validFragment on CatOrDog {
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn not_on_scalar() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarFragment on Boolean {
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn not_on_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarFragment on FurColor {
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn not_on_input_object() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment inputFragment on ComplexInput {
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn not_on_scalar_inline() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidFragment on Pet {

--- a/juniper/src/validation/rules/known_argument_names.rs
+++ b/juniper/src/validation/rules/known_argument_names.rs
@@ -3,7 +3,7 @@ use parser::Spanning;
 use schema::meta::Argument;
 use std::fmt::Debug;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug)]
 enum ArgumentPosition<'a> {
@@ -21,7 +21,7 @@ pub fn factory<'a, S: Debug>() -> KnownArgumentNames<'a, S> {
 
 impl<'a, S> Visitor<'a, S> for KnownArgumentNames<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_directive(
         &mut self,
@@ -108,11 +108,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn single_arg_is_known() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment argOnRequiredArg on Dog {
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn multiple_args_are_known() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment multipleArgs on ComplicatedArgs {
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn ignores_args_of_unknown_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment argOnUnknownField on Dog {
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn multiple_args_in_reverse_order_are_known() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment multipleArgsReverseOrder on ComplicatedArgs {
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn no_args_on_optional_arg() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment noArgOnOptionalArg on Dog {
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn args_are_known_deeply() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn directive_args_are_known() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn undirective_args_are_invalid() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn invalid_arg_name() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidArgName on Dog {
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn unknown_args_amongst_known_args() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment oneGoodArgOneInvalidArg on Dog {
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn unknown_args_deeply() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {

--- a/juniper/src/validation/rules/known_directives.rs
+++ b/juniper/src/validation/rules/known_directives.rs
@@ -2,7 +2,7 @@ use ast::{Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation,
 use parser::Spanning;
 use schema::model::DirectiveLocation;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct KnownDirectives {
     location_stack: Vec<DirectiveLocation>,
@@ -16,7 +16,7 @@ pub fn factory() -> KnownDirectives {
 
 impl<'a, S> Visitor<'a, S> for KnownDirectives
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_operation_definition(
@@ -148,11 +148,11 @@ mod tests {
     use parser::SourcePosition;
     use schema::model::DirectiveLocation;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn with_no_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn with_known_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn with_unknown_directive() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn with_many_unknown_directives() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn with_well_placed_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo @onQuery {
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn with_misplaced_directives() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo @include(if: true) {

--- a/juniper/src/validation/rules/known_fragment_names.rs
+++ b/juniper/src/validation/rules/known_fragment_names.rs
@@ -1,7 +1,7 @@
 use ast::FragmentSpread;
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct KnownFragmentNames;
 
@@ -11,7 +11,7 @@ pub fn factory() -> KnownFragmentNames {
 
 impl<'a, S> Visitor<'a, S> for KnownFragmentNames
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_fragment_spread(
@@ -39,11 +39,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn known() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn unknown() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {

--- a/juniper/src/validation/rules/known_type_names.rs
+++ b/juniper/src/validation/rules/known_type_names.rs
@@ -2,7 +2,7 @@ use ast::{Fragment, InlineFragment, VariableDefinition};
 use parser::{SourcePosition, Spanning};
 use std::fmt::Debug;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct KnownTypeNames;
 
@@ -12,7 +12,7 @@ pub fn factory() -> KnownTypeNames {
 
 impl<'a, S> Visitor<'a, S> for KnownTypeNames
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_inline_fragment(
         &mut self,
@@ -63,11 +63,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn known_type_names_are_valid() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($var: String, $required: [String!]!) {
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn unknown_type_names_are_invalid() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($var: JumbledUpLetters) {

--- a/juniper/src/validation/rules/lone_anonymous_operation.rs
+++ b/juniper/src/validation/rules/lone_anonymous_operation.rs
@@ -1,7 +1,7 @@
 use ast::{Definition, Document, Operation};
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct LoneAnonymousOperation {
     operation_count: Option<usize>,
@@ -15,7 +15,7 @@ pub fn factory() -> LoneAnonymousOperation {
 
 impl<'a, S> Visitor<'a, S> for LoneAnonymousOperation
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_document(&mut self, _: &mut ValidatorContext<'a, S>, doc: &'a Document<S>) {
         self.operation_count = Some(
@@ -50,11 +50,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn no_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Type {
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn one_anon_operation() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn multiple_named_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn anon_operation_with_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn multiple_anon_operations() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn anon_operation_with_a_mutation() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {

--- a/juniper/src/validation/rules/mod.rs
+++ b/juniper/src/validation/rules/mod.rs
@@ -26,11 +26,11 @@ mod variables_in_allowed_position;
 use ast::Document;
 use std::fmt::Debug;
 use validation::{visit, MultiVisitorNil, ValidatorContext};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub(crate) fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let mut mv = MultiVisitorNil
         .with(self::arguments_of_correct_type::factory())

--- a/juniper/src/validation/rules/no_fragment_cycles.rs
+++ b/juniper/src/validation/rules/no_fragment_cycles.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use ast::{Document, Fragment, FragmentSpread};
 use parser::Spanning;
 use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct NoFragmentCycles<'a> {
     current_fragment: Option<&'a str>,
@@ -28,7 +28,7 @@ pub fn factory<'a>() -> NoFragmentCycles<'a> {
 
 impl<'a, S> Visitor<'a, S> for NoFragmentCycles<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn exit_document(&mut self, ctx: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {
@@ -136,11 +136,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn single_reference_is_valid() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB }
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn spreading_twice_is_not_circular() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB, ...fragB }
@@ -162,7 +162,7 @@ mod tests {
 
     #[test]
     fn spreading_twice_indirectly_is_not_circular() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB, ...fragC }
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn double_spread_within_abstract_types() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment nameFragment on Pet {
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn does_not_false_positive_on_unknown_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment nameFragment on Pet {
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn spreading_recursively_within_field_fails() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Human { relatives { ...fragA } },
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_directly() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragA }
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_directly_within_inline_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Pet {
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_indirectly() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB }
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_indirectly_reports_opposite_order() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragB on Dog { ...fragA }
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_indirectly_within_inline_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Pet {
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_deeply() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB }
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_deeply_two_paths() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB, ...fragC }
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_deeply_two_paths_alt_traversal_order() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragC }
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn no_spreading_itself_deeply_and_immediately() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog { ...fragB }

--- a/juniper/src/validation/rules/no_undefined_variables.rs
+++ b/juniper/src/validation/rules/no_undefined_variables.rs
@@ -2,7 +2,7 @@ use ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDef
 use parser::{SourcePosition, Spanning};
 use std::collections::{HashMap, HashSet};
 use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -58,7 +58,7 @@ impl<'a> NoUndefinedVariables<'a> {
 
 impl<'a, S> Visitor<'a, S> for NoUndefinedVariables<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn exit_document(&mut self, ctx: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {
         for (op_name, &(ref pos, ref def_vars)) in &self.defined_variables {
@@ -167,11 +167,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn all_variables_defined() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn all_variables_deeply_defined() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn all_variables_deeply_defined_in_inline_fragments_defined() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn all_variables_in_fragments_deeply_defined() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn variable_within_single_fragment_defined_in_multiple_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn variable_within_fragments_defined_in_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn variable_within_recursive_fragment_defined() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn variable_not_defined() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn variable_not_defined_by_unnamed_query() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn multiple_variables_not_defined() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn variable_in_fragment_not_defined_by_unnamed_query() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn variable_in_fragment_not_defined_by_operation() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String) {
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn multiple_variables_in_fragments_not_defined() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn single_variable_in_fragment_not_defined_by_multiple_operations() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -495,7 +495,7 @@ mod tests {
 
     #[test]
     fn variables_in_fragment_not_defined_by_multiple_operations() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn variable_in_fragment_used_by_other_operation() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {
@@ -566,7 +566,7 @@ mod tests {
 
     #[test]
     fn multiple_undefined_variables_produce_multiple_errors() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {

--- a/juniper/src/validation/rules/no_unused_fragments.rs
+++ b/juniper/src/validation/rules/no_unused_fragments.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use ast::{Definition, Document, Fragment, FragmentSpread, Operation};
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -45,7 +45,7 @@ impl<'a> NoUnusedFragments<'a> {
 
 impl<'a, S> Visitor<'a, S> for NoUnusedFragments<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn exit_document(&mut self, ctx: &mut ValidatorContext<'a, S>, defs: &'a Document<S>) {
         let mut reachable = HashSet::new();
@@ -111,11 +111,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn all_fragment_names_are_used() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn all_fragment_names_are_used_by_multiple_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn contains_unknown_fragments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn contains_unknown_fragments_with_ref_cycle() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn contains_unknown_and_undef_fragments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {

--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -2,7 +2,7 @@ use ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDef
 use parser::Spanning;
 use std::collections::{HashMap, HashSet};
 use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -58,7 +58,7 @@ impl<'a> NoUnusedVariables<'a> {
 
 impl<'a, S> Visitor<'a, S> for NoUnusedVariables<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn exit_document(&mut self, ctx: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {
         for (op_name, def_vars) in &self.defined_variables {
@@ -157,11 +157,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn uses_all_variables() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query ($a: String, $b: String, $c: String) {
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn uses_all_variables_deeply() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn uses_all_variables_deeply_in_inline_fragments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn uses_all_variables_in_fragments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn variable_used_by_fragment_in_multiple_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn variable_used_by_recursive_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String) {
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn variable_not_used() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query ($a: String, $b: String, $c: String) {
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn multiple_variables_not_used_1() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn variable_not_used_in_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn multiple_variables_not_used_2() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: String, $c: String) {
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn variable_not_used_by_unreferenced_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn variable_not_used_by_fragment_used_by_other_operation() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($b: String) {

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug)]
 struct Conflict(ConflictReason, Vec<SourcePosition>, Vec<SourcePosition>);
@@ -154,7 +154,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         ctx: &ValidatorContext<'a, S>,
     ) -> Vec<Conflict>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         let mut conflicts = Vec::new();
 
@@ -194,7 +194,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         mutually_exclusive: bool,
         ctx: &ValidatorContext<'a, S>,
     ) where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         if fragment_name1 == fragment_name2 {
             return;
@@ -270,7 +270,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         mutually_exclusive: bool,
         ctx: &ValidatorContext<'a, S>,
     ) where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         let fragment = match self.named_fragments.get(fragment_name) {
             Some(f) => f,
@@ -301,7 +301,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         field_map2: &AstAndDefCollection<'a, S>,
         ctx: &ValidatorContext<'a, S>,
     ) where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         for (response_name, fields1) in field_map1.iter() {
             if let Some(fields2) = field_map2.get(response_name) {
@@ -328,7 +328,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         field_map: &AstAndDefCollection<'a, S>,
         ctx: &ValidatorContext<'a, S>,
     ) where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         for (response_name, fields) in field_map.iter() {
             for (i, field1) in fields.iter().enumerate() {
@@ -352,7 +352,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         ctx: &ValidatorContext<'a, S>,
     ) -> Option<Conflict>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         let AstAndDef(ref parent_type1, ast1, ref def1) = *field1;
         let AstAndDef(ref parent_type2, ast2, ref def2) = *field2;
@@ -438,7 +438,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         ctx: &ValidatorContext<'a, S>,
     ) -> Vec<Conflict>
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         let mut conflicts = Vec::new();
 
@@ -555,7 +555,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         args2: &Option<Spanning<Arguments<S>>>,
     ) -> bool
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
     {
         match (args1, args2) {
             (&None, &None) => true,
@@ -680,7 +680,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
 
 impl<'a, S> Visitor<'a, S> for OverlappingFieldsCanBeMerged<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_document(&mut self, _: &mut ValidatorContext<'a, S>, defs: &'a Document<S>) {
         for def in defs {
@@ -745,11 +745,11 @@ mod tests {
         expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
         expect_passes_rule_with_schema, RuleError,
     };
-    use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use value::{DefaultGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue};
 
     #[test]
     fn unique_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment uniqueFields on Dog {
@@ -762,7 +762,7 @@ mod tests {
 
     #[test]
     fn identical_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment mergeIdenticalFields on Dog {
@@ -775,7 +775,7 @@ mod tests {
 
     #[test]
     fn identical_fields_with_identical_args() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
@@ -788,7 +788,7 @@ mod tests {
 
     #[test]
     fn identical_fields_with_identical_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment mergeSameFieldsWithSameDirectives on Dog {
@@ -801,7 +801,7 @@ mod tests {
 
     #[test]
     fn different_args_with_different_aliases() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment differentArgsWithDifferentAliases on Dog {
@@ -814,7 +814,7 @@ mod tests {
 
     #[test]
     fn different_directives_with_different_aliases() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment differentDirectivesWithDifferentAliases on Dog {
@@ -827,7 +827,7 @@ mod tests {
 
     #[test]
     fn different_skip_include_directives_accepted() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment differentDirectivesWithDifferentAliases on Dog {
@@ -840,7 +840,7 @@ mod tests {
 
     #[test]
     fn same_aliases_with_different_field_targets() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment sameAliasesWithDifferentFieldTargets on Dog {
@@ -863,7 +863,7 @@ mod tests {
 
     #[test]
     fn same_aliases_allowed_on_nonoverlapping_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment sameAliasesWithDifferentFieldTargets on Pet {
@@ -880,7 +880,7 @@ mod tests {
 
     #[test]
     fn alias_masking_direct_field_access() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment aliasMaskingDirectFieldAccess on Dog {
@@ -903,7 +903,7 @@ mod tests {
 
     #[test]
     fn different_args_second_adds_an_argument() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment conflictingArgs on Dog {
@@ -926,7 +926,7 @@ mod tests {
 
     #[test]
     fn different_args_second_missing_an_argument() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment conflictingArgs on Dog {
@@ -949,7 +949,7 @@ mod tests {
 
     #[test]
     fn conflicting_args() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment conflictingArgs on Dog {
@@ -972,7 +972,7 @@ mod tests {
 
     #[test]
     fn allows_different_args_where_no_conflict_is_possible() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment conflictingArgs on Pet {
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn encounters_conflict_in_fragments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1015,7 +1015,7 @@ mod tests {
 
     #[test]
     fn reports_each_conflict_once() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1068,7 +1068,7 @@ mod tests {
 
     #[test]
     fn deep_conflict() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[test]
     fn deep_conflict_with_multiple_issues() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1142,7 +1142,7 @@ mod tests {
 
     #[test]
     fn very_deep_conflict() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[test]
     fn reports_deep_conflict_to_nearest_common_ancestor() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1222,7 +1222,7 @@ mod tests {
 
     #[test]
     fn reports_deep_conflict_to_nearest_common_ancestor_in_fragments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1269,7 +1269,7 @@ mod tests {
 
     #[test]
     fn reports_deep_conflict_in_nested_fragments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -1323,7 +1323,7 @@ mod tests {
 
     #[test]
     fn ignores_unknown_fragments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
         {
@@ -1358,7 +1358,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for SomeBox
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1384,7 +1384,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for StringBox
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1416,7 +1416,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for IntBox
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1448,7 +1448,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for NonNullStringBox1
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1470,7 +1470,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for NonNullStringBox1Impl
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1501,7 +1501,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for NonNullStringBox2
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1523,7 +1523,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for NonNullStringBox2Impl
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1554,7 +1554,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for Node
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1579,7 +1579,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for Edge
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1601,7 +1601,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for Connection
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1623,7 +1623,7 @@ mod tests {
 
     impl<S> GraphQLType<S> for QueryRoot
     where
-        S: ScalarValue,
+        S: GraphQLScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
         type Context = ();
@@ -1652,7 +1652,7 @@ mod tests {
 
     #[test]
     fn conflicting_return_types_which_potentially_overlap() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1683,7 +1683,7 @@ mod tests {
 
     #[test]
     fn compatible_return_shapes_on_different_return_types() {
-        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1708,7 +1708,7 @@ mod tests {
 
     #[test]
     fn disallows_differing_return_types_despite_no_overlap() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1739,7 +1739,7 @@ mod tests {
 
     #[test]
     fn reports_correctly_when_a_non_exclusive_follows_an_exclusive() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1807,7 +1807,7 @@ mod tests {
 
     #[test]
     fn disallows_differing_return_type_nullability_despite_no_overlap() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1838,7 +1838,7 @@ mod tests {
 
     #[test]
     fn disallows_differing_return_type_list_despite_no_overlap() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1870,7 +1870,7 @@ mod tests {
             )],
         );
 
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1905,7 +1905,7 @@ mod tests {
 
     #[test]
     fn disallows_differing_subfields() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1941,7 +1941,7 @@ mod tests {
 
     #[test]
     fn disallows_differing_deep_return_types_despite_no_overlap() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -1981,7 +1981,7 @@ mod tests {
 
     #[test]
     fn allows_non_conflicting_overlapping_types() {
-        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -2002,7 +2002,7 @@ mod tests {
 
     #[test]
     fn same_wrapped_scalar_return_types() {
-        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -2023,7 +2023,7 @@ mod tests {
 
     #[test]
     fn allows_inline_typeless_fragments() {
-        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -2044,7 +2044,7 @@ mod tests {
 
     #[test]
     fn compares_deep_types_including_list() {
-        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_fails_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,
@@ -2093,7 +2093,7 @@ mod tests {
 
     #[test]
     fn ignores_unknown_types() {
-        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultScalarValue>(
+        expect_passes_rule_with_schema::<_, EmptyMutation<()>, _, _, DefaultGraphQLScalarValue>(
             QueryRoot,
             EmptyMutation::new(),
             factory,

--- a/juniper/src/validation/rules/possible_fragment_spreads.rs
+++ b/juniper/src/validation/rules/possible_fragment_spreads.rs
@@ -5,7 +5,7 @@ use parser::Spanning;
 use schema::meta::MetaType;
 use std::collections::HashMap;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct PossibleFragmentSpreads<'a, S: Debug + 'a> {
     fragment_types: HashMap<&'a str, &'a MetaType<'a, S>>,
@@ -19,7 +19,7 @@ pub fn factory<'a, S: Debug>() -> PossibleFragmentSpreads<'a, S> {
 
 impl<'a, S> Visitor<'a, S> for PossibleFragmentSpreads<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_document(&mut self, ctx: &mut ValidatorContext<'a, S>, defs: &'a Document<S>) {
@@ -102,11 +102,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn of_the_same_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectWithinObject on Dog { ...dogFragment }
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn of_the_same_object_with_inline_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectWithinObjectAnon on Dog { ... on Dog { barkVolume } }
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn object_into_an_implemented_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectWithinInterface on Pet { ...dogFragment }
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn object_into_containing_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment objectWithinUnion on CatOrDog { ...dogFragment }
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn union_into_contained_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment unionWithinObject on Dog { ...catOrDogFragment }
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn union_into_overlapping_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment unionWithinInterface on Pet { ...catOrDogFragment }
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn union_into_overlapping_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment unionWithinUnion on DogOrHuman { ...catOrDogFragment }
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn interface_into_implemented_object() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceWithinObject on Dog { ...petFragment }
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn interface_into_overlapping_interface() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceWithinInterface on Pet { ...beingFragment }
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn interface_into_overlapping_interface_in_inline_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceWithinInterface on Pet { ... on Being { name } }
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn interface_into_overlapping_union() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment interfaceWithinUnion on CatOrDog { ...petFragment }
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn different_object_into_object() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidObjectWithinObject on Cat { ...dogFragment }
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn different_object_into_object_in_inline_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidObjectWithinObjectAnon on Cat {
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn object_into_not_implementing_interface() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidObjectWithinInterface on Pet { ...humanFragment }
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn object_into_not_containing_union() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidObjectWithinUnion on CatOrDog { ...humanFragment }
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn union_into_not_contained_object() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidUnionWithinObject on Human { ...catOrDogFragment }
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn union_into_non_overlapping_interface() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidUnionWithinInterface on Pet { ...humanOrAlienFragment }
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn union_into_non_overlapping_union() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidUnionWithinUnion on CatOrDog { ...humanOrAlienFragment }
@@ -331,7 +331,7 @@ mod tests {
 
     #[test]
     fn interface_into_non_implementing_object() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidInterfaceWithinObject on Cat { ...intelligentFragment }
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn interface_into_non_overlapping_interface() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidInterfaceWithinInterface on Pet {
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn interface_into_non_overlapping_interface_in_inline_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidInterfaceWithinInterfaceAnon on Pet {
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn interface_into_non_overlapping_union() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment invalidInterfaceWithinUnion on HumanOrAlien { ...petFragment }

--- a/juniper/src/validation/rules/provided_non_null_arguments.rs
+++ b/juniper/src/validation/rules/provided_non_null_arguments.rs
@@ -3,7 +3,7 @@ use parser::Spanning;
 use schema::meta::Field as FieldType;
 use schema::model::DirectiveType;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct ProvidedNonNullArguments;
 
@@ -13,7 +13,7 @@ pub fn factory() -> ProvidedNonNullArguments {
 
 impl<'a, S> Visitor<'a, S> for ProvidedNonNullArguments
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_field(&mut self, ctx: &mut ValidatorContext<'a, S>, field: &'a Spanning<Field<S>>) {
         let field_name = &field.item.name.item;
@@ -99,11 +99,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn ignores_unknown_arguments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn arg_on_optional_arg() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn no_arg_on_optional_arg() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn multiple_args() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn multiple_args_reverse_order() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn no_args_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn one_arg_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn second_arg_on_multiple_optional() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn muliple_reqs_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn multiple_reqs_and_one_opt_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn all_reqs_on_opts_on_mixed_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn missing_one_non_nullable_argument() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn missing_multiple_non_nullable_arguments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn incorrect_value_and_missing_argument() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn ignores_unknown_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn with_directives_of_valid_types() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn with_directive_with_missing_types() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
             {

--- a/juniper/src/validation/rules/scalar_leafs.rs
+++ b/juniper/src/validation/rules/scalar_leafs.rs
@@ -1,7 +1,7 @@
 use ast::Field;
 use parser::Spanning;
 use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct ScalarLeafs;
 
@@ -11,7 +11,7 @@ pub fn factory() -> ScalarLeafs {
 
 impl<'a, S> Visitor<'a, S> for ScalarLeafs
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_field(
@@ -64,11 +64,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn valid_scalar_selection() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelection on Dog {
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn object_type_missing_selection() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query directQueryOnObjectWithoutSubFields {
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn interface_type_missing_selection() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn valid_scalar_selection_with_args() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionWithArgs on Dog {
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn scalar_selection_not_allowed_on_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionsNotAllowedOnBoolean on Dog {
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn scalar_selection_not_allowed_on_enum() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionsNotAllowedOnEnum on Cat {
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn scalar_selection_not_allowed_with_args() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionsNotAllowedWithArgs on Dog {
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn scalar_selection_not_allowed_with_directives() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionsNotAllowedWithDirectives on Dog {
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn scalar_selection_not_allowed_with_directives_and_args() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment scalarSelectionsNotAllowedWithDirectivesAndArgs on Dog {

--- a/juniper/src/validation/rules/unique_argument_names.rs
+++ b/juniper/src/validation/rules/unique_argument_names.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use ast::{Directive, Field, InputValue};
 use parser::{SourcePosition, Spanning};
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueArgumentNames<'a> {
     known_names: HashMap<&'a str, SourcePosition>,
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> UniqueArgumentNames<'a> {
 
 impl<'a, S> Visitor<'a, S> for UniqueArgumentNames<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_directive(
@@ -65,11 +65,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn no_arguments_on_field() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn no_arguments_on_directive() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn argument_on_field() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn argument_on_directive() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn same_argument_on_two_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn same_argument_on_field_and_directive() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn same_argument_on_two_directives() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn multiple_field_arguments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn multiple_directive_arguments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn duplicate_field_arguments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn many_duplicate_field_arguments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn duplicate_directive_arguments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn many_duplicate_directive_arguments() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {

--- a/juniper/src/validation/rules/unique_fragment_names.rs
+++ b/juniper/src/validation/rules/unique_fragment_names.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use ast::Fragment;
 use parser::{SourcePosition, Spanning};
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueFragmentNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> UniqueFragmentNames<'a> {
 
 impl<'a, S> Visitor<'a, S> for UniqueFragmentNames<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_fragment_definition(
@@ -49,11 +49,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn no_fragments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn one_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn many_fragments() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -110,7 +110,7 @@ mod tests {
 
     #[test]
     fn inline_fragments_always_unique() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn fragment_and_operation_named_the_same() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn fragments_named_the_same() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn fragments_named_the_same_no_reference() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog {

--- a/juniper/src/validation/rules/unique_input_field_names.rs
+++ b/juniper/src/validation/rules/unique_input_field_names.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use ast::InputValue;
 use parser::{SourcePosition, Spanning};
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueInputFieldNames<'a> {
     known_name_stack: Vec<HashMap<&'a str, SourcePosition>>,
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> UniqueInputFieldNames<'a> {
 
 impl<'a, S> Visitor<'a, S> for UniqueInputFieldNames<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_object_value(
         &mut self,
@@ -66,11 +66,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn input_object_with_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn same_input_object_within_two_args() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn multiple_input_object_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn allows_for_nested_input_objects_with_similar_fields() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn duplicate_input_object_fields() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn many_duplicate_input_object_fields() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {

--- a/juniper/src/validation/rules/unique_operation_names.rs
+++ b/juniper/src/validation/rules/unique_operation_names.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use ast::Operation;
 use parser::{SourcePosition, Spanning};
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueOperationNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> UniqueOperationNames<'a> {
 
 impl<'a, S> Visitor<'a, S> for UniqueOperationNames<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_operation_definition(
@@ -51,11 +51,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn no_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment fragA on Dog {
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn one_anon_operation() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           {
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn one_named_operation() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn multiple_operations() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn multiple_operations_of_different_types() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn fragment_and_operation_named_the_same() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn multiple_operations_of_same_name() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn multiple_ops_of_same_name_of_different_types() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo {

--- a/juniper/src/validation/rules/unique_variable_names.rs
+++ b/juniper/src/validation/rules/unique_variable_names.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::{Entry, HashMap};
 use ast::{Operation, VariableDefinition};
 use parser::{SourcePosition, Spanning};
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueVariableNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -17,7 +17,7 @@ pub fn factory<'a>() -> UniqueVariableNames<'a> {
 
 impl<'a, S> Visitor<'a, S> for UniqueVariableNames<'a>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
 
     fn enter_operation_definition(
@@ -57,11 +57,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn unique_variable_names() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query A($x: Int, $y: String) { __typename }
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn duplicate_variable_names() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query A($x: Int, $x: Int, $x: String) { __typename }

--- a/juniper/src/validation/rules/variables_are_input_types.rs
+++ b/juniper/src/validation/rules/variables_are_input_types.rs
@@ -1,7 +1,7 @@
 use ast::VariableDefinition;
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 pub struct UniqueVariableNames;
 
@@ -11,7 +11,7 @@ pub fn factory() -> UniqueVariableNames {
 
 impl<'a, S> Visitor<'a, S> for UniqueVariableNames
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_variable_definition(
         &mut self,
@@ -45,11 +45,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn input_types_are_valid() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {
@@ -61,7 +61,7 @@ mod tests {
 
     #[test]
     fn output_types_are_invalid() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition};
 use parser::Spanning;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -81,7 +81,7 @@ impl<'a, S: Debug> VariableInAllowedPosition<'a, S> {
 
 impl<'a, S> Visitor<'a, S> for VariableInAllowedPosition<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn exit_document(&mut self, ctx: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {
         for (op_scope, var_defs) in &self.variable_defs {
@@ -163,11 +163,11 @@ mod tests {
 
     use parser::SourcePosition;
     use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use value::DefaultGraphQLScalarValue;
 
     #[test]
     fn boolean_into_boolean() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($booleanArg: Boolean)
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn boolean_into_boolean_within_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment booleanArgFrag on ComplicatedArgs {
@@ -197,7 +197,7 @@ mod tests {
         "#,
         );
 
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($booleanArg: Boolean)
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn non_null_boolean_into_boolean() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($nonNullBooleanArg: Boolean!)
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn non_null_boolean_into_boolean_within_fragment() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment booleanArgFrag on ComplicatedArgs {
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn int_into_non_null_int_with_default() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($intArg: Int = 1)
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn string_list_into_string_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringListVar: [String])
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn non_null_string_list_into_string_list() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringListVar: [String!])
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn string_into_string_list_in_item_position() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringVar: String)
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn non_null_string_into_string_list_in_item_position() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringVar: String!)
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn complex_input_into_complex_input() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($complexVar: ComplexInput)
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn complex_input_into_complex_input_in_field_position() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($boolVar: Boolean = false)
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn non_null_boolean_into_non_null_boolean_in_directive() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($boolVar: Boolean!)
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn boolean_in_non_null_in_directive_with_default() {
-        expect_passes_rule::<_, _, DefaultScalarValue>(
+        expect_passes_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($boolVar: Boolean = false)
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn int_into_non_null_int() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($intArg: Int) {
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn int_into_non_null_int_within_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment nonNullIntArgFieldFrag on ComplicatedArgs {
@@ -426,7 +426,7 @@ mod tests {
 
     #[test]
     fn int_into_non_null_int_within_nested_fragment() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           fragment outerFrag on ComplicatedArgs {
@@ -455,7 +455,7 @@ mod tests {
 
     #[test]
     fn string_over_boolean() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringVar: String) {
@@ -476,7 +476,7 @@ mod tests {
 
     #[test]
     fn string_into_string_list() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringVar: String) {
@@ -497,7 +497,7 @@ mod tests {
 
     #[test]
     fn boolean_into_non_null_boolean_in_directive() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($boolVar: Boolean) {
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn string_into_non_null_boolean_in_directive() {
-        expect_fails_rule::<_, _, DefaultScalarValue>(
+        expect_fails_rule::<_, _, DefaultGraphQLScalarValue>(
             factory,
             r#"
           query Query($stringVar: String) {

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -6,7 +6,7 @@ use schema::model::{DirectiveLocation, DirectiveType, RootNode};
 use types::base::GraphQLType;
 use types::scalars::ID;
 use validation::{visit, MultiVisitorNil, RuleError, ValidatorContext, Visitor};
-use value::{ScalarRefValue, ScalarValue};
+use value::{ScalarRefValue, GraphQLScalarValue};
 
 struct Being;
 struct Pet;
@@ -62,7 +62,7 @@ struct ComplexInput {
 
 impl<S> GraphQLType<S> for Being
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -86,7 +86,7 @@ where
 
 impl<S> GraphQLType<S> for Pet
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -110,7 +110,7 @@ where
 
 impl<S> GraphQLType<S> for Canine
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -134,7 +134,7 @@ where
 
 impl<S> GraphQLType<S> for DogCommand
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -162,7 +162,7 @@ where
 
 impl<S> FromInputValue<S> for DogCommand
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value<'a>(v: &InputValue<S>) -> Option<DogCommand>
     where
@@ -179,7 +179,7 @@ where
 
 impl<S> GraphQLType<S> for Dog
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -224,7 +224,7 @@ where
 
 impl<S> GraphQLType<S> for FurColor
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -253,7 +253,7 @@ where
 
 impl<S> FromInputValue<S> for FurColor
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value<'a>(v: &InputValue<S>) -> Option<FurColor>
     where
@@ -273,7 +273,7 @@ where
 
 impl<S> GraphQLType<S> for Cat
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -306,7 +306,7 @@ where
 
 impl<S> GraphQLType<S> for CatOrDog
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -328,7 +328,7 @@ where
 
 impl<S> GraphQLType<S> for Intelligent
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -350,7 +350,7 @@ where
 
 impl<S> GraphQLType<S> for Human
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -383,7 +383,7 @@ where
 
 impl<S> GraphQLType<S> for Alien
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -416,7 +416,7 @@ where
 
 impl<S> GraphQLType<S> for DogOrHuman
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -438,7 +438,7 @@ where
 
 impl<S> GraphQLType<S> for HumanOrAlien
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -460,7 +460,7 @@ where
 
 impl<S> GraphQLType<S> for ComplexInput
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -490,7 +490,7 @@ where
 
 impl<S> FromInputValue<S> for ComplexInput
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from_input_value<'a>(v: &InputValue<S>) -> Option<ComplexInput>
     where
@@ -517,7 +517,7 @@ where
 
 impl<S> GraphQLType<S> for ComplicatedArgs
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -581,7 +581,7 @@ where
 
 impl<S> GraphQLType<S> for QueryRoot
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -615,7 +615,7 @@ where
 
 impl<S> GraphQLType<S> for MutationRoot
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     type Context = ();
@@ -647,7 +647,7 @@ where
 pub fn validate<'a, Q, M, V, F, S>(r: Q, m: M, q: &'a str, factory: F) -> Vec<RuleError>
 where
     for<'b> &'b S: ScalarRefValue<'b>,
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     Q: GraphQLType<S, TypeInfo = ()>,
     M: GraphQLType<S, TypeInfo = ()>,
     V: Visitor<'a, S> + 'a,
@@ -698,7 +698,7 @@ where
 
 pub fn expect_passes_rule<'a, V, F, S>(factory: F, q: &'a str)
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
     V: Visitor<'a, S> + 'a,
     F: Fn() -> V,
@@ -708,7 +708,7 @@ where
 
 pub fn expect_passes_rule_with_schema<'a, Q, M, V, F, S>(r: Q, m: M, factory: F, q: &'a str)
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
     Q: GraphQLType<S, TypeInfo = ()>,
     M: GraphQLType<S, TypeInfo = ()>,
@@ -725,7 +725,7 @@ where
 
 pub fn expect_fails_rule<'a, V, F, S>(factory: F, q: &'a str, expected_errors: &[RuleError])
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
     V: Visitor<'a, S> + 'a,
     F: Fn() -> V,
@@ -740,7 +740,7 @@ pub fn expect_fails_rule_with_schema<'a, Q, M, V, F, S>(
     q: &'a str,
     expected_errors: &[RuleError],
 ) where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
     Q: GraphQLType<S, TypeInfo = ()>,
     M: GraphQLType<S, TypeInfo = ()>,

--- a/juniper/src/validation/traits.rs
+++ b/juniper/src/validation/traits.rs
@@ -4,12 +4,12 @@ use ast::{
 };
 use parser::Spanning;
 use validation::ValidatorContext;
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[doc(hidden)]
 pub trait Visitor<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn enter_document(&mut self, _: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {}
     fn exit_document(&mut self, _: &mut ValidatorContext<'a, S>, _: &'a Document<S>) {}

--- a/juniper/src/validation/visitor.rs
+++ b/juniper/src/validation/visitor.rs
@@ -8,7 +8,7 @@ use parser::Spanning;
 use schema::meta::Argument;
 use validation::multi_visitor::MultiVisitorCons;
 use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use value::GraphQLScalarValue;
 
 #[doc(hidden)]
 pub fn visit<'a, A, B, S>(
@@ -16,7 +16,7 @@ pub fn visit<'a, A, B, S>(
     ctx: &mut ValidatorContext<'a, S>,
     d: &'a Document<S>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     MultiVisitorCons<A, B>: Visitor<'a, S>,
 {
     v.enter_document(ctx, d);
@@ -29,7 +29,7 @@ fn visit_definitions<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     d: &'a Vec<Definition<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     for def in d {
@@ -75,7 +75,7 @@ fn visit_definitions<'a, S, V>(
 
 fn enter_definition<'a, S, V>(v: &mut V, ctx: &mut ValidatorContext<'a, S>, def: &'a Definition<S>)
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     match *def {
@@ -86,7 +86,7 @@ where
 
 fn exit_definition<'a, S, V>(v: &mut V, ctx: &mut ValidatorContext<'a, S>, def: &'a Definition<S>)
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     match *def {
@@ -97,7 +97,7 @@ where
 
 fn visit_definition<'a, S, V>(v: &mut V, ctx: &mut ValidatorContext<'a, S>, def: &'a Definition<S>)
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     match *def {
@@ -118,7 +118,7 @@ fn visit_variable_definitions<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     defs: &'a Option<Spanning<VariableDefinitions<S>>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     if let Some(ref defs) = *defs {
@@ -143,7 +143,7 @@ fn visit_directives<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     directives: &'a Option<Vec<Spanning<Directive<S>>>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     if let Some(ref directives) = *directives {
@@ -166,7 +166,7 @@ fn visit_arguments<'a, S, V>(
     meta_args: &Option<&Vec<Argument<'a, S>>>,
     arguments: &'a Option<Spanning<Arguments<S>>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     if let Some(ref arguments) = *arguments {
@@ -191,7 +191,7 @@ fn visit_selection_set<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     selection_set: &'a Vec<Selection<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     ctx.with_pushed_parent_type(|ctx| {
@@ -210,7 +210,7 @@ fn visit_selection<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     selection: &'a Selection<S>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     match *selection {
@@ -225,7 +225,7 @@ fn visit_field<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     field: &'a Spanning<Field<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     let meta_field = ctx
@@ -254,7 +254,7 @@ fn visit_fragment_spread<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     spread: &'a Spanning<FragmentSpread<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     v.enter_fragment_spread(ctx, spread);
@@ -269,7 +269,7 @@ fn visit_inline_fragment<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     fragment: &'a Spanning<InlineFragment<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     let mut visit_fn = move |ctx: &mut ValidatorContext<'a, S>| {
@@ -299,7 +299,7 @@ fn visit_input_value<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     input_value: &'a Spanning<InputValue<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     enter_input_value(v, ctx, input_value);
@@ -347,7 +347,7 @@ fn enter_input_value<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     input_value: &'a Spanning<InputValue<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     use InputValue::*;
@@ -370,7 +370,7 @@ fn exit_input_value<'a, S, V>(
     ctx: &mut ValidatorContext<'a, S>,
     input_value: &'a Spanning<InputValue<S>>,
 ) where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     V: Visitor<'a, S>,
 {
     use InputValue::*;

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -6,7 +6,7 @@ mod scalar;
 pub use self::object::Object;
 
 pub use self::scalar::{
-    DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue,
+    DefaultGraphQLScalarValue, ParseScalarResult, ParseGraphQLScalarValue, ScalarRefValue, GraphQLScalarValue,
 };
 
 /// Serializable value returned from query and field execution.
@@ -20,7 +20,7 @@ pub use self::scalar::{
 /// than parsing a source query.
 #[derive(Debug, PartialEq, Clone)]
 #[allow(missing_docs)]
-pub enum Value<S = DefaultScalarValue> {
+pub enum Value<S = DefaultGraphQLScalarValue> {
     Null,
     Scalar(S),
     List(Vec<Value<S>>),
@@ -29,7 +29,7 @@ pub enum Value<S = DefaultScalarValue> {
 
 impl<S> Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     // CONSTRUCTORS
 
@@ -158,7 +158,7 @@ where
     }
 }
 
-impl<S: ScalarValue> ToInputValue<S> for Value<S> {
+impl<S: GraphQLScalarValue> ToInputValue<S> for Value<S> {
     fn to_input_value(&self) -> InputValue<S> {
         match *self {
             Value::Null => InputValue::Null,
@@ -183,7 +183,7 @@ impl<S: ScalarValue> ToInputValue<S> for Value<S> {
 
 impl<S, T> From<Option<T>> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     Value<S>: From<T>,
 {
     fn from(v: Option<T>) -> Value<S> {
@@ -196,7 +196,7 @@ where
 
 impl<'a, S> From<&'a str> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from(s: &'a str) -> Self {
         Value::scalar(s.to_owned())
@@ -205,7 +205,7 @@ where
 
 impl<S> From<String> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from(s: String) -> Self {
         Value::scalar(s)
@@ -214,7 +214,7 @@ where
 
 impl<S> From<i32> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from(i: i32) -> Self {
         Value::scalar(i)
@@ -223,7 +223,7 @@ where
 
 impl<S> From<f64> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from(f: f64) -> Self {
         Value::scalar(f)
@@ -232,7 +232,7 @@ where
 
 impl<S> From<bool> for Value<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn from(b: bool) -> Self {
         Value::scalar(b)
@@ -248,8 +248,8 @@ where
 /// passed in.
 /// ```rust
 /// #[macro_use] extern crate juniper;
-/// # use juniper::{Value, DefaultScalarValue};
-/// # type V = Value<DefaultScalarValue>;
+/// # use juniper::{Value, DefaultGraphQLScalarValue};
+/// # type V = Value<DefaultGraphQLScalarValue>;
 ///
 /// # fn main() {
 /// # let _: V =
@@ -284,39 +284,39 @@ mod tests {
 
     #[test]
     fn value_macro_string() {
-        let s: Value<DefaultScalarValue> = graphql_value!("test");
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!("test");
         assert_eq!(s, Value::scalar("test"));
     }
 
     #[test]
     fn value_macro_int() {
-        let s: Value<DefaultScalarValue> = graphql_value!(123);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!(123);
         assert_eq!(s, Value::scalar(123));
     }
 
     #[test]
     fn value_macro_float() {
-        let s: Value<DefaultScalarValue> = graphql_value!(123.5);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!(123.5);
         assert_eq!(s, Value::scalar(123.5));
     }
 
     #[test]
     fn value_macro_boolean() {
-        let s: Value<DefaultScalarValue> = graphql_value!(false);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!(false);
         assert_eq!(s, Value::scalar(false));
     }
 
     #[test]
     fn value_macro_option() {
-        let s: Value<DefaultScalarValue> = graphql_value!(Some("test"));
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!(Some("test"));
         assert_eq!(s, Value::scalar("test"));
-        let s: Value<DefaultScalarValue> = graphql_value!(None);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!(None);
         assert_eq!(s, Value::null());
     }
 
     #[test]
     fn value_macro_list() {
-        let s: Value<DefaultScalarValue> = graphql_value!([123, "Test", false]);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!([123, "Test", false]);
         assert_eq!(
             s,
             Value::list(vec![
@@ -325,7 +325,7 @@ mod tests {
                 Value::scalar(false),
             ])
         );
-        let s: Value<DefaultScalarValue> = graphql_value!([123, [456], 789]);
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!([123, [456], 789]);
         assert_eq!(
             s,
             Value::list(vec![
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn value_macro_object() {
-        let s: Value<DefaultScalarValue> = graphql_value!({ "key": 123, "next": true });
+        let s: Value<DefaultGraphQLScalarValue> = graphql_value!({ "key": 123, "next": true });
         assert_eq!(
             s,
             Value::object(

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -208,7 +208,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
 
     let body = quote! {
         impl<__S> #juniper_path::GraphQLType<__S> for #ident
-        where __S: #juniper_path::ScalarValue,
+        where __S: #juniper_path::GraphQLScalarValue,
             for<'__b> &'__b __S: #juniper_path::ScalarRefValue<'__b>
         {
             type Context = ();
@@ -241,7 +241,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
             }
         }
 
-        impl<__S: #juniper_path::ScalarValue> #juniper_path::FromInputValue<__S> for #ident {
+        impl<__S: #juniper_path::GraphQLScalarValue> #juniper_path::FromInputValue<__S> for #ident {
             fn from_input_value(v: &#juniper_path::InputValue<__S>) -> Option<#ident>
                 where for<'__b> &'__b __S: #juniper_path::ScalarRefValue<'__b>
             {
@@ -254,7 +254,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
             }
         }
 
-        impl<__S: #juniper_path::ScalarValue> #juniper_path::ToInputValue<__S> for #ident {
+        impl<__S: #juniper_path::GraphQLScalarValue> #juniper_path::ToInputValue<__S> for #ident {
             fn to_input_value(&self) -> #juniper_path::InputValue<__S> {
                 match self {
                     #(#to_inputs)*

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -266,7 +266,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput, is_internal: bool) -> TokenStre
             let where_clause = generics.where_clause.get_or_insert(parse_quote!(where));
             where_clause
                 .predicates
-                .push(parse_quote!(__S: #juniper_path::ScalarValue));
+                .push(parse_quote!(__S: #juniper_path::GraphQLScalarValue));
             where_clause
                 .predicates
                 .push(parse_quote!(for<'__b> &'__b __S: #juniper_path::ScalarRefValue<'__b>));

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -212,7 +212,7 @@ pub fn impl_object(ast: &syn::DeriveInput) -> TokenStream {
             let where_clause = generics.where_clause.get_or_insert(parse_quote!(where));
             where_clause
                 .predicates
-                .push(parse_quote!(__S: juniper::ScalarValue));
+                .push(parse_quote!(__S: juniper::GraphQLScalarValue));
             where_clause
                 .predicates
                 .push(parse_quote!(for<'__b> &'__b __S: juniper::ScalarRefValue<'__b>));

--- a/juniper_codegen/src/derive_scalar_value.rs
+++ b/juniper_codegen/src/derive_scalar_value.rs
@@ -8,7 +8,7 @@ pub fn impl_scalar_value(ast: &syn::DeriveInput, is_internal: bool) -> TokenStre
     let variants = match ast.data {
         Data::Enum(ref enum_data) => &enum_data.variants,
         _ => {
-            panic!("#[derive(ScalarValue)] may only be applied to enums, not to structs");
+            panic!("#[derive(GraphQLScalarValue)] may only be applied to enums, not to structs");
         }
     };
 

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -61,7 +61,7 @@ pub fn derive_object(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-#[proc_macro_derive(ScalarValue)]
+#[proc_macro_derive(GraphQLScalarValue)]
 pub fn derive_scalar_value(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_scalar_value::impl_scalar_value(&ast, false);

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -17,7 +17,7 @@ use hyper::rt::Stream;
 use hyper::{header, Body, Method, Request, Response, StatusCode};
 use juniper::http::GraphQLRequest as JuniperGraphQLRequest;
 use juniper::serde::Deserialize;
-use juniper::{DefaultScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue};
+use juniper::{DefaultGraphQLScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, GraphQLScalarValue};
 use serde_json::error::Error as SerdeError;
 use std::error::Error;
 use std::fmt;
@@ -32,7 +32,7 @@ pub fn graphql<CtxT, QueryT, MutationT, S>(
     request: Request<Body>,
 ) -> impl Future<Item = Response<Body>, Error = hyper::Error>
 where
-    S: ScalarValue + Send + Sync + 'static,
+    S: GraphQLScalarValue + Send + Sync + 'static,
     for<'b> &'b S: ScalarRefValue<'b>,
     CtxT: Send + Sync + 'static,
     QueryT: GraphQLType<S, Context = CtxT> + Send + Sync + 'static,
@@ -102,7 +102,7 @@ fn execute_request<CtxT, QueryT, MutationT, S>(
     request: GraphQLRequest<S>,
 ) -> impl Future<Item = Response<Body>, Error = tokio_threadpool::BlockingError>
 where
-    S: ScalarValue + Send + Sync + 'static,
+    S: GraphQLScalarValue + Send + Sync + 'static,
     for<'b> &'b S: ScalarRefValue<'b>,
     CtxT: Send + Sync + 'static,
     QueryT: GraphQLType<S, Context = CtxT> + Send + Sync + 'static,
@@ -128,7 +128,7 @@ where
 
 fn gql_request_from_get<S>(input: &str) -> Result<JuniperGraphQLRequest<S>, GraphQLRequestError>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     let mut query = None;
     let operation_name = None;
@@ -193,9 +193,9 @@ fn new_html_response(code: StatusCode) -> Response<Body> {
 #[derive(Deserialize)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
-enum GraphQLRequest<S = DefaultScalarValue>
+enum GraphQLRequest<S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(JuniperGraphQLRequest<S>),
     Batch(Vec<JuniperGraphQLRequest<S>>),
@@ -203,7 +203,7 @@ where
 
 impl<S> GraphQLRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     fn execute<'a, CtxT: 'a, QueryT, MutationT>(

--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -128,14 +128,14 @@ use serde_json::error::Error as SerdeError;
 
 use juniper::http;
 use juniper::serde::Deserialize;
-use juniper::{DefaultScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue};
+use juniper::{DefaultGraphQLScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, GraphQLScalarValue};
 
 #[derive(Deserialize)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
-enum GraphQLBatchRequest<S = DefaultScalarValue>
+enum GraphQLBatchRequest<S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(http::GraphQLRequest<S>),
     Batch(Vec<http::GraphQLRequest<S>>),
@@ -143,9 +143,9 @@ where
 
 #[derive(Serialize)]
 #[serde(untagged)]
-enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
+enum GraphQLBatchResponse<'a, S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(http::GraphQLResponse<'a, S>),
     Batch(Vec<http::GraphQLResponse<'a, S>>),
@@ -153,7 +153,7 @@ where
 
 impl<S> GraphQLBatchRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     pub fn execute<'a, CtxT, QueryT, MutationT>(
@@ -181,7 +181,7 @@ where
 
 impl<'a, S> GraphQLBatchResponse<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn is_ok(&self) -> bool {
         match self {
@@ -203,9 +203,9 @@ where
 /// this endpoint containing the field `"query"` and optionally `"variables"`.
 /// The variables should be a JSON object containing the variable to value
 /// mapping.
-pub struct GraphQLHandler<'a, CtxFactory, Query, Mutation, CtxT, S = DefaultScalarValue>
+pub struct GraphQLHandler<'a, CtxFactory, Query, Mutation, CtxT, S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
     CtxFactory: Fn(&mut Request) -> IronResult<CtxT> + Send + Sync + 'static,
     CtxT: 'static,
@@ -239,7 +239,7 @@ fn parse_url_param(params: Option<Vec<String>>) -> IronResult<Option<String>> {
 
 fn parse_variable_param<S>(params: Option<Vec<String>>) -> IronResult<Option<InputValue<S>>>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     if let Some(values) = params {
         Ok(
@@ -255,7 +255,7 @@ where
 impl<'a, CtxFactory, Query, Mutation, CtxT, S>
     GraphQLHandler<'a, CtxFactory, Query, Mutation, CtxT, S>
 where
-    S: ScalarValue + 'a,
+    S: GraphQLScalarValue + 'a,
     for<'b> &'b S: ScalarRefValue<'b>,
     CtxFactory: Fn(&mut Request) -> IronResult<CtxT> + Send + Sync + 'static,
     CtxT: 'static,
@@ -330,7 +330,7 @@ impl GraphiQLHandler {
 impl<'a, CtxFactory, Query, Mutation, CtxT, S> Handler
     for GraphQLHandler<'a, CtxFactory, Query, Mutation, CtxT, S>
 where
-    S: ScalarValue + Sync + Send + 'static,
+    S: GraphQLScalarValue + Sync + Send + 'static,
     for<'b> &'b S: ScalarRefValue<'b>,
     CtxFactory: Fn(&mut Request) -> IronResult<CtxT> + Send + Sync + 'static,
     CtxT: 'static,

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -59,19 +59,19 @@ use juniper::http;
 use juniper::InputValue;
 
 use juniper::serde::Deserialize;
-use juniper::DefaultScalarValue;
+use juniper::DefaultGraphQLScalarValue;
 use juniper::FieldError;
 use juniper::GraphQLType;
 use juniper::RootNode;
 use juniper::ScalarRefValue;
-use juniper::ScalarValue;
+use juniper::GraphQLScalarValue;
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
-enum GraphQLBatchRequest<S = DefaultScalarValue>
+enum GraphQLBatchRequest<S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(http::GraphQLRequest<S>),
     Batch(Vec<http::GraphQLRequest<S>>),
@@ -79,9 +79,9 @@ where
 
 #[derive(Serialize)]
 #[serde(untagged)]
-enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
+enum GraphQLBatchResponse<'a, S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(http::GraphQLResponse<'a, S>),
     Batch(Vec<http::GraphQLResponse<'a, S>>),
@@ -89,7 +89,7 @@ where
 
 impl<S> GraphQLBatchRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     pub fn execute<'a, CtxT, QueryT, MutationT>(
@@ -117,7 +117,7 @@ where
 
 impl<'a, S> GraphQLBatchResponse<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn is_ok(&self) -> bool {
         match self {
@@ -135,9 +135,9 @@ where
 /// automatically from both GET and POST routes by implementing the `FromForm`
 /// and `FromData` traits.
 #[derive(Debug, PartialEq)]
-pub struct GraphQLRequest<S = DefaultScalarValue>(GraphQLBatchRequest<S>)
+pub struct GraphQLRequest<S = DefaultGraphQLScalarValue>(GraphQLBatchRequest<S>)
 where
-    S: ScalarValue;
+    S: GraphQLScalarValue;
 
 /// Simple wrapper around the result of executing a GraphQL query
 pub struct GraphQLResponse(pub Status, pub String);
@@ -149,7 +149,7 @@ pub fn graphiql_source(graphql_endpoint_url: &str) -> content::Html<String> {
 
 impl<S> GraphQLRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     /// Execute an incoming GraphQL query
@@ -230,7 +230,7 @@ impl GraphQLResponse {
 
 impl<'f, S> FromForm<'f> for GraphQLRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     type Error = String;
 
@@ -300,7 +300,7 @@ where
 }
 
 impl<'v, S> FromFormValue<'v> for GraphQLRequest<S>
-    where S: ScalarValue
+    where S: GraphQLScalarValue
 {
     type Error = String;
 
@@ -313,7 +313,7 @@ impl<'v, S> FromFormValue<'v> for GraphQLRequest<S>
 
 impl<S> FromDataSimple for GraphQLRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     type Error = String;
 

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -54,7 +54,7 @@ extern crate warp;
 extern crate percent_encoding;
 
 use futures::{future::poll_fn, Future};
-use juniper::{DefaultScalarValue, InputValue, ScalarRefValue, ScalarValue};
+use juniper::{DefaultGraphQLScalarValue, InputValue, ScalarRefValue, GraphQLScalarValue};
 use serde::Deserialize;
 use std::sync::Arc;
 use warp::{filters::BoxedFilter, Filter};
@@ -62,9 +62,9 @@ use warp::{filters::BoxedFilter, Filter};
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
-enum GraphQLBatchRequest<S = DefaultScalarValue>
+enum GraphQLBatchRequest<S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(juniper::http::GraphQLRequest<S>),
     Batch(Vec<juniper::http::GraphQLRequest<S>>),
@@ -72,7 +72,7 @@ where
 
 impl<S> GraphQLBatchRequest<S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
     for<'b> &'b S: ScalarRefValue<'b>,
 {
     pub fn execute<'a, CtxT, QueryT, MutationT>(
@@ -100,9 +100,9 @@ where
 
 #[derive(Serialize)]
 #[serde(untagged)]
-enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
+enum GraphQLBatchResponse<'a, S = DefaultGraphQLScalarValue>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     Single(juniper::http::GraphQLResponse<'a, S>),
     Batch(Vec<juniper::http::GraphQLResponse<'a, S>>),
@@ -110,7 +110,7 @@ where
 
 impl<'a, S> GraphQLBatchResponse<'a, S>
 where
-    S: ScalarValue,
+    S: GraphQLScalarValue,
 {
     fn is_ok(&self) -> bool {
         match self {
@@ -183,7 +183,7 @@ pub fn make_graphql_filter<Query, Mutation, Context, S>(
     context_extractor: BoxedFilter<(Context,)>,
 ) -> BoxedFilter<(warp::http::Response<Vec<u8>>,)>
 where
-    S: ScalarValue + Send + Sync + 'static,
+    S: GraphQLScalarValue + Send + Sync + 'static,
     for<'b> &'b S: ScalarRefValue<'b>,
     Context: Send + 'static,
     Query: juniper::GraphQLType<S, Context = Context, TypeInfo = ()> + Send + Sync + 'static,


### PR DESCRIPTION
- The `ScalarValue` derive has been renamed to `GraphQLScalarValue`.
- The `DefaultScalarValue` enum has been renamed to `DefaultGraphQLScalarValue`.

Fixes https://github.com/graphql-rust/juniper/issues/299.