### PR TITLE
Fix Azure Pipelines formatting job display name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,16 +1,17 @@
 jobs:
 
 - job: check_formatting
+  displayName: Check formatting
   pool:
     vmImage: ubuntu-16.04
   steps:
     - script: |
         curl https://sh.rustup.rs -sSf | sh -s -- -y
         $HOME/.cargo/bin/rustup component add rustfmt
-      displayName: Install rust
+      displayName: Install stable Rust
     - script: |
         $HOME/.cargo/bin/cargo fmt -- --check
-      displayName: Check formatting
+      displayName: Run rustfmt
 
 - template: _build/azure-pipelines-template.yml
   parameters:


### PR DESCRIPTION
This was showing up as `check_formatting Job`, see https://dev.azure.com/graphql-rust/GraphQL%20Rust/_build/results?buildId=162