### PR TITLE
Fix the literal value of DirectiveLocation::InlineFragment

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - The minimum required Rust version is now `1.30.0`.
 - The `ScalarValue` custom derive has been renamed to `GraphQLScalarValue`.
+- Fix introspection query validity
+    The DirectiveLocation::InlineFragment had an invalid literal value,
+    which broke third party tools like apollo cli.
 
 # [0.11.1] 2018-12-19
 

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -67,7 +67,7 @@ pub enum DirectiveLocation {
     FragmentDefinition,
     #[graphql(name = "FRAGMENT_SPREAD")]
     FragmentSpread,
-    #[graphql(name = "INLINE_SPREAD")]
+    #[graphql(name = "INLINE_FRAGMENT")]
     InlineFragment,
 }
 

--- a/juniper/src/tests/introspection_tests.rs
+++ b/juniper/src/tests/introspection_tests.rs
@@ -141,6 +141,50 @@ fn test_introspection_documentation() {
 }
 
 #[test]
+fn test_introspection_directives() {
+    let q = r#"
+        query IntrospectionQuery {
+          __schema {
+            directives {
+              name
+              locations
+            }
+          }
+        }
+    "#;
+
+    let database = Database::new();
+    let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
+
+    let result = ::execute(q, None, &schema, &Variables::new(), &database).unwrap();
+
+    let expected = graphql_value!({
+        "__schema": {
+            "directives": [
+                {
+                    "name": "skip",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT",
+                    ],
+                },
+                {
+                    "name": "include",
+                    "locations": [
+                        "FIELD",
+                        "FRAGMENT_SPREAD",
+                        "INLINE_FRAGMENT",
+                    ],
+                },
+            ],
+        },
+    });
+
+    assert_eq!(result, (expected, vec![]));
+}
+
+#[test]
 fn test_introspection_possible_types() {
     let doc = r#"
         query IntrospectionDroidDescriptionQuery {


### PR DESCRIPTION
The literal value according to the standard is INLINE_FRAGMENT,
not INLINE_SPREAD.

This oversight leads to invalid introspection schemas and trips up
third party tools.

Closes #305 