### PR TITLE
Fix broken docs links

### DIFF
--- a/docs/book/content/advanced/index.md
+++ b/docs/book/content/advanced/index.md
@@ -2,7 +2,7 @@
 
 The chapters below cover some more advanced scenarios.
 
-- [Introspection](advanced/introspection.md)
-- [Non-struct objects](advanced/non_struct_objects.md)
-- [Objects and generics](advanced/objects_and_generics.md)
-- [Multiple operations per request](advanced/multiple_ops_per_request.md)
+- [Introspection](introspection.md)
+- [Non-struct objects](non_struct_objects.md)
+- [Objects and generics](objects_and_generics.md)
+- [Multiple operations per request](multiple_ops_per_request.md)

--- a/docs/book/content/schema/schemas_and_mutations.md
+++ b/docs/book/content/schema/schemas_and_mutations.md
@@ -9,8 +9,8 @@ other object in Juniper. The mutation object, however, is optional since schemas
 can be read-only.
 
 In Juniper, the `RootNode` type represents a schema. You usually don't have to
-create this object yourself: see the framework integrations for [Iron](iron.md)
-and [Rocket](rocket.md) how schemas are created together with the handlers
+create this object yourself: see the framework integrations for [Iron](../servers/iron.md)
+and [Rocket](../servers/rocket.md) how schemas are created together with the handlers
 themselves.
 
 When the schema is first created, Juniper will traverse the entire object graph

--- a/docs/book/content/servers/index.md
+++ b/docs/book/content/servers/index.md
@@ -6,12 +6,13 @@ it does **not** come with a built in HTTP server.
 To actually get a server up and running, there are multiple official and 
 third-party integration crates that will get you there.
 
-- [Official Server Integrations](servers/official.md) - [Hyper](servers/hyper.md)
-    - [Warp](servers/warp.md)
-    - [Rocket](servers/rocket.md)
-    - [Iron](servers/iron.md)
-    - [Hyper](servers/hyper.md)
-- [Third Party Integrations](servers/third-party.md)
+- [Official Server Integrations](official.md)
+    - [Hyper](hyper.md)
+    - [Warp](warp.md)
+    - [Rocket](rocket.md)
+    - [Iron](iron.md)
+    - [Hyper](hyper.md)
+- [Third Party Integrations](third-party.md)
     - [Actix-Web](https://github.com/actix/examples/tree/master/juniper)
     - [Finchers](https://github.com/finchers-rs/finchers-juniper)
     - [Tsukuyomi](https://github.com/tsukuyomi-rs/tsukuyomi/tree/master/examples/juniper)

--- a/docs/book/content/servers/iron.md
+++ b/docs/book/content/servers/iron.md
@@ -75,8 +75,7 @@ fn main() {
 ## Accessing data from the request
 
 If you want to access e.g. the source IP address of the request from a field
-resolver, you need to pass this data using Juniper's [context
-feature](context.md).
+resolver, you need to pass this data using Juniper's [context feature](../types/objects/using_contexts.md).
 
 ```rust,ignore
 # extern crate juniper;

--- a/docs/book/content/servers/official.md
+++ b/docs/book/content/servers/official.md
@@ -3,7 +3,7 @@
 Juniper provides official integration crates for several popular Rust server
 libraries.
 
-- [Hyper](./hyper.md)
-- [Warp](./warp.md)
-- [Rocket](./rocket.md)
-- [Iron](./iron.md)
+- [Hyper](hyper.md)
+- [Warp](warp.md)
+- [Rocket](rocket.md)
+- [Iron](iron.md)

--- a/docs/book/content/types/enums.md
+++ b/docs/book/content/types/enums.md
@@ -18,7 +18,7 @@ enum Episode {
 Juniper converts all enum variants to uppercase, so the corresponding string
 values for these variants are `NEWHOPE`, `EMPIRE`, and `JEDI`, respectively. If
 you want to override this, you can use the `graphql` attribute, similar to how
-it works when [defining objects](defining_objects.md):
+it works when [defining objects](objects/defining_objects.md):
 
 ```rust
 #[derive(juniper::GraphQLEnum)]

--- a/docs/book/content/types/index.md
+++ b/docs/book/content/types/index.md
@@ -8,13 +8,13 @@ as painless as possible.
 
 Find out more in the individual chapters below.
 
-- [Defining objects](types/objects/defining_objects.md)
-  - [Complex fields](types/objects/complex_fields.md)
-  - [Using contexts](types/objects/using_contexts.md)
-  - [Error handling](types/objects/error_handling.md)
-- [Other types](types/other-index.md)
-  - [Enums](types/enums.md)
-  - [Interfaces](types/interfaces.md)
-  - [Input objects](types/input_objects.md)
-  - [Scalars](types/scalars.md)
-  - [Unions](types/unions.md)
+- [Defining objects](objects/defining_objects.md)
+  - [Complex fields](objects/complex_fields.md)
+  - [Using contexts](objects/using_contexts.md)
+  - [Error handling](objects/error_handling.md)
+- [Other types](other-index.md)
+  - [Enums](enums.md)
+  - [Interfaces](interfaces.md)
+  - [Input objects](input_objects.md)
+  - [Scalars](scalars.md)
+  - [Unions](unions.md)

--- a/docs/book/content/types/input_objects.md
+++ b/docs/book/content/types/input_objects.md
@@ -26,7 +26,7 @@ juniper::graphql_object!(Root: () |&self| {
 
 ## Documentation and renaming
 
-Just like the [other](defining_objects.md) [derives](enums.md), you can rename
+Just like the [other](objects/defining_objects.md) [derives](enums.md), you can rename
 and add documentation to both the type and the fields:
 
 ```rust

--- a/docs/book/content/types/objects/using_contexts.md
+++ b/docs/book/content/types/objects/using_contexts.md
@@ -4,7 +4,7 @@ The context type is a feature in Juniper that lets field resolvers access global
 data, most commonly database connections or authentication information. The
 context is usually created from a _context factory_. How this is defined is
 specific to the framework integration you're using, so check out the
-documentation for either the [Iron](iron.md) or [Rocket](rocket.md)
+documentation for either the [Iron](../../servers/iron.md) or [Rocket](../../servers/rocket.md)
 integration.
 
 In this chapter, we'll show you how to define a context type and use it in field

--- a/docs/book/content/types/other-index.md
+++ b/docs/book/content/types/other-index.md
@@ -4,8 +4,8 @@ The GraphQL type system provides several types in additon to objects.
 
 Find out more about each type below:
 
-- [Enums](./enums.md)
-- [Interfaces](./interfaces.md)
-- [Input objects](./input_objects.md)
-- [Scalars](./scalars.md)
-- [Unions](./unions.md)
+- [Enums](enums.md)
+- [Interfaces](interfaces.md)
+- [Input objects](input_objects.md)
+- [Scalars](scalars.md)
+- [Unions](unions.md)


### PR DESCRIPTION
This PR fixes many links on the documentation that were broken because they were not using the correct relative paths.