### PR TITLE
Refactor to 2018 edition + some clippy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ rust:
   - nightly
 
   # Prevent accidentally breaking older Rust versions
+  - 1.32.0
   - 1.31.0
-  - 1.30.0
 
 matrix:
   include:

--- a/_build/azure-pipelines-template.yml
+++ b/_build/azure-pipelines-template.yml
@@ -11,9 +11,9 @@ jobs:
       nightly:
         rustup_toolchain: nightly
       minimum_supported_version_plus_one:
-        rustup_toolchain: 1.31.0
+        rustup_toolchain: 1.32.0
       minimum_supported_version:
-        rustup_toolchain: 1.30.0
+        rustup_toolchain: 1.31.0
   steps:
   - ${{ if ne(parameters.name, 'Windows') }}:
     # Linux and macOS.

--- a/docs/book/content/quickstart.md
+++ b/docs/book/content/quickstart.md
@@ -127,8 +127,7 @@ You can invoke `juniper::execute` directly to run a GraphQL query:
 
 ```rust
 # // Only needed due to 2018 edition because the macro is not accessible.
-# #[macro_use]
-# extern crate juniper;
+# #[macro_use] extern crate juniper;
 use juniper::{FieldResult, Variables, EmptyMutation};
 
 #[derive(juniper::GraphQLEnum, Clone, Copy)]

--- a/docs/book/content/types/objects/error_handling.md
+++ b/docs/book/content/types/objects/error_handling.md
@@ -129,7 +129,7 @@ impl juniper::IntoFieldError for CustomError {
         match self {
             CustomError::WhateverNotSet => juniper::FieldError::new(
                 "Whatever does not exist",
-                juniper::graphql_value!({
+                graphql_value!({
                     "type": "NO_WHATEVER"
                 }),
             ),

--- a/integration_tests/juniper_tests/Cargo.toml
+++ b/integration_tests/juniper_tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "juniper_tests"
 version = "0.1.0"
 publish = false
+edition = "2018"
 
 [dependencies]
 juniper = { version = "0.11.0", path = "../../juniper" }

--- a/integration_tests/juniper_tests/src/codegen/derive_enum.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_enum.rs
@@ -4,7 +4,7 @@ use fnv::FnvHashMap;
 #[cfg(test)]
 use juniper::{self, DefaultScalarValue, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
-#[derive(GraphQLEnum, Debug, PartialEq)]
+#[derive(juniper::GraphQLEnum, Debug, PartialEq)]
 #[graphql(name = "Some", description = "enum descr")]
 enum SomeEnum {
     Regular,
@@ -13,7 +13,7 @@ enum SomeEnum {
 }
 
 /// Enum doc.
-#[derive(GraphQLEnum)]
+#[derive(juniper::GraphQLEnum)]
 enum DocEnum {
     /// Variant doc.
     Foo,
@@ -23,7 +23,7 @@ enum DocEnum {
 /// Doc 2.
 ///
 /// Doc 4.
-#[derive(GraphQLEnum, Debug, PartialEq)]
+#[derive(juniper::GraphQLEnum, Debug, PartialEq)]
 enum MultiDocEnum {
     /// Variant 1.
     /// Variant 2.
@@ -31,7 +31,7 @@ enum MultiDocEnum {
 }
 
 /// This is not used as the description.
-#[derive(GraphQLEnum, Debug, PartialEq)]
+#[derive(juniper::GraphQLEnum, Debug, PartialEq)]
 #[graphql(description = "enum override")]
 enum OverrideDocEnum {
     /// This is not used as the description.

--- a/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 use fnv::FnvHashMap;
 
-use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
-use juniper::GraphQLInputObject;
 use juniper::DefaultScalarValue;
+use juniper::GraphQLInputObject;
+use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
 #[graphql(

--- a/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
@@ -2,7 +2,7 @@
 use fnv::FnvHashMap;
 
 use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
-
+use juniper::GraphQLInputObject;
 use juniper::DefaultScalarValue;
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
@@ -103,7 +103,7 @@ fn test_derived_input_object() {
 
     // Test default value injection.
 
-    let input_no_defaults: InputValue = ::serde_json::from_value(json!({
+    let input_no_defaults: InputValue = ::serde_json::from_value(serde_json::json!({
         "regularField": "a",
     }))
     .unwrap();
@@ -120,7 +120,7 @@ fn test_derived_input_object() {
 
     // Test with all values supplied.
 
-    let input: InputValue = ::serde_json::from_value(json!({
+    let input: InputValue = ::serde_json::from_value(serde_json::json!({
         "regularField": "a",
         "haha": 55,
         "other": true,

--- a/integration_tests/juniper_tests/src/codegen/derive_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object.rs
@@ -3,6 +3,7 @@ use fnv::FnvHashMap;
 use juniper::DefaultScalarValue;
 #[cfg(test)]
 use juniper::Object;
+use juniper::GraphQLObject;
 
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};
@@ -79,7 +80,7 @@ struct WithCustomContext {
     a: bool,
 }
 
-graphql_object!(Query: () |&self| {
+juniper::graphql_object!(Query: () |&self| {
     field obj() -> Obj {
       Obj{
         regular_field: true,

--- a/integration_tests/juniper_tests/src/codegen/derive_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 use fnv::FnvHashMap;
 use juniper::DefaultScalarValue;
+use juniper::GraphQLObject;
 #[cfg(test)]
 use juniper::Object;
-use juniper::GraphQLObject;
 
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};

--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -9,7 +9,7 @@ use juniper::{execute, EmptyMutation, Object, RootNode, Variables};
 use juniper::{InputValue, ParseScalarResult, ScalarValue, Value};
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, GraphQLScalarValue)]
+#[derive(Debug, Clone, PartialEq, juniper::GraphQLScalarValue)]
 enum MyScalarValue {
     Int(i32),
     Long(i64),
@@ -126,7 +126,7 @@ impl<'de> de::Visitor<'de> for MyScalarValueVisitor {
     }
 }
 
-graphql_scalar!(i64 as "Long" where Scalar = MyScalarValue {
+juniper::graphql_scalar!(i64 as "Long" where Scalar = MyScalarValue {
     resolve(&self) -> Value {
         Value::scalar(*self)
     }
@@ -151,7 +151,7 @@ graphql_scalar!(i64 as "Long" where Scalar = MyScalarValue {
 
 struct TestType;
 
-graphql_object!(TestType: () where Scalar = MyScalarValue |&self| {
+juniper::graphql_object!(TestType: () where Scalar = MyScalarValue |&self| {
     field long_field()  -> i64 {
         (::std::i32::MAX as i64) + 1
     }

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -1,7 +1,5 @@
-#[macro_use]
 extern crate juniper;
 #[cfg(test)]
-#[macro_use]
 extern crate serde_json;
 
 #[cfg(test)]

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
-- The minimum required Rust version is now `1.30.0`.
+- Refactored all crates to the 2018 editio [#345](https://github.com/graphql-rust/juniper/pull/345)
+- The minimum required Rust version is now `1.31.0`.
 - The `ScalarValue` custom derive has been renamed to `GraphQLScalarValue`.
 - Added built-in support for the canonical schema introspection query via
   `juniper::introspect()`. [#307](https://github.com/graphql-rust/juniper/issues/307)

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/graphql-rust/juniper"
 readme = "../README.md"
 keywords = ["graphql", "server", "web", "rocket"]
 categories = ["web-programming"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "graphql-rust/juniper" }

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -6,9 +6,9 @@ use std::vec;
 
 use indexmap::IndexMap;
 
-use executor::Variables;
-use parser::Spanning;
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use crate::executor::Variables;
+use crate::parser::Spanning;
+use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
 /// A type literal in the syntax tree
 ///
@@ -434,7 +434,7 @@ where
 
     /// Compare equality with another `InputValue` ignoring any source position information.
     pub fn unlocated_eq(&self, other: &Self) -> bool {
-        use InputValue::*;
+        use crate::InputValue::*;
 
         match (self, other) {
             (&Null, &Null) => true,
@@ -533,7 +533,7 @@ impl<'a, S> VariableDefinitions<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::InputValue;
-    use parser::Spanning;
+    use crate::parser::Spanning;
 
     #[test]
     fn test_input_value_fmt() {

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -352,7 +352,7 @@ where
     where
         &'a S: Into<Option<&'a i32>>,
     {
-        self.as_scalar_value().map(|i| *i)
+        self.as_scalar_value().cloned()
     }
 
     /// View the underlying float value, if present.
@@ -361,7 +361,7 @@ where
     where
         &'a S: Into<Option<&'a f64>>,
     {
-        self.as_scalar_value().map(|f| *f)
+        self.as_scalar_value().cloned()
     }
 
     /// View the underlying string value, if present.

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -391,9 +391,9 @@ mod tests {
     use crate::ast::Document;
     use crate::parser::UnlocatedParseResult;
     use crate::schema::model::SchemaType;
-    use std::collections::HashMap;
     use crate::validation::test_harness::{MutationRoot, QueryRoot};
     use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use std::collections::HashMap;
 
     fn parse_document_source<S>(q: &str) -> UnlocatedParseResult<Document<S>>
     where

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -1,6 +1,6 @@
-use ast::{Directive, Fragment, InputValue, Selection};
-use parser::Spanning;
-use value::{ScalarRefValue, ScalarValue};
+use crate::ast::{Directive, Fragment, InputValue, Selection};
+use crate::parser::Spanning;
+use crate::value::{ScalarRefValue, ScalarValue};
 
 use std::collections::HashMap;
 
@@ -388,25 +388,25 @@ impl<'a, S> LookAheadMethods<S> for LookAheadSelection<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ast::Document;
-    use parser::UnlocatedParseResult;
-    use schema::model::SchemaType;
+    use crate::ast::Document;
+    use crate::parser::UnlocatedParseResult;
+    use crate::schema::model::SchemaType;
     use std::collections::HashMap;
-    use validation::test_harness::{MutationRoot, QueryRoot};
-    use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use crate::validation::test_harness::{MutationRoot, QueryRoot};
+    use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
     fn parse_document_source<S>(q: &str) -> UnlocatedParseResult<Document<S>>
     where
         S: ScalarValue,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
-        ::parse_document_source(q, &SchemaType::new::<QueryRoot, MutationRoot>(&(), &()))
+        crate::parse_document_source(q, &SchemaType::new::<QueryRoot, MutationRoot>(&(), &()))
     }
 
     fn extract_fragments<'a, S>(doc: &'a Document<S>) -> HashMap<&'a str, &'a Fragment<'a, S>> {
         let mut fragments = HashMap::new();
         for d in doc {
-            if let ::ast::Definition::Fragment(ref f) = *d {
+            if let crate::ast::Definition::Fragment(ref f) = *d {
                 let f = &f.item;
                 fragments.insert(f.name.item, f);
             }
@@ -429,7 +429,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -483,7 +483,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -541,7 +541,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -623,7 +623,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -683,7 +683,7 @@ query Hero($episode: Episode) {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let mut vars = Variables::default();
             vars.insert("episode".into(), InputValue::Enum("JEDI".into()));
             let look_ahead = LookAheadSelection::build_from_selection(
@@ -790,7 +790,7 @@ fragment commonFields on Character {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -854,7 +854,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -912,7 +912,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -986,7 +986,7 @@ fragment comparisonFields on Character {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let mut vars = Variables::default();
             vars.insert("id".into(), InputValue::Scalar(DefaultScalarValue::Int(42)));
             // This will normally be there
@@ -1144,7 +1144,7 @@ query Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],
@@ -1293,7 +1293,7 @@ fragment heroFriendNames on Hero {
         .unwrap();
         let fragments = extract_fragments(&docs);
 
-        if let ::ast::Definition::Operation(ref op) = docs[0] {
+        if let crate::ast::Definition::Operation(ref op) = docs[0] {
             let vars = Variables::default();
             let look_ahead = LookAheadSelection::build_from_selection(
                 &op.item.selection_set[0],

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -151,7 +151,7 @@ where
                                     LookAheadValue::from_input_value(&v.item, vars)
                                 {
                                     <&S as Into<Option<&bool>>>::into(s)
-                                        .map(|b| *b)
+                                        .cloned()
                                         .unwrap_or(false)
                                 } else {
                                     false

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -157,9 +157,10 @@ impl<S> FieldError<S> {
     /// You can use the `graphql_value!` macro to construct an error:
     ///
     /// ```rust
-    /// # #[macro_use] extern crate juniper;
+    /// # extern crate juniper;
     /// use juniper::FieldError;
     /// # use juniper::DefaultScalarValue;
+    /// use juniper::graphql_value;
     ///
     /// # fn sample() {
     /// # let _: FieldError<DefaultScalarValue> =

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -789,10 +789,8 @@ where
 
     fn insert_placeholder(&mut self, name: Name, of_type: Type<'r>) {
         if !self.types.contains_key(&name) {
-            self.types.insert(
-                name,
-                MetaType::Placeholder(PlaceholderMeta { of_type }),
-            );
+            self.types
+                .insert(name, MetaType::Placeholder(PlaceholderMeta { of_type }));
         }
     }
 

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -6,23 +6,23 @@ use std::sync::RwLock;
 
 use fnv::FnvHashMap;
 
-use ast::{
+use crate::ast::{
     Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
     ToInputValue, Type,
 };
-use parser::SourcePosition;
-use value::Value;
-use GraphQLError;
+use crate::parser::SourcePosition;
+use crate::value::Value;
+use crate::GraphQLError;
 
-use schema::meta::{
+use crate::schema::meta::{
     Argument, DeprecationStatus, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta,
     ListMeta, MetaType, NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
 };
-use schema::model::{RootNode, SchemaType, TypeType};
+use crate::schema::model::{RootNode, SchemaType, TypeType};
 
-use types::base::GraphQLType;
-use types::name::Name;
-use value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::types::base::GraphQLType;
+use crate::types::name::Name;
+use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
 
 mod look_ahead;
 
@@ -141,7 +141,7 @@ pub struct FieldError<S = DefaultScalarValue> {
 
 impl<T: Display, S> From<T> for FieldError<S>
 where
-    S: ::value::ScalarValue,
+    S: crate::value::ScalarValue,
 {
     fn from(e: T) -> FieldError<S> {
         FieldError {

--- a/juniper/src/executor_tests/directives.rs
+++ b/juniper/src/executor_tests/directives.rs
@@ -21,7 +21,8 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) =
+        crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/directives.rs
+++ b/juniper/src/executor_tests/directives.rs
@@ -1,7 +1,7 @@
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 struct TestType;
 
@@ -21,7 +21,7 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = ::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -33,7 +33,8 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) =
+        crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+
 use crate::ast::InputValue;
 use crate::executor::Variables;
 use crate::parser::SourcePosition;
@@ -7,7 +9,7 @@ use crate::validation::RuleError;
 use crate::value::{DefaultScalarValue, Object, Value};
 use crate::GraphQLError::ValidationError;
 
-#[derive(GraphQLEnumInternal, Debug)]
+#[derive(GraphQLEnum, Debug)]
 enum Color {
     Red,
     Green,

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -1,11 +1,11 @@
-use ast::InputValue;
-use executor::Variables;
-use parser::SourcePosition;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use validation::RuleError;
-use value::{DefaultScalarValue, Object, Value};
-use GraphQLError::ValidationError;
+use crate::ast::InputValue;
+use crate::executor::Variables;
+use crate::parser::SourcePosition;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::validation::RuleError;
+use crate::value::{DefaultScalarValue, Object, Value};
+use crate::GraphQLError::ValidationError;
 
 #[derive(GraphQLEnumInternal, Debug)]
 enum Color {
@@ -31,7 +31,7 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = ::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -76,7 +76,7 @@ fn does_not_accept_string_literals() {
     let query = r#"{ toString(color: "RED") }"#;
     let vars = vec![].into_iter().collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -112,7 +112,7 @@ fn does_not_accept_incorrect_enum_name_in_variables() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -132,7 +132,7 @@ fn does_not_accept_incorrect_type_in_variables() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -1,8 +1,8 @@
 mod field_execution {
-    use ast::InputValue;
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::ast::InputValue;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     struct DataType;
     struct DeepDataType;
@@ -65,7 +65,7 @@ mod field_execution {
             .into_iter()
             .collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -132,9 +132,9 @@ mod field_execution {
 }
 
 mod merge_parallel_fragments {
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     struct Type;
 
@@ -161,7 +161,7 @@ mod merge_parallel_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -205,9 +205,9 @@ mod merge_parallel_fragments {
 }
 
 mod merge_parallel_inline_fragments {
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     struct Type;
     struct Other;
@@ -258,7 +258,7 @@ mod merge_parallel_inline_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -326,10 +326,10 @@ mod merge_parallel_inline_fragments {
 }
 
 mod threads_context_correctly {
-    use executor::Context;
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::executor::Context;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     struct Schema;
 
@@ -350,7 +350,7 @@ mod threads_context_correctly {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(
+        let (result, errs) = crate::execute(
             doc,
             None,
             &schema,
@@ -379,11 +379,11 @@ mod threads_context_correctly {
 mod dynamic_context_switching {
     use indexmap::IndexMap;
 
-    use executor::{Context, ExecutionError, FieldError, FieldResult};
-    use parser::SourcePosition;
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::executor::{Context, ExecutionError, FieldError, FieldResult};
+    use crate::parser::SourcePosition;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     struct Schema;
 
@@ -457,7 +457,7 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -513,7 +513,7 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, vec![]);
 
@@ -566,7 +566,7 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -614,7 +614,7 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -674,7 +674,7 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -699,11 +699,11 @@ mod dynamic_context_switching {
 }
 
 mod propagates_errors_to_nullable_fields {
-    use executor::{ExecutionError, FieldError, FieldResult, IntoFieldError};
-    use parser::SourcePosition;
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::{ScalarValue, Value};
+    use crate::executor::{ExecutionError, FieldError, FieldResult, IntoFieldError};
+    use crate::parser::SourcePosition;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::{ScalarValue, Value};
 
     struct Schema;
     struct Inner;
@@ -749,7 +749,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -775,7 +775,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -798,7 +798,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -821,7 +821,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -847,7 +847,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -870,7 +870,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -896,7 +896,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -919,7 +919,7 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -962,10 +962,10 @@ mod propagates_errors_to_nullable_fields {
 }
 
 mod named_operations {
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
-    use GraphQLError;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
+    use crate::GraphQLError;
 
     struct Schema;
 
@@ -980,7 +980,7 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -997,7 +997,7 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -1015,7 +1015,7 @@ mod named_operations {
         let vars = vec![].into_iter().collect();
 
         let (result, errs) =
-            ::execute(doc, Some("OtherExample"), &schema, &vars, &()).expect("Execution failed");
+            crate::execute(doc, Some("OtherExample"), &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -1032,7 +1032,7 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let err = ::execute(doc, None, &schema, &vars, &()).unwrap_err();
+        let err = crate::execute(doc, None, &schema, &vars, &()).unwrap_err();
 
         assert_eq!(err, GraphQLError::MultipleOperationsProvided);
     }
@@ -1044,7 +1044,7 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let err = ::execute(doc, Some("UnknownExample"), &schema, &vars, &()).unwrap_err();
+        let err = crate::execute(doc, Some("UnknownExample"), &schema, &vars, &()).unwrap_err();
 
         assert_eq!(err, GraphQLError::UnknownOperationName);
     }

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -65,7 +65,8 @@ mod field_execution {
             .into_iter()
             .collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -161,7 +162,8 @@ mod merge_parallel_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -258,7 +260,8 @@ mod merge_parallel_inline_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -457,7 +460,8 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -513,7 +517,8 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, vec![]);
 
@@ -566,7 +571,8 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -614,7 +620,8 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -674,7 +681,8 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &ctx).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -749,7 +757,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -775,7 +784,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -798,7 +808,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -821,7 +832,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -847,7 +859,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -870,7 +883,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -896,7 +910,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -919,7 +934,8 @@ mod propagates_errors_to_nullable_fields {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -980,7 +996,8 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -997,7 +1014,8 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -1014,8 +1032,8 @@ mod named_operations {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute(doc, Some("OtherExample"), &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, Some("OtherExample"), &schema, &vars, &())
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/interfaces_unions.rs
+++ b/juniper/src/executor_tests/interfaces_unions.rs
@@ -1,7 +1,7 @@
 mod interface {
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     trait Pet {
         fn name(&self) -> &str;
@@ -107,7 +107,7 @@ mod interface {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -145,9 +145,9 @@ mod interface {
 }
 
 mod union {
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     trait Pet {
         fn as_dog(&self) -> Option<&Dog> {
@@ -241,7 +241,7 @@ mod union {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/interfaces_unions.rs
+++ b/juniper/src/executor_tests/interfaces_unions.rs
@@ -107,7 +107,8 @@ mod interface {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -241,7 +242,8 @@ mod union {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) =
+            crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,7 +1,7 @@
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 /*
 
@@ -78,7 +78,7 @@ where
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+
 use crate::executor::Variables;
 use crate::schema::model::RootNode;
 use crate::types::scalars::EmptyMutation;
@@ -15,33 +17,33 @@ Syntax to validate:
 
 */
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 enum DefaultName {
     Foo,
     Bar,
 }
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 #[graphql(name = "ANamedEnum")]
 enum Named {
     Foo,
     Bar,
 }
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 enum NoTrailingComma {
     Foo,
     Bar,
 }
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 #[graphql(description = "A description of the enum itself")]
 enum EnumDescription {
     Foo,
     Bar,
 }
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 enum EnumValueDescription {
     #[graphql(description = "The FOO value")]
     Foo,
@@ -49,7 +51,7 @@ enum EnumValueDescription {
     Bar,
 }
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 enum EnumDeprecation {
     #[graphql(deprecated = "Please don't use FOO any more")]
     Foo,

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+
 use crate::ast::{FromInputValue, InputValue};
 use crate::executor::Variables;
 use crate::schema::model::RootNode;
@@ -6,47 +8,47 @@ use crate::value::{DefaultScalarValue, Object, Value};
 
 struct Root;
 
-#[derive(GraphQLInputObjectInternal)]
+#[derive(GraphQLInputObject)]
 struct DefaultName {
     field_one: String,
     field_two: String,
 }
 
-#[derive(GraphQLInputObjectInternal)]
+#[derive(GraphQLInputObject)]
 struct NoTrailingComma {
     field_one: String,
     field_two: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 struct Derive {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(name = "ANamedInputObject")]
 struct Named {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(description = "Description for the input object")]
 struct Description {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 pub struct Public {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(description = "Description for the input object")]
 pub struct PublicWithDescription {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(
     name = "APublicNamedInputObjectWithDescription",
     description = "Description for the input object"
@@ -55,13 +57,13 @@ pub struct NamedPublicWithDescription {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(name = "APublicNamedInputObject")]
 pub struct NamedPublic {
     field_one: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 struct FieldDescription {
     #[graphql(description = "The first field")]
     field_one: String,
@@ -69,7 +71,7 @@ struct FieldDescription {
     field_two: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 struct FieldWithDefaults {
     #[graphql(default = "123")]
     field_one: i32,

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -1,8 +1,8 @@
-use ast::{FromInputValue, InputValue};
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::ast::{FromInputValue, InputValue};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 struct Root;
 
@@ -102,7 +102,7 @@ where
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -5,10 +5,10 @@ mod input_object;
 #[allow(unused_imports)]
 use self::input_object::{NamedPublic, NamedPublicWithDescription};
 
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{ParseScalarResult, ParseScalarValue, Value};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{ParseScalarResult, ParseScalarValue, Value};
 
 #[derive(GraphQLEnumInternal)]
 #[graphql(name = "SampleEnum")]
@@ -78,7 +78,7 @@ fn test_execution() {
     let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -122,7 +122,7 @@ fn enum_introspection() {
     let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -231,7 +231,7 @@ fn interface_introspection() {
     let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -378,7 +378,7 @@ fn object_introspection() {
     let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -585,7 +585,7 @@ fn scalar_introspection() {
     let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -1,6 +1,8 @@
 mod enums;
 mod input_object;
 
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+
 // This asserts that the input objects defined public actually became public
 #[allow(unused_imports)]
 use self::input_object::{NamedPublic, NamedPublicWithDescription};
@@ -10,7 +12,7 @@ use crate::schema::model::RootNode;
 use crate::types::scalars::EmptyMutation;
 use crate::value::{ParseScalarResult, ParseScalarValue, Value};
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 #[graphql(name = "SampleEnum")]
 enum Sample {
     One,

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,11 +1,11 @@
-use ast::InputValue;
-use executor::Variables;
-use parser::SourcePosition;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use validation::RuleError;
-use value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
-use GraphQLError::ValidationError;
+use crate::ast::InputValue;
+use crate::executor::Variables;
+use crate::parser::SourcePosition;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::validation::RuleError;
+use crate::value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
+use crate::GraphQLError::ValidationError;
 
 #[derive(Debug)]
 struct TestComplexScalar;
@@ -120,7 +120,7 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = ::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 
@@ -271,7 +271,7 @@ fn variable_error_on_nested_non_null() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -291,7 +291,7 @@ fn variable_error_on_incorrect_type() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -320,7 +320,7 @@ fn variable_error_on_omit_non_null() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -351,7 +351,7 @@ fn variable_multiple_errors_with_nesting() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -386,7 +386,7 @@ fn variable_error_on_additional_field() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -488,7 +488,7 @@ fn does_not_allow_non_nullable_input_to_be_omitted_in_variable() {
     let query = r#"query q($value: String!) { fieldWithNonNullableStringInput(input: $value) }"#;
     let vars = vec![].into_iter().collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -508,7 +508,7 @@ fn does_not_allow_non_nullable_input_to_be_set_to_null_in_variable() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -615,7 +615,7 @@ fn does_not_allow_non_null_lists_to_be_null() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -718,7 +718,7 @@ fn does_not_allow_lists_of_non_null_to_contain_null() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -744,7 +744,7 @@ fn does_not_allow_non_null_lists_of_non_null_to_contain_null() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -763,7 +763,7 @@ fn does_not_allow_non_null_lists_of_non_null_to_be_null() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -805,7 +805,7 @@ fn does_not_allow_invalid_types_to_be_used_as_values() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -827,7 +827,7 @@ fn does_not_allow_unknown_types_to_be_used_as_values() {
     .into_iter()
     .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(error, ValidationError(vec![
         RuleError::new(
@@ -940,7 +940,7 @@ fn does_not_allow_missing_required_field() {
     let query = r#"{ exampleInput(arg: {a: "abc"}) }"#;
     let vars = vec![].into_iter().collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -958,7 +958,7 @@ fn does_not_allow_null_in_required_field() {
     let query = r#"{ exampleInput(arg: {a: "abc", b: null}) }"#;
     let vars = vec![].into_iter().collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -976,7 +976,7 @@ fn does_not_allow_missing_variable_for_required_field() {
     let query = r#"query q($var: Int!) { exampleInput(arg: {b: $var}) }"#;
     let vars = vec![].into_iter().collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -996,7 +996,7 @@ fn does_not_allow_null_variable_for_required_field() {
         .into_iter()
         .collect();
 
-    let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
     assert_eq!(
         error,
@@ -1095,7 +1095,7 @@ mod integers {
             .into_iter()
             .collect();
 
-        let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+        let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
         assert_eq!(
             error,
@@ -1115,7 +1115,7 @@ mod integers {
             .into_iter()
             .collect();
 
-        let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+        let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
         assert_eq!(
             error,
@@ -1171,7 +1171,7 @@ mod floats {
             .into_iter()
             .collect();
 
-        let error = ::execute(query, None, &schema, &vars, &()).unwrap_err();
+        let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
 
         assert_eq!(
             error,

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -122,7 +122,8 @@ where
 {
     let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
 
-    let (result, errs) = crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) =
+        crate::execute(query, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+
 use crate::ast::InputValue;
 use crate::executor::Variables;
 use crate::parser::SourcePosition;
@@ -32,7 +34,7 @@ graphql_scalar!(TestComplexScalar {
     }
 });
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(scalar = "DefaultScalarValue")]
 struct TestInputObject {
     a: Option<String>,
@@ -41,20 +43,20 @@ struct TestInputObject {
     d: Option<TestComplexScalar>,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 #[graphql(scalar = "DefaultScalarValue")]
 struct TestNestedInputObject {
     na: TestInputObject,
     nb: String,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 struct ExampleInputObject {
     a: Option<String>,
     b: i32,
 }
 
-#[derive(GraphQLInputObjectInternal, Debug)]
+#[derive(GraphQLInputObject, Debug)]
 struct InputWithDefaults {
     #[graphql(default = "123")]
     a: i32,

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -5,7 +5,7 @@ pub mod playground;
 
 use serde::de::Deserialize;
 use serde::ser::{self, Serialize, SerializeMap};
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::ast::InputValue;
 use crate::executor::ExecutionError;

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -6,10 +6,10 @@ pub mod playground;
 use serde::de::Deserialize;
 use serde::ser::{self, Serialize, SerializeMap};
 
-use ast::InputValue;
-use executor::ExecutionError;
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
-use {FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
+use crate::ast::InputValue;
+use crate::executor::ExecutionError;
+use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use crate::{FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
 
 /// The expected structure of the decoded JSON document for either POST or GET requests.
 ///
@@ -80,7 +80,7 @@ where
         MutationT: GraphQLType<S, Context = CtxT>,
         for<'b> &'b S: ScalarRefValue<'b>,
     {
-        GraphQLResponse(::execute(
+        GraphQLResponse(crate::execute(
             &self.query,
             self.operation_name(),
             root_node,

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -60,9 +60,9 @@ where
         variables: Option<InputValue<S>>,
     ) -> Self {
         GraphQLRequest {
-            query: query,
-            operation_name: operation_name,
-            variables: variables,
+            query,
+            operation_name,
+            variables,
         }
     }
 

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -5,6 +5,7 @@ pub mod playground;
 
 use serde::de::Deserialize;
 use serde::ser::{self, Serialize, SerializeMap};
+use serde_derive::{Serialize, Deserialize};
 
 use crate::ast::InputValue;
 use crate::executor::ExecutionError;

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -111,13 +111,14 @@ graphql_scalar!(NaiveDateTime where Scalar = <S> {
 
 #[cfg(test)]
 mod test {
-    use chrono::prelude::*;
     use crate::{value::DefaultScalarValue, InputValue};
+    use chrono::prelude::*;
 
     fn datetime_fixedoffset_test(raw: &'static str) {
         let input: crate::InputValue<DefaultScalarValue> = InputValue::scalar(raw.to_string());
 
-        let parsed: DateTime<FixedOffset> = crate::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: DateTime<FixedOffset> =
+            crate::FromInputValue::from_input_value(&input).unwrap();
         let expected = DateTime::parse_from_rfc3339(raw).unwrap();
 
         assert_eq!(parsed, expected);

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -15,9 +15,9 @@
 */
 use chrono::prelude::*;
 
-use parser::{ParseError, ScalarToken, Token};
-use value::{ParseScalarResult, ParseScalarValue};
-use Value;
+use crate::parser::{ParseError, ScalarToken, Token};
+use crate::value::{ParseScalarResult, ParseScalarValue};
+use crate::Value;
 
 #[doc(hidden)]
 pub static RFC3339_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%.f%:z";
@@ -90,8 +90,8 @@ graphql_scalar!(NaiveDate where Scalar = <S>{
     }
 });
 
-/// JSON numbers (i.e. IEEE doubles) are not precise enough for nanosecond
-/// datetimes. Values will be truncated to microsecond resolution.
+// JSON numbers (i.e. IEEE doubles) are not precise enough for nanosecond
+// datetimes. Values will be truncated to microsecond resolution.
 graphql_scalar!(NaiveDateTime where Scalar = <S> {
     description: "NaiveDateTime"
 
@@ -112,12 +112,12 @@ graphql_scalar!(NaiveDateTime where Scalar = <S> {
 #[cfg(test)]
 mod test {
     use chrono::prelude::*;
-    use value::DefaultScalarValue;
+    use crate::{value::DefaultScalarValue, InputValue};
 
     fn datetime_fixedoffset_test(raw: &'static str) {
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: crate::InputValue<DefaultScalarValue> = InputValue::scalar(raw.to_string());
 
-        let parsed: DateTime<FixedOffset> = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: DateTime<FixedOffset> = crate::FromInputValue::from_input_value(&input).unwrap();
         let expected = DateTime::parse_from_rfc3339(raw).unwrap();
 
         assert_eq!(parsed, expected);
@@ -139,9 +139,9 @@ mod test {
     }
 
     fn datetime_utc_test(raw: &'static str) {
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: crate::InputValue<DefaultScalarValue> = InputValue::scalar(raw.to_string());
 
-        let parsed: DateTime<Utc> = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: DateTime<Utc> = crate::FromInputValue::from_input_value(&input).unwrap();
         let expected = DateTime::parse_from_rfc3339(raw)
             .unwrap()
             .with_timezone(&Utc);
@@ -166,13 +166,13 @@ mod test {
 
     #[test]
     fn naivedate_from_input_value() {
-        let input: ::InputValue<DefaultScalarValue> =
-            ::InputValue::scalar("1996-12-19".to_string());
+        let input: crate::InputValue<DefaultScalarValue> =
+            InputValue::scalar("1996-12-19".to_string());
         let y = 1996;
         let m = 12;
         let d = 19;
 
-        let parsed: NaiveDate = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: NaiveDate = crate::FromInputValue::from_input_value(&input).unwrap();
         let expected = NaiveDate::from_ymd(y, m, d);
 
         assert_eq!(parsed, expected);
@@ -185,9 +185,9 @@ mod test {
     #[test]
     fn naivedatetime_from_input_value() {
         let raw = 1_000_000_000_f64;
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw);
+        let input: InputValue<DefaultScalarValue> = InputValue::scalar(raw);
 
-        let parsed: NaiveDateTime = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: NaiveDateTime = crate::FromInputValue::from_input_value(&input).unwrap();
         let expected = NaiveDateTime::from_timestamp_opt(raw as i64, 0).unwrap();
 
         assert_eq!(parsed, expected);
@@ -200,10 +200,10 @@ mod integration_test {
     use chrono::prelude::*;
     use chrono::Utc;
 
-    use executor::Variables;
-    use schema::model::RootNode;
-    use types::scalars::EmptyMutation;
-    use value::Value;
+    use crate::executor::Variables;
+    use crate::schema::model::RootNode;
+    use crate::types::scalars::EmptyMutation;
+    use crate::value::Value;
 
     #[test]
     fn test_serialization() {
@@ -235,7 +235,7 @@ mod integration_test {
         let schema = RootNode::new(Root, EmptyMutation::<()>::new());
 
         let (result, errs) =
-            ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+            crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
         assert_eq!(errs, []);
 

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -399,10 +399,10 @@ where
 mod tests {
     use super::{ExecutionError, GraphQLError};
     use crate::ast::InputValue;
-    use serde_json::from_str;
-    use serde_json::to_string;
     use crate::value::{DefaultScalarValue, Object};
     use crate::{FieldError, Value};
+    use serde_json::from_str;
+    use serde_json::to_string;
 
     #[test]
     fn int() {

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -4,11 +4,11 @@ use serde::{de, ser};
 
 use std::fmt;
 
-use ast::InputValue;
-use executor::ExecutionError;
-use parser::{ParseError, SourcePosition, Spanning};
-use validation::RuleError;
-use {GraphQLError, Object, ScalarValue, Value};
+use crate::ast::InputValue;
+use crate::executor::ExecutionError;
+use crate::parser::{ParseError, SourcePosition, Spanning};
+use crate::validation::RuleError;
+use crate::{GraphQLError, Object, ScalarValue, Value};
 
 #[derive(Serialize)]
 struct SerializeHelper {
@@ -397,11 +397,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::{ExecutionError, GraphQLError};
-    use ast::InputValue;
+    use crate::ast::InputValue;
     use serde_json::from_str;
     use serde_json::to_string;
-    use value::{DefaultScalarValue, Object};
-    use {FieldError, Value};
+    use crate::value::{DefaultScalarValue, Object};
+    use crate::{FieldError, Value};
 
     #[test]
     fn int() {

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use serde::ser::SerializeMap;
 use serde::{de, ser};
+use serde_derive::Serialize;
 
 use std::fmt;
 
@@ -130,7 +131,7 @@ where
                 self.0.visit_i64(value).map(InputValue::Scalar)
             }
 
-            serde_if_integer128! {
+            serde::serde_if_integer128! {
                 fn visit_i128<E>(self, value: i128) -> Result<InputValue<S>, E>
                 where
                     E: de::Error,
@@ -167,7 +168,7 @@ where
                 self.0.visit_u64(value).map(InputValue::Scalar)
             }
 
-            serde_if_integer128! {
+            serde::serde_if_integer128! {
                 fn visit_u128<E>(self, value: u128) -> Result<InputValue<S>, E>
                 where
                     E: de::Error,

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -22,8 +22,8 @@ graphql_scalar!(Url where Scalar = <S>{
 
 #[cfg(test)]
 mod test {
-    use url::Url;
     use crate::InputValue;
+    use url::Url;
 
     #[test]
     fn url_from_input_value() {

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -1,7 +1,7 @@
 use url::Url;
 
-use value::{ParseScalarResult, ParseScalarValue};
-use Value;
+use crate::value::{ParseScalarResult, ParseScalarValue};
+use crate::Value;
 
 graphql_scalar!(Url where Scalar = <S>{
     description: "Url"
@@ -23,13 +23,14 @@ graphql_scalar!(Url where Scalar = <S>{
 #[cfg(test)]
 mod test {
     use url::Url;
+    use crate::InputValue;
 
     #[test]
     fn url_from_input_value() {
         let raw = "https://example.net/";
-        let input: ::InputValue = ::InputValue::scalar(raw.to_string());
+        let input: InputValue = InputValue::scalar(raw.to_string());
 
-        let parsed: Url = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: Url = crate::FromInputValue::from_input_value(&input).unwrap();
         let url = Url::parse(raw).unwrap();
 
         assert_eq!(parsed, url);

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -1,8 +1,10 @@
 use uuid::Uuid;
 
-use parser::{ParseError, ScalarToken, Token};
-use value::ParseScalarResult;
-use Value;
+use crate::{
+    parser::{ParseError, ScalarToken, Token},
+    value::ParseScalarResult,
+    Value,
+};
 
 graphql_scalar!(Uuid where Scalar = <S> {
     description: "Uuid"
@@ -28,14 +30,14 @@ graphql_scalar!(Uuid where Scalar = <S> {
 #[cfg(test)]
 mod test {
     use uuid::Uuid;
-    use value::DefaultScalarValue;
+    use crate::{value::DefaultScalarValue, InputValue};
 
     #[test]
     fn uuid_from_input_value() {
         let raw = "123e4567-e89b-12d3-a456-426655440000";
-        let input: ::InputValue<DefaultScalarValue> = ::InputValue::scalar(raw.to_string());
+        let input: InputValue<DefaultScalarValue> = InputValue::scalar(raw.to_string());
 
-        let parsed: Uuid = ::FromInputValue::from_input_value(&input).unwrap();
+        let parsed: Uuid = crate::FromInputValue::from_input_value(&input).unwrap();
         let id = Uuid::parse_str(raw).unwrap();
 
         assert_eq!(parsed, id);

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -29,8 +29,8 @@ graphql_scalar!(Uuid where Scalar = <S> {
 
 #[cfg(test)]
 mod test {
-    use uuid::Uuid;
     use crate::{value::DefaultScalarValue, InputValue};
+    use uuid::Uuid;
 
     #[test]
     fn uuid_from_input_value() {

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -138,7 +138,7 @@ mod validation;
 pub mod http;
 pub mod integrations;
 // TODO: remove this alias export in 0.10. (breaking change)
-pub use http::graphiql;
+pub use crate::http::graphiql;
 
 #[cfg(all(test, not(feature = "expose-test-schema")))]
 mod tests;
@@ -149,28 +149,28 @@ pub mod tests;
 mod executor_tests;
 
 // Needs to be public because macros use it.
-pub use util::to_camel_case;
+pub use crate::util::to_camel_case;
 
-use executor::execute_validated_query;
-use introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS};
-use parser::{parse_document_source, ParseError, Spanning};
-use validation::{validate_input_values, visit_all_rules, ValidatorContext};
+use crate::executor::execute_validated_query;
+use crate::introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS};
+use crate::parser::{parse_document_source, ParseError, Spanning};
+use crate::validation::{validate_input_values, visit_all_rules, ValidatorContext};
 
-pub use ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
-pub use executor::{
+pub use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
+pub use crate::executor::{
     Applies, LookAheadArgument, LookAheadMethods, LookAheadSelection, LookAheadValue,
 };
-pub use executor::{
+pub use crate::executor::{
     Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult, FromContext,
     IntoFieldError, IntoResolvable, Registry, Variables,
 };
-pub use introspection::IntrospectionFormat;
-pub use schema::meta;
-pub use schema::model::RootNode;
-pub use types::base::{Arguments, GraphQLType, TypeKind};
-pub use types::scalars::{EmptyMutation, ID};
-pub use validation::RuleError;
-pub use value::{
+pub use crate::introspection::IntrospectionFormat;
+pub use crate::schema::meta;
+pub use crate::schema::model::RootNode;
+pub use crate::types::base::{Arguments, GraphQLType, TypeKind};
+pub use crate::types::scalars::{EmptyMutation, ID};
+pub use crate::validation::RuleError;
+pub use crate::value::{
     DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue,
     Value,
 };

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -91,17 +91,10 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 #![warn(missing_docs)]
 
 #[doc(hidden)]
-#[macro_use]
 pub extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 
 #[cfg(any(test, feature = "expose-test-schema"))]
 extern crate serde_json;
-
-extern crate fnv;
-
-extern crate indexmap;
 
 #[cfg(any(test, feature = "chrono"))]
 extern crate chrono;
@@ -115,9 +108,6 @@ extern crate uuid;
 // Depend on juniper_codegen and re-export everything in it.
 // This allows users to just depend on juniper and get the derive
 // functionality automatically.
-#[allow(unused_imports)]
-#[macro_use]
-extern crate juniper_codegen;
 #[doc(hidden)]
 pub use juniper_codegen::*;
 

--- a/juniper/src/macros/interface.rs
+++ b/juniper/src/macros/interface.rs
@@ -40,7 +40,7 @@ A simplified extract from the StarWars schema example shows how to use the
 shared context to implement downcasts.
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 # use std::collections::HashMap;
 struct Human { id: String }
 struct Droid { id: String }
@@ -61,16 +61,16 @@ impl Character for Droid {
     fn id(&self) -> &str { &self.id }
 }
 
-graphql_object!(Human: Database as "Human" |&self| {
+juniper::graphql_object!(Human: Database as "Human" |&self| {
     field id() -> &str { &self.id }
 });
 
-graphql_object!(Droid: Database as "Droid" |&self| {
+juniper::graphql_object!(Droid: Database as "Droid" |&self| {
     field id() -> &str { &self.id }
 });
 
 // You can introduce lifetimes or generic parameters by < > before the name.
-graphql_interface!(<'a> &'a Character: Database as "Character" |&self| {
+juniper::graphql_interface!(<'a> &'a Character: Database as "Character" |&self| {
     field id() -> &str { self.id() }
 
     instance_resolvers: |&context| {

--- a/juniper/src/macros/object.rs
+++ b/juniper/src/macros/object.rs
@@ -10,10 +10,10 @@ safety and reduce repetitive declarations.
 The simplest case exposes fields on a struct:
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 struct User { id: String, name: String, group_ids: Vec<String> }
 
-graphql_object!(User: () |&self| {
+juniper::graphql_object!(User: () |&self| {
     field id() -> &String {
         &self.id
     }
@@ -42,10 +42,10 @@ attributes. Alternatively the same syntax as for the type could be
 used
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 struct User { id: String, name: String, group_ids: Vec<String> }
 
-graphql_object!(User: () |&self| {
+juniper::graphql_object!(User: () |&self| {
     description: "A user in the database"
 
 
@@ -77,16 +77,16 @@ You can expose generic or pointer types by prefixing the type with the necessary
 generic parameters:
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 trait SomeTrait { fn id(&self) -> &str; }
 
-graphql_object!(<'a> &'a SomeTrait: () as "SomeTrait" |&self| {
+juniper::graphql_object!(<'a> &'a SomeTrait: () as "SomeTrait" |&self| {
     field id() -> &str { self.id() }
 });
 
 struct GenericType<T> { items: Vec<T> }
 
-graphql_object!(<T> GenericType<T>: () as "GenericType" |&self| {
+juniper::graphql_object!(<T> GenericType<T>: () as "GenericType" |&self| {
     field count() -> i32 { self.items.len() as i32 }
 });
 
@@ -98,14 +98,14 @@ graphql_object!(<T> GenericType<T>: () as "GenericType" |&self| {
 You can use the `interfaces` item to implement interfaces:
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 trait Interface {
     fn id(&self) -> &str;
     fn as_implementor(&self) -> Option<Implementor>;
 }
 struct Implementor { id: String }
 
-graphql_interface!(<'a> &'a Interface: () as "Interface" |&self| {
+juniper::graphql_interface!(<'a> &'a Interface: () as "Interface" |&self| {
     field id() -> &str { self.id() }
 
     instance_resolvers: |&context| {
@@ -113,7 +113,7 @@ graphql_interface!(<'a> &'a Interface: () as "Interface" |&self| {
     }
 });
 
-graphql_object!(Implementor: () |&self| {
+juniper::graphql_object!(Implementor: () |&self| {
     field id() -> &str { &self.id }
 
     interfaces: [&Interface]
@@ -140,11 +140,11 @@ automatically via the `?` operator, or you can construct them yourself using
 `FieldError::new`.
 
 ```
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 # use juniper::FieldResult;
 struct User { id: String }
 
-graphql_object!(User: () |&self| {
+juniper::graphql_object!(User: () |&self| {
     field id() -> FieldResult<&String> {
         Ok(&self.id)
     }
@@ -172,10 +172,10 @@ be used as type parameter to the implementing type.
 Example for using a generic scalar value type
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 struct User { id: String }
 
-graphql_object!(User: () where Scalar = <S> |&self| {
+juniper::graphql_object!(User: () where Scalar = <S> |&self| {
     field id() -> &String {
         &self.id
     }

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -17,11 +17,11 @@ possible to use the same syntax as on `graphql_object!` to specify a custom
 representation.
 
 ```rust
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 # use juniper::{Value, FieldResult, ParseScalarValue, ParseScalarResult};
 struct UserID(String);
 
-graphql_scalar!(UserID {
+juniper::graphql_scalar!(UserID {
     description: "An opaque identifier, represented as a string"
 
     resolve(&self) -> Value {

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -1,7 +1,7 @@
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Value};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Value};
 
 struct Root;
 
@@ -109,7 +109,7 @@ where
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+
 use crate::executor::Variables;
 use crate::schema::model::RootNode;
 use crate::types::scalars::EmptyMutation;
@@ -19,7 +21,7 @@ Syntax to validate:
 
 */
 
-#[derive(GraphQLInputObjectInternal)]
+#[derive(GraphQLInputObject)]
 struct Point {
     x: i32,
 }

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -1,8 +1,8 @@
-use ast::InputValue;
-use executor::FieldResult;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::ast::InputValue;
+use crate::executor::FieldResult;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 struct Interface;
 #[derive(Debug)]
@@ -124,7 +124,7 @@ where
         .into_iter()
         .collect();
 
-    let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/macros/tests/interface.rs
+++ b/juniper/src/macros/tests/interface.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use ast::InputValue;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::ast::InputValue;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 /*
 
@@ -147,7 +147,7 @@ where
         .into_iter()
         .collect();
 
-    let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/macros/tests/object.rs
+++ b/juniper/src/macros/tests/object.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
-use ast::InputValue;
-use executor::{Context, FieldResult};
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::ast::InputValue;
+use crate::executor::{Context, FieldResult};
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 /*
 
@@ -174,7 +174,7 @@ where
         .collect();
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &vars, &InnerContext).expect("Execution failed");
+        crate::execute(doc, None, &schema, &vars, &InnerContext).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/macros/tests/scalar.rs
+++ b/juniper/src/macros/tests/scalar.rs
@@ -1,7 +1,7 @@
-use executor::Variables;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
 
 struct DefaultName(i32);
 struct OtherOrder(i32);
@@ -92,7 +92,7 @@ where
     let schema = RootNode::new(Root {}, EmptyMutation::<()>::new());
 
     let (result, errs) =
-        ::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
+        crate::execute(doc, None, &schema, &Variables::new(), &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/macros/tests/union.rs
+++ b/juniper/src/macros/tests/union.rs
@@ -1,9 +1,9 @@
 use std::marker::PhantomData;
 
-use ast::InputValue;
-use schema::model::RootNode;
-use types::scalars::EmptyMutation;
-use value::{DefaultScalarValue, Object, Value};
+use crate::ast::InputValue;
+use crate::schema::model::RootNode;
+use crate::types::scalars::EmptyMutation;
+use crate::value::{DefaultScalarValue, Object, Value};
 
 /*
 
@@ -128,7 +128,7 @@ where
         .into_iter()
         .collect();
 
-    let (result, errs) = ::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
+    let (result, errs) = crate::execute(doc, None, &schema, &vars, &()).expect("Execution failed");
 
     assert_eq!(errs, []);
 

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -498,10 +498,7 @@ where
     Ok(Spanning::start_end(
         &start_pos,
         &arguments.as_ref().map_or(&name.end, |s| &s.end).clone(),
-        Directive {
-            name,
-            arguments,
-        },
+        Directive { name, arguments },
     ))
 }
 

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -109,8 +109,8 @@ where
             &selection_set.end,
             Operation {
                 operation_type: operation_type.item,
-                name: name,
-                variable_definitions: variable_definitions,
+                name,
+                variable_definitions,
                 directives: directives.map(|s| s.item),
                 selection_set: selection_set.item,
             },
@@ -154,7 +154,7 @@ where
         &start_pos,
         &selection_set.end,
         Fragment {
-            name: name,
+            name,
             type_condition: type_cond,
             directives: directives.map(|s| s.item),
             selection_set: selection_set.item,
@@ -330,9 +330,9 @@ where
             .unwrap_or(&name.end)
             .clone(),
         Field {
-            alias: alias,
-            name: name,
-            arguments: arguments,
+            alias,
+            name,
+            arguments,
             directives: directives.map(|s| s.item),
             selection_set: selection_set.map(|s| s.item),
         },
@@ -449,8 +449,8 @@ where
         (
             Spanning::start_end(&start_pos, &var_name.end, var_name.item),
             VariableDefinition {
-                var_type: var_type,
-                default_value: default_value,
+                var_type,
+                default_value,
             },
         ),
     ))
@@ -499,8 +499,8 @@ where
         &start_pos,
         &arguments.as_ref().map_or(&name.end, |s| &s.end).clone(),
         Directive {
-            name: name,
-            arguments: arguments,
+            name,
+            arguments,
         },
     ))
 }

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -1,18 +1,18 @@
 use std::borrow::Cow;
 
-use ast::{
+use crate::ast::{
     Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread, InlineFragment,
     InputValue, Operation, OperationType, Selection, Type, VariableDefinition, VariableDefinitions,
 };
 
-use parser::value::parse_value_literal;
-use parser::{
+use crate::parser::value::parse_value_literal;
+use crate::parser::{
     Lexer, OptionParseResult, ParseError, ParseResult, Parser, Spanning, Token,
     UnlocatedParseResult,
 };
-use schema::meta::{Argument, Field as MetaField};
-use schema::model::SchemaType;
-use value::ScalarValue;
+use crate::schema::meta::{Argument, Field as MetaField};
+use crate::schema::model::SchemaType;
+use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub fn parse_document_source<'a, 'b, S>(

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -190,10 +190,9 @@ impl<'a> Lexer<'a> {
 
     fn scan_name(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, start_ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
-            &self.position,
-            LexerError::UnexpectedEndOfFile,
-        ))?;
+        let (start_idx, start_ch) = self
+            .next_char()
+            .ok_or_else(|| Spanning::zero_width(&self.position, LexerError::UnexpectedEndOfFile))?;
         assert!(is_name_start(start_ch));
 
         let mut end_idx = start_idx;
@@ -216,10 +215,9 @@ impl<'a> Lexer<'a> {
 
     fn scan_string(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, start_ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
-            &self.position,
-            LexerError::UnexpectedEndOfFile,
-        ))?;
+        let (start_idx, start_ch) = self
+            .next_char()
+            .ok_or_else(|| Spanning::zero_width(&self.position, LexerError::UnexpectedEndOfFile))?;
         if start_ch != '"' {
             return Err(Spanning::zero_width(
                 &self.position,
@@ -279,18 +277,16 @@ impl<'a> Lexer<'a> {
         &mut self,
         start_pos: &SourcePosition,
     ) -> Result<(), Spanning<LexerError>> {
-        let (start_idx, _) = self.peek_char().ok_or_else(|| Spanning::zero_width(
-            &self.position,
-            LexerError::UnterminatedString,
-        ))?;
+        let (start_idx, _) = self
+            .peek_char()
+            .ok_or_else(|| Spanning::zero_width(&self.position, LexerError::UnterminatedString))?;
         let mut end_idx = start_idx;
         let mut len = 0;
 
         for _ in 0..4 {
-            let (idx, ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
-                &self.position,
-                LexerError::UnterminatedString,
-            ))?;
+            let (idx, ch) = self.next_char().ok_or_else(|| {
+                Spanning::zero_width(&self.position, LexerError::UnterminatedString)
+            })?;
 
             if !ch.is_alphanumeric() {
                 break;
@@ -328,10 +324,9 @@ impl<'a> Lexer<'a> {
 
     fn scan_number(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, _) = self.peek_char().ok_or_else(|| Spanning::zero_width(
-            &self.position,
-            LexerError::UnexpectedEndOfFile,
-        ))?;
+        let (start_idx, _) = self
+            .peek_char()
+            .ok_or_else(|| Spanning::zero_width(&self.position, LexerError::UnexpectedEndOfFile))?;
 
         let mut last_idx = start_idx;
         let mut last_char = '1';

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -100,7 +100,7 @@ impl<'a> Lexer<'a> {
     pub fn new(source: &'a str) -> Lexer<'a> {
         Lexer {
             iterator: source.char_indices().peekable(),
-            source: source,
+            source,
             length: source.len(),
             position: SourcePosition::new_origin(),
             has_reached_eof: false,
@@ -190,7 +190,7 @@ impl<'a> Lexer<'a> {
 
     fn scan_name(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, start_ch) = self.next_char().ok_or(Spanning::zero_width(
+        let (start_idx, start_ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
             &self.position,
             LexerError::UnexpectedEndOfFile,
         ))?;
@@ -210,13 +210,13 @@ impl<'a> Lexer<'a> {
         Ok(Spanning::start_end(
             &start_pos,
             &self.position,
-            Token::Name(&self.source[start_idx..end_idx + 1]),
+            Token::Name(&self.source[start_idx..=end_idx]),
         ))
     }
 
     fn scan_string(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, start_ch) = self.next_char().ok_or(Spanning::zero_width(
+        let (start_idx, start_ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
             &self.position,
             LexerError::UnexpectedEndOfFile,
         ))?;
@@ -279,7 +279,7 @@ impl<'a> Lexer<'a> {
         &mut self,
         start_pos: &SourcePosition,
     ) -> Result<(), Spanning<LexerError>> {
-        let (start_idx, _) = self.peek_char().ok_or(Spanning::zero_width(
+        let (start_idx, _) = self.peek_char().ok_or_else(|| Spanning::zero_width(
             &self.position,
             LexerError::UnterminatedString,
         ))?;
@@ -287,7 +287,7 @@ impl<'a> Lexer<'a> {
         let mut len = 0;
 
         for _ in 0..4 {
-            let (idx, ch) = self.next_char().ok_or(Spanning::zero_width(
+            let (idx, ch) = self.next_char().ok_or_else(|| Spanning::zero_width(
                 &self.position,
                 LexerError::UnterminatedString,
             ))?;
@@ -300,7 +300,7 @@ impl<'a> Lexer<'a> {
             len += 1;
         }
 
-        let escape = &self.source[start_idx..end_idx + 1];
+        let escape = &self.source[start_idx..=end_idx];
 
         if len != 4 {
             return Err(Spanning::zero_width(
@@ -328,7 +328,7 @@ impl<'a> Lexer<'a> {
 
     fn scan_number(&mut self) -> LexerResult<'a> {
         let start_pos = self.position;
-        let (start_idx, _) = self.peek_char().ok_or(Spanning::zero_width(
+        let (start_idx, _) = self.peek_char().ok_or_else(|| Spanning::zero_width(
             &self.position,
             LexerError::UnexpectedEndOfFile,
         ))?;

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -4,7 +4,7 @@ use std::iter::{Iterator, Peekable};
 use std::result::Result;
 use std::str::CharIndices;
 
-use parser::{SourcePosition, Spanning};
+use crate::parser::{SourcePosition, Spanning};
 
 #[doc(hidden)]
 #[derive(Debug)]

--- a/juniper/src/parser/parser.rs
+++ b/juniper/src/parser/parser.rs
@@ -43,7 +43,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(Parser { tokens: tokens })
+        Ok(Parser { tokens })
     }
 
     #[doc(hidden)]
@@ -55,8 +55,8 @@ impl<'a> Parser<'a> {
     pub fn next(&mut self) -> ParseResult<'a, Token<'a>> {
         if self.tokens.len() == 1 {
             Err(Spanning::start_end(
-                &self.peek().start.clone(),
-                &self.peek().end.clone(),
+                &self.peek().start,
+                &self.peek().end,
                 ParseError::UnexpectedEndOfFile,
             ))
         } else {

--- a/juniper/src/parser/parser.rs
+++ b/juniper/src/parser/parser.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::result::Result;
 
-use parser::{Lexer, LexerError, Spanning, Token};
+use crate::parser::{Lexer, LexerError, Spanning, Token};
 
 /// Error while parsing a GraphQL query
 #[derive(Debug, PartialEq)]

--- a/juniper/src/parser/tests/document.rs
+++ b/juniper/src/parser/tests/document.rs
@@ -1,11 +1,11 @@
-use ast::{
+use crate::ast::{
     Arguments, Definition, Document, Field, InputValue, Operation, OperationType, Selection,
 };
-use parser::document::parse_document_source;
-use parser::{ParseError, SourcePosition, Spanning, Token};
-use schema::model::SchemaType;
-use validation::test_harness::{MutationRoot, QueryRoot};
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use crate::parser::document::parse_document_source;
+use crate::parser::{ParseError, SourcePosition, Spanning, Token};
+use crate::schema::model::SchemaType;
+use crate::validation::test_harness::{MutationRoot, QueryRoot};
+use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
 fn parse_document<S>(s: &str) -> Document<S>
 where

--- a/juniper/src/parser/tests/lexer.rs
+++ b/juniper/src/parser/tests/lexer.rs
@@ -1,4 +1,4 @@
-use parser::{Lexer, LexerError, ScalarToken, SourcePosition, Spanning, Token};
+use crate::parser::{Lexer, LexerError, ScalarToken, SourcePosition, Spanning, Token};
 
 fn tokenize_to_vec<'a>(s: &'a str) -> Vec<Spanning<Token<'a>>> {
     let mut tokens = Vec::new();

--- a/juniper/src/parser/tests/value.rs
+++ b/juniper/src/parser/tests/value.rs
@@ -1,8 +1,7 @@
 use indexmap::IndexMap;
 
 use juniper_codegen::{
-    GraphQLInputObjectInternal as GraphQLInputObject,
-    GraphQLEnumInternal as GraphQLEnum,
+    GraphQLEnumInternal as GraphQLEnum, GraphQLInputObjectInternal as GraphQLInputObject,
 };
 
 use crate::ast::{FromInputValue, InputValue, Type};

--- a/juniper/src/parser/tests/value.rs
+++ b/juniper/src/parser/tests/value.rs
@@ -1,13 +1,13 @@
 use indexmap::IndexMap;
 
-use ast::{FromInputValue, InputValue, Type};
-use parser::value::parse_value_literal;
-use parser::{Lexer, Parser, SourcePosition, Spanning};
-use value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::ast::{FromInputValue, InputValue, Type};
+use crate::parser::value::parse_value_literal;
+use crate::parser::{Lexer, Parser, SourcePosition, Spanning};
+use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
 
-use schema::meta::{Argument, EnumMeta, EnumValue, InputObjectMeta, MetaType, ScalarMeta};
-use schema::model::SchemaType;
-use types::scalars::EmptyMutation;
+use crate::schema::meta::{Argument, EnumMeta, EnumValue, InputObjectMeta, MetaType, ScalarMeta};
+use crate::schema::model::SchemaType;
+use crate::types::scalars::EmptyMutation;
 
 #[derive(GraphQLEnumInternal)]
 enum Enum {

--- a/juniper/src/parser/tests/value.rs
+++ b/juniper/src/parser/tests/value.rs
@@ -1,5 +1,10 @@
 use indexmap::IndexMap;
 
+use juniper_codegen::{
+    GraphQLInputObjectInternal as GraphQLInputObject,
+    GraphQLEnumInternal as GraphQLEnum,
+};
+
 use crate::ast::{FromInputValue, InputValue, Type};
 use crate::parser::value::parse_value_literal;
 use crate::parser::{Lexer, Parser, SourcePosition, Spanning};
@@ -9,17 +14,17 @@ use crate::schema::meta::{Argument, EnumMeta, EnumValue, InputObjectMeta, MetaTy
 use crate::schema::model::SchemaType;
 use crate::types::scalars::EmptyMutation;
 
-#[derive(GraphQLEnumInternal)]
+#[derive(GraphQLEnum)]
 enum Enum {
     EnumValue,
 }
 
-#[derive(GraphQLInputObjectInternal)]
+#[derive(GraphQLInputObject)]
 struct Bar {
     foo: String,
 }
 
-#[derive(GraphQLInputObjectInternal)]
+#[derive(GraphQLInputObject)]
 struct Foo {
     key: i32,
     other: Bar,

--- a/juniper/src/parser/utils.rs
+++ b/juniper/src/parser/utils.rs
@@ -60,10 +60,7 @@ impl<T> Spanning<T> {
 
     #[doc(hidden)]
     pub fn spanning(v: Vec<Spanning<T>>) -> Option<Spanning<Vec<Spanning<T>>>> {
-        if let (Some(start), Some(end)) = (
-            v.first().map(|s| s.start),
-            v.last().map(|s| s.end),
-        ) {
+        if let (Some(start), Some(end)) = (v.first().map(|s| s.start), v.last().map(|s| s.end)) {
             Some(Spanning {
                 item: v,
                 start,
@@ -98,11 +95,7 @@ impl SourcePosition {
     pub fn new(index: usize, line: usize, col: usize) -> SourcePosition {
         assert!(index >= line + col);
 
-        SourcePosition {
-            index,
-            line,
-            col,
-        }
+        SourcePosition { index, line, col }
     }
 
     #[doc(hidden)]

--- a/juniper/src/parser/utils.rs
+++ b/juniper/src/parser/utils.rs
@@ -31,43 +31,43 @@ impl<T> Spanning<T> {
     #[doc(hidden)]
     pub fn zero_width(pos: &SourcePosition, item: T) -> Spanning<T> {
         Spanning {
-            item: item,
-            start: pos.clone(),
-            end: pos.clone(),
+            item,
+            start: *pos,
+            end: *pos,
         }
     }
 
     #[doc(hidden)]
     pub fn single_width(pos: &SourcePosition, item: T) -> Spanning<T> {
-        let mut end = pos.clone();
+        let mut end = *pos;
         end.advance_col();
 
         Spanning {
-            item: item,
-            start: pos.clone(),
-            end: end,
+            item,
+            start: *pos,
+            end,
         }
     }
 
     #[doc(hidden)]
     pub fn start_end(start: &SourcePosition, end: &SourcePosition, item: T) -> Spanning<T> {
         Spanning {
-            item: item,
-            start: start.clone(),
-            end: end.clone(),
+            item,
+            start: *start,
+            end: *end,
         }
     }
 
     #[doc(hidden)]
     pub fn spanning(v: Vec<Spanning<T>>) -> Option<Spanning<Vec<Spanning<T>>>> {
         if let (Some(start), Some(end)) = (
-            v.first().map(|s| s.start.clone()),
-            v.last().map(|s| s.end.clone()),
+            v.first().map(|s| s.start),
+            v.last().map(|s| s.end),
         ) {
             Some(Spanning {
                 item: v,
-                start: start,
-                end: end,
+                start,
+                end,
             })
         } else {
             None
@@ -77,7 +77,7 @@ impl<T> Spanning<T> {
     #[doc(hidden)]
     pub fn unlocated(item: T) -> Spanning<T> {
         Spanning {
-            item: item,
+            item,
             start: SourcePosition::new_origin(),
             end: SourcePosition::new_origin(),
         }
@@ -87,8 +87,8 @@ impl<T> Spanning<T> {
     pub fn map<O: fmt::Debug, F: Fn(T) -> O>(self, f: F) -> Spanning<O> {
         Spanning {
             item: f(self.item),
-            start: self.start.clone(),
-            end: self.end.clone(),
+            start: self.start,
+            end: self.end,
         }
     }
 }
@@ -99,9 +99,9 @@ impl SourcePosition {
         assert!(index >= line + col);
 
         SourcePosition {
-            index: index,
-            line: line,
-            col: col,
+            index,
+            line,
+            col,
         }
     }
 

--- a/juniper/src/parser/value.rs
+++ b/juniper/src/parser/value.rs
@@ -171,7 +171,7 @@ where
     let value = parse_value_literal(parser, is_const, schema, tpe)?;
 
     Ok(Spanning::start_end(
-        &key.start.clone(),
+        &key.start,
         &value.end.clone(),
         (key.map(|s| s.to_owned()), value),
     ))

--- a/juniper/src/parser/value.rs
+++ b/juniper/src/parser/value.rs
@@ -1,9 +1,9 @@
-use ast::InputValue;
+use crate::ast::InputValue;
 
-use parser::{ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token};
-use schema::meta::{InputObjectMeta, MetaType};
-use schema::model::SchemaType;
-use value::ScalarValue;
+use crate::parser::{ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token};
+use crate::schema::meta::{InputObjectMeta, MetaType};
+use crate::schema::model::SchemaType;
+use crate::value::ScalarValue;
 
 pub fn parse_value_literal<'a, 'b, S>(
     parser: &mut Parser<'a>,

--- a/juniper/src/parser/value.rs
+++ b/juniper/src/parser/value.rs
@@ -1,6 +1,8 @@
 use crate::ast::InputValue;
 
-use crate::parser::{ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token};
+use crate::parser::{
+    ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token,
+};
 use crate::schema::meta::{InputObjectMeta, MetaType};
 use crate::schema::model::SchemaType;
 use crate::value::ScalarValue;

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -780,12 +780,7 @@ fn clean_docstring(multiline: &[&str]) -> Option<String> {
             .iter()
             .enumerate()
             .flat_map(|(line, ln)| {
-                let new_ln = if !ln
-                    .chars()
-                    .next()
-                    .map(char::is_whitespace)
-                    .unwrap_or(false)
-                {
+                let new_ln = if !ln.chars().next().map(char::is_whitespace).unwrap_or(false) {
                     ln.trim_end() // skip trimming the first line
                 } else if ln.len() >= trim_start {
                     ln[trim_start..].trim_end()

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -3,11 +3,11 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use ast::{FromInputValue, InputValue, Type};
-use parser::{ParseError, ScalarToken};
-use schema::model::SchemaType;
-use types::base::TypeKind;
-use value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::ast::{FromInputValue, InputValue, Type};
+use crate::parser::{ParseError, ScalarToken};
+use crate::schema::model::SchemaType;
+use crate::types::base::TypeKind;
+use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
 
 /// Whether an item is deprecated, with context.
 #[derive(Debug, PartialEq, Hash, Clone)]

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -2,12 +2,12 @@ use std::fmt;
 
 use fnv::FnvHashMap;
 
-use ast::Type;
-use executor::{Context, Registry};
-use schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
-use types::base::GraphQLType;
-use types::name::Name;
-use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use crate::ast::Type;
+use crate::executor::{Context, Registry};
+use crate::schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
+use crate::types::base::GraphQLType;
+use crate::types::name::Name;
+use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
 /// Root query node of a schema
 ///
@@ -319,7 +319,7 @@ impl<'a, S> SchemaType<'a, S> {
     }
 
     pub fn is_subtype<'b>(&self, sub_type: &Type<'b>, super_type: &Type<'b>) -> bool {
-        use ast::Type::*;
+        use crate::ast::Type::*;
 
         if super_type == sub_type {
             return true;

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -6,7 +6,9 @@ use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
 use crate::ast::Type;
 use crate::executor::{Context, Registry};
-use crate::schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
+use crate::schema::meta::{
+    Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta,
+};
 use crate::types::base::GraphQLType;
 use crate::types::name::Name;
 use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -2,6 +2,8 @@ use std::fmt;
 
 use fnv::FnvHashMap;
 
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+
 use crate::ast::Type;
 use crate::executor::{Context, Registry};
 use crate::schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta};
@@ -57,7 +59,7 @@ pub struct DirectiveType<'a, S> {
     pub arguments: Vec<Argument<'a, S>>,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, GraphQLEnumInternal)]
+#[derive(Clone, PartialEq, Eq, Debug, GraphQLEnum)]
 #[graphql(name = "__DirectiveLocation")]
 pub enum DirectiveLocation {
     Query,

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -115,8 +115,8 @@ where
             query_type: query_obj,
             mutation_type: mutation_obj,
             schema: SchemaType::new::<QueryT, MutationT>(&query_info, &mutation_info),
-            query_info: query_info,
-            mutation_info: mutation_info,
+            query_info,
+            mutation_info,
         }
     }
 }
@@ -179,13 +179,13 @@ impl<'a, S> SchemaType<'a, S> {
         }
         SchemaType {
             types: registry.types,
-            query_type_name: query_type_name,
+            query_type_name,
             mutation_type_name: if &mutation_type_name != "_EmptyMutation" {
                 Some(mutation_type_name)
             } else {
                 None
             },
-            directives: directives,
+            directives,
         }
     }
 

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -1,13 +1,13 @@
-use ast::Selection;
-use executor::{ExecutionResult, Executor, Registry};
-use types::base::{Arguments, GraphQLType, TypeKind};
-use value::{ScalarRefValue, ScalarValue, Value};
+use crate::ast::Selection;
+use crate::executor::{ExecutionResult, Executor, Registry};
+use crate::types::base::{Arguments, GraphQLType, TypeKind};
+use crate::value::{ScalarRefValue, ScalarValue, Value};
 
-use schema::meta::{
+use crate::schema::meta::{
     Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType, ObjectMeta,
     UnionMeta,
 };
-use schema::model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, TypeType};
+use crate::schema::model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, TypeType};
 
 impl<'a, CtxT, S, QueryT, MutationT> GraphQLType<S> for RootNode<'a, QueryT, MutationT, S>
 where
@@ -58,8 +58,8 @@ where
         selection_set: Option<&[Selection<S>]>,
         executor: &Executor<Self::Context, S>,
     ) -> Value<S> {
-        use types::base::resolve_selection_set_into;
-        use value::Object;
+        use crate::types::base::resolve_selection_set_into;
+        use crate::value::Object;
         if let Some(selection_set) = selection_set {
             let mut result = Object::with_capacity(selection_set.len());
             if resolve_selection_set_into(self, info, selection_set, executor, &mut result) {

--- a/juniper/src/tests/introspection_tests.rs
+++ b/juniper/src/tests/introspection_tests.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 
 use super::schema_introspection::*;
-use executor::Variables;
-use introspection::IntrospectionFormat;
-use schema::model::RootNode;
-use tests::model::Database;
-use types::scalars::EmptyMutation;
+use crate::executor::Variables;
+use crate::introspection::IntrospectionFormat;
+use crate::schema::model::RootNode;
+use crate::tests::model::Database;
+use crate::types::scalars::EmptyMutation;
 
 #[test]
 fn test_introspection_query_type_name() {
@@ -21,7 +21,7 @@ fn test_introspection_query_type_name() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             graphql_value!({
                 "__schema": {
@@ -48,7 +48,7 @@ fn test_introspection_type_name() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             graphql_value!({
                 "__type": {
@@ -74,7 +74,7 @@ fn test_introspection_specific_object_type_name_and_kind() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             graphql_value!({
                 "__type": {
@@ -101,7 +101,7 @@ fn test_introspection_specific_interface_type_name_and_kind() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             graphql_value!({
                 "__type": {
@@ -128,7 +128,7 @@ fn test_introspection_documentation() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             graphql_value!({
                 "__type": {
@@ -201,7 +201,7 @@ fn test_introspection_possible_types() {
     let database = Database::new();
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
-    let result = ::execute(doc, None, &schema, &Variables::new(), &database);
+    let result = crate::execute(doc, None, &schema, &Variables::new(), &database);
 
     let (result, errors) = result.ok().expect("Query returned error");
 

--- a/juniper/src/tests/model.rs
+++ b/juniper/src/tests/model.rs
@@ -1,8 +1,9 @@
 #![allow(missing_docs)]
 
 use std::collections::HashMap;
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
-#[derive(GraphQLEnumInternal, Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(GraphQLEnum, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Episode {
     #[graphql(name = "NEW_HOPE")]
     NewHope,

--- a/juniper/src/tests/model.rs
+++ b/juniper/src/tests/model.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
-use std::collections::HashMap;
 use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use std::collections::HashMap;
 
 #[derive(GraphQLEnum, Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Episode {

--- a/juniper/src/tests/query_tests.rs
+++ b/juniper/src/tests/query_tests.rs
@@ -1,9 +1,9 @@
-use ast::InputValue;
-use executor::Variables;
-use schema::model::RootNode;
-use tests::model::Database;
-use types::scalars::EmptyMutation;
-use value::Value;
+use crate::ast::InputValue;
+use crate::executor::Variables;
+use crate::schema::model::RootNode;
+use crate::tests::model::Database;
+use crate::types::scalars::EmptyMutation;
+use crate::value::Value;
 
 #[test]
 fn test_hero_name() {
@@ -17,7 +17,7 @@ fn test_hero_name() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -45,7 +45,7 @@ fn test_hero_field_order() {
             }
         }"#;
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -74,7 +74,7 @@ fn test_hero_field_order() {
             }
         }"#;
     assert_eq!(
-        ::execute(doc_reversed, None, &schema, &Variables::new(), &database),
+        crate::execute(doc_reversed, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -112,7 +112,7 @@ fn test_hero_name_and_friends() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -174,7 +174,7 @@ fn test_hero_name_and_friends_and_friends_of_friends() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -335,7 +335,7 @@ fn test_query_name() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -361,7 +361,7 @@ fn test_query_alias_single() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -391,7 +391,7 @@ fn test_query_alias_multiple() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![
@@ -436,7 +436,7 @@ fn test_query_alias_multiple_with_fragment() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![
@@ -482,7 +482,7 @@ fn test_query_name_variable() {
         .collect();
 
     assert_eq!(
-        ::execute(doc, None, &schema, &vars, &database),
+        crate::execute(doc, None, &schema, &vars, &database),
         Ok((
             Value::object(
                 vec![(
@@ -512,7 +512,7 @@ fn test_query_name_invalid_variable() {
         .collect();
 
     assert_eq!(
-        ::execute(doc, None, &schema, &vars, &database),
+        crate::execute(doc, None, &schema, &vars, &database),
         Ok((
             Value::object(vec![("human", Value::null())].into_iter().collect()),
             vec![]
@@ -527,7 +527,7 @@ fn test_query_friends_names() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -584,7 +584,7 @@ fn test_query_inline_fragments_droid() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -621,7 +621,7 @@ fn test_query_inline_fragments_human() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(
@@ -655,7 +655,7 @@ fn test_object_typename() {
     let schema = RootNode::new(&database, EmptyMutation::<Database>::new());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &database),
+        crate::execute(doc, None, &schema, &Variables::new(), &database),
         Ok((
             Value::object(
                 vec![(

--- a/juniper/src/tests/schema.rs
+++ b/juniper/src/tests/schema.rs
@@ -1,5 +1,5 @@
-use executor::Context;
-use tests::model::{Character, Database, Droid, Episode, Human};
+use crate::executor::Context;
+use crate::tests::model::{Character, Database, Droid, Episode, Human};
 
 impl Context for Database {}
 

--- a/juniper/src/tests/type_info_tests.rs
+++ b/juniper/src/tests/type_info_tests.rs
@@ -1,11 +1,11 @@
 use indexmap::IndexMap;
 
-use executor::{ExecutionResult, Executor, Registry, Variables};
-use schema::meta::MetaType;
-use schema::model::RootNode;
-use types::base::{Arguments, GraphQLType};
-use types::scalars::EmptyMutation;
-use value::{ScalarRefValue, ScalarValue, Value};
+use crate::executor::{ExecutionResult, Executor, Registry, Variables};
+use crate::schema::meta::MetaType;
+use crate::schema::model::RootNode;
+use crate::types::base::{Arguments, GraphQLType};
+use crate::types::scalars::EmptyMutation;
+use crate::value::{ScalarRefValue, ScalarValue, Value};
 
 pub struct NodeTypeInfo {
     name: String,
@@ -75,7 +75,7 @@ fn test_node() {
     let schema: RootNode<_, _> = RootNode::new_with_info(node, EmptyMutation::new(), node_info, ());
 
     assert_eq!(
-        ::execute(doc, None, &schema, &Variables::new(), &()),
+        crate::execute(doc, None, &schema, &Variables::new(), &()),
         Ok((
             Value::object(
                 vec![

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -1,12 +1,12 @@
 use indexmap::IndexMap;
 
-use ast::{Directive, FromInputValue, InputValue, Selection};
-use executor::Variables;
-use value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value};
+use crate::ast::{Directive, FromInputValue, InputValue, Selection};
+use crate::executor::Variables;
+use crate::value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value};
 
-use executor::{ExecutionResult, Executor, Registry};
-use parser::Spanning;
-use schema::meta::{Argument, MetaType};
+use crate::executor::{ExecutionResult, Executor, Registry};
+use crate::parser::Spanning;
+use crate::schema::meta::{Argument, MetaType};
 
 /// GraphQL type kind
 ///

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -99,7 +99,7 @@ where
             }
         }
 
-        Arguments { args: args }
+        Arguments { args }
     }
 
     /// Get and convert an argument into the desired type.
@@ -479,16 +479,14 @@ where
                     } else if let Err(e) = sub_result {
                         sub_exec.push_error_at(e, start_pos.clone());
                     }
-                } else {
-                    if !resolve_selection_set_into(
+                } else if !resolve_selection_set_into(
                         instance,
                         info,
                         &fragment.selection_set[..],
                         &sub_exec,
                         result,
-                    ) {
-                        return false;
-                    }
+                ) {
+                    return false;
                 }
             }
         }

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -1,5 +1,7 @@
 use indexmap::IndexMap;
 
+use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+
 use crate::ast::{Directive, FromInputValue, InputValue, Selection};
 use crate::executor::Variables;
 use crate::value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value};
@@ -12,7 +14,7 @@ use crate::schema::meta::{Argument, MetaType};
 ///
 /// The GraphQL specification defines a number of type kinds - the meta type
 /// of a type.
-#[derive(Clone, Eq, PartialEq, Debug, GraphQLEnumInternal)]
+#[derive(Clone, Eq, PartialEq, Debug, GraphQLEnum)]
 #[graphql(name = "__TypeKind")]
 pub enum TypeKind {
     /// ## Scalar types

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -480,11 +480,11 @@ where
                         sub_exec.push_error_at(e, start_pos.clone());
                     }
                 } else if !resolve_selection_set_into(
-                        instance,
-                        info,
-                        &fragment.selection_set[..],
-                        &sub_exec,
-                        result,
+                    instance,
+                    info,
+                    &fragment.selection_set[..],
+                    &sub_exec,
+                    result,
                 ) {
                     return false;
                 }

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -1,9 +1,9 @@
-use ast::{FromInputValue, InputValue, Selection, ToInputValue};
-use schema::meta::MetaType;
-use value::{ScalarRefValue, ScalarValue, Value};
+use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue};
+use crate::schema::meta::MetaType;
+use crate::value::{ScalarRefValue, ScalarValue, Value};
 
-use executor::{Executor, Registry};
-use types::base::GraphQLType;
+use crate::executor::{Executor, Registry};
+use crate::types::base::GraphQLType;
 
 impl<S, T, CtxT> GraphQLType<S> for Option<T>
 where

--- a/juniper/src/types/name.rs
+++ b/juniper/src/types/name.rs
@@ -7,11 +7,11 @@ use std::str::FromStr;
 // stabilise (https://github.com/rust-lang/rust/issues/39658).
 
 fn is_ascii_alphabetic(c: char) -> bool {
-    return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
+    c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
 }
 
 fn is_ascii_digit(c: char) -> bool {
-    return c >= '0' && c <= '9';
+    c >= '0' && c <= '9'
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -20,17 +20,12 @@ pub struct Name(String);
 impl Name {
     pub fn is_valid(input: &str) -> bool {
         for (i, c) in input.chars().enumerate() {
-            if i == 0 {
-                if !is_ascii_alphabetic(c) && c != '_' {
-                    return false;
-                }
-            } else {
-                if !is_ascii_alphabetic(c) && !is_ascii_digit(c) && c != '_' {
-                    return false;
-                }
+            let is_valid = is_ascii_alphabetic(c) || c == '_' || (i > 0 && is_ascii_digit(c));
+            if !is_valid {
+                return false;
             }
         }
-        return !input.is_empty();
+        !input.is_empty()
     }
 }
 

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -1,11 +1,11 @@
-use ast::{FromInputValue, InputValue, Selection, ToInputValue};
+use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use executor::{ExecutionResult, Executor, Registry};
-use schema::meta::MetaType;
-use types::base::{Arguments, GraphQLType};
-use value::{ScalarRefValue, ScalarValue, Value};
+use crate::executor::{ExecutionResult, Executor, Registry};
+use crate::schema::meta::MetaType;
+use crate::types::base::{Arguments, GraphQLType};
+use crate::value::{ScalarRefValue, ScalarValue, Value};
 
 impl<S, T, CtxT> GraphQLType<S> for Box<T>
 where

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -4,12 +4,12 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::{char, u32};
 
-use ast::{FromInputValue, InputValue, Selection, ToInputValue};
-use executor::{Executor, Registry};
-use parser::{LexerError, ParseError, ScalarToken, Token};
-use schema::meta::MetaType;
-use types::base::GraphQLType;
-use value::{ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue, Value};
+use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue};
+use crate::executor::{Executor, Registry};
+use crate::parser::{LexerError, ParseError, ScalarToken, Token};
+use crate::schema::meta::MetaType;
+use crate::types::base::GraphQLType;
+use crate::value::{ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue, Value};
 
 /// An ID as defined by the GraphQL specification
 ///
@@ -355,8 +355,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::ID;
-    use parser::ScalarToken;
-    use value::{DefaultScalarValue, ParseScalarValue};
+    use crate::parser::ScalarToken;
+    use crate::value::{DefaultScalarValue, ParseScalarValue};
 
     #[test]
     fn test_id_from_string() {

--- a/juniper/src/types/utilities.rs
+++ b/juniper/src/types/utilities.rs
@@ -1,8 +1,8 @@
 use crate::ast::InputValue;
 use crate::schema::meta::{EnumMeta, InputObjectMeta, MetaType};
 use crate::schema::model::{SchemaType, TypeType};
-use std::collections::HashSet;
 use crate::value::ScalarValue;
+use std::collections::HashSet;
 
 pub fn is_valid_literal_value<S>(
     schema: &SchemaType<S>,

--- a/juniper/src/types/utilities.rs
+++ b/juniper/src/types/utilities.rs
@@ -1,8 +1,8 @@
-use ast::InputValue;
-use schema::meta::{EnumMeta, InputObjectMeta, MetaType};
-use schema::model::{SchemaType, TypeType};
+use crate::ast::InputValue;
+use crate::schema::meta::{EnumMeta, InputObjectMeta, MetaType};
+use crate::schema::model::{SchemaType, TypeType};
 use std::collections::HashSet;
-use value::ScalarValue;
+use crate::value::ScalarValue;
 
 pub fn is_valid_literal_value<S>(
     schema: &SchemaType<S>,

--- a/juniper/src/validation/context.rs
+++ b/juniper/src/validation/context.rs
@@ -1,12 +1,12 @@
 use std::collections::HashSet;
 use std::fmt::Debug;
 
-use ast::{Definition, Document, Type};
+use crate::ast::{Definition, Document, Type};
 
-use schema::meta::MetaType;
-use schema::model::SchemaType;
+use crate::schema::meta::MetaType;
+use crate::schema::model::SchemaType;
 
-use parser::SourcePosition;
+use crate::parser::SourcePosition;
 
 /// Query validation error
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/juniper/src/validation/context.rs
+++ b/juniper/src/validation/context.rs
@@ -55,7 +55,7 @@ impl<'a, S: Debug> ValidatorContext<'a, S> {
     pub fn new(schema: &'a SchemaType<S>, document: &Document<'a, S>) -> ValidatorContext<'a, S> {
         ValidatorContext {
             errors: Vec::new(),
-            schema: schema,
+            schema,
             type_stack: Vec::new(),
             type_literal_stack: Vec::new(),
             parent_type_stack: Vec::new(),

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 use std::fmt;
 
-use ast::{Definition, Document, InputValue, VariableDefinitions};
-use executor::Variables;
-use parser::SourcePosition;
-use schema::meta::{EnumMeta, InputObjectMeta, MetaType, ScalarMeta};
-use schema::model::{SchemaType, TypeType};
-use validation::RuleError;
-use value::{ScalarRefValue, ScalarValue};
+use crate::ast::{Definition, Document, InputValue, VariableDefinitions};
+use crate::executor::Variables;
+use crate::parser::SourcePosition;
+use crate::schema::meta::{EnumMeta, InputObjectMeta, MetaType, ScalarMeta};
+use crate::schema::model::{SchemaType, TypeType};
+use crate::validation::RuleError;
+use crate::value::{ScalarRefValue, ScalarValue};
 
 #[derive(Debug)]
 enum Path<'a> {

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -61,7 +61,7 @@ fn validate_var_defs<S>(
                             name.item,
                             def.var_type.item,
                         ),
-                        &[name.start.clone()],
+                        &[name.start],
                     ));
                 } else if let Some(v) = values.get(name.item) {
                     errors.append(&mut unify_value(name.item, &name.start, v, &ct, schema, Path::Root));
@@ -72,7 +72,7 @@ fn validate_var_defs<S>(
                     r#"Variable "${}" expected value of type "{}" which cannot be used as an input type."#,
                     name.item, def.var_type.item,
                 ),
-                &[ name.start.clone() ],
+                &[ name.start ],
             )),
         }
     }

--- a/juniper/src/validation/multi_visitor.rs
+++ b/juniper/src/validation/multi_visitor.rs
@@ -1,10 +1,10 @@
-use ast::{
+use crate::ast::{
     Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
     Selection, VariableDefinition,
 };
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub struct MultiVisitorNil;

--- a/juniper/src/validation/rules/arguments_of_correct_type.rs
+++ b/juniper/src/validation/rules/arguments_of_correct_type.rs
@@ -1,10 +1,10 @@
-use ast::{Directive, Field, InputValue};
-use parser::Spanning;
-use schema::meta::Argument;
+use crate::ast::{Directive, Field, InputValue};
+use crate::parser::Spanning;
+use crate::schema::meta::Argument;
 use std::fmt::Debug;
-use types::utilities::is_valid_literal_value;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::types::utilities::is_valid_literal_value;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct ArgumentsOfCorrectType<'a, S: Debug + 'a> {
     current_args: Option<&'a Vec<Argument<'a, S>>>,
@@ -76,9 +76,9 @@ fn error_message(arg_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn good_null_value() {

--- a/juniper/src/validation/rules/arguments_of_correct_type.rs
+++ b/juniper/src/validation/rules/arguments_of_correct_type.rs
@@ -58,7 +58,7 @@ where
             if !is_valid_literal_value(ctx.schema, &meta_type, &arg_value.item) {
                 ctx.report_error(
                     &error_message(arg_name.item, &format!("{}", argument_meta.arg_type)),
-                    &[arg_value.start.clone()],
+                    &[arg_value.start],
                 );
             }
         }

--- a/juniper/src/validation/rules/arguments_of_correct_type.rs
+++ b/juniper/src/validation/rules/arguments_of_correct_type.rs
@@ -1,10 +1,10 @@
 use crate::ast::{Directive, Field, InputValue};
 use crate::parser::Spanning;
 use crate::schema::meta::Argument;
-use std::fmt::Debug;
 use crate::types::utilities::is_valid_literal_value;
 use crate::validation::{ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::fmt::Debug;
 
 pub struct ArgumentsOfCorrectType<'a, S: Debug + 'a> {
     current_args: Option<&'a Vec<Argument<'a, S>>>,

--- a/juniper/src/validation/rules/default_values_of_correct_type.rs
+++ b/juniper/src/validation/rules/default_values_of_correct_type.rs
@@ -1,8 +1,8 @@
-use ast::VariableDefinition;
-use parser::Spanning;
-use types::utilities::is_valid_literal_value;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::VariableDefinition;
+use crate::parser::Spanning;
+use crate::types::utilities::is_valid_literal_value;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct DefaultValuesOfCorrectType;
 
@@ -62,9 +62,9 @@ fn non_null_error_message(arg_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{factory, non_null_error_message, type_error_message};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn variables_with_no_default_values() {

--- a/juniper/src/validation/rules/default_values_of_correct_type.rs
+++ b/juniper/src/validation/rules/default_values_of_correct_type.rs
@@ -28,7 +28,7 @@ where
             if var_def.var_type.item.is_non_null() {
                 ctx.report_error(
                     &non_null_error_message(var_name.item, &format!("{}", var_def.var_type.item)),
-                    &[start.clone()],
+                    &[*start],
                 )
             } else {
                 let meta_type = ctx.schema.make_type(&var_def.var_type.item);
@@ -36,7 +36,7 @@ where
                 if !is_valid_literal_value(ctx.schema, &meta_type, var_value) {
                     ctx.report_error(
                         &type_error_message(var_name.item, &format!("{}", var_def.var_type.item)),
-                        &[start.clone()],
+                        &[*start],
                     );
                 }
             }

--- a/juniper/src/validation/rules/fields_on_correct_type.rs
+++ b/juniper/src/validation/rules/fields_on_correct_type.rs
@@ -1,8 +1,8 @@
-use ast::Field;
-use parser::Spanning;
-use schema::meta::MetaType;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::Field;
+use crate::parser::Spanning;
+use crate::schema::meta::MetaType;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct FieldsOnCorrectType;
 
@@ -55,9 +55,9 @@ fn error_message(field: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn selection_on_object() {

--- a/juniper/src/validation/rules/fields_on_correct_type.rs
+++ b/juniper/src/validation/rules/fields_on_correct_type.rs
@@ -39,7 +39,7 @@ where
 
                     context.report_error(
                         &error_message(field_name.item, type_name),
-                        &[field_name.start.clone()],
+                        &[field_name.start],
                     );
                 }
             }

--- a/juniper/src/validation/rules/fragments_on_composite_types.rs
+++ b/juniper/src/validation/rules/fragments_on_composite_types.rs
@@ -26,7 +26,7 @@ where
 
                     context.report_error(
                         &error_message(Some(f.item.name.item), type_name),
-                        &[type_cond.start.clone()],
+                        &[type_cond.start],
                     );
                 }
             }

--- a/juniper/src/validation/rules/fragments_on_composite_types.rs
+++ b/juniper/src/validation/rules/fragments_on_composite_types.rs
@@ -1,7 +1,7 @@
-use ast::{Fragment, InlineFragment};
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Fragment, InlineFragment};
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct FragmentsOnCompositeTypes;
 
@@ -73,9 +73,9 @@ fn error_message(fragment_name: Option<&str>, on_type: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn on_object() {

--- a/juniper/src/validation/rules/known_argument_names.rs
+++ b/juniper/src/validation/rules/known_argument_names.rs
@@ -1,9 +1,9 @@
 use crate::ast::{Directive, Field, InputValue};
 use crate::parser::Spanning;
 use crate::schema::meta::Argument;
-use std::fmt::Debug;
 use crate::validation::{ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::fmt::Debug;
 
 #[derive(Debug)]
 enum ArgumentPosition<'a> {

--- a/juniper/src/validation/rules/known_argument_names.rs
+++ b/juniper/src/validation/rules/known_argument_names.rs
@@ -82,7 +82,7 @@ where
                     }
                 };
 
-                ctx.report_error(&message, &[arg_name.start.clone()]);
+                ctx.report_error(&message, &[arg_name.start]);
             }
         }
     }

--- a/juniper/src/validation/rules/known_argument_names.rs
+++ b/juniper/src/validation/rules/known_argument_names.rs
@@ -1,9 +1,9 @@
-use ast::{Directive, Field, InputValue};
-use parser::Spanning;
-use schema::meta::Argument;
+use crate::ast::{Directive, Field, InputValue};
+use crate::parser::Spanning;
+use crate::schema::meta::Argument;
 use std::fmt::Debug;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug)]
 enum ArgumentPosition<'a> {
@@ -106,9 +106,9 @@ fn directive_error_message(arg_name: &str, directive_name: &str) -> String {
 mod tests {
     use super::{directive_error_message, factory, field_error_message};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn single_arg_is_known() {

--- a/juniper/src/validation/rules/known_directives.rs
+++ b/juniper/src/validation/rules/known_directives.rs
@@ -123,7 +123,7 @@ where
         } else {
             ctx.report_error(
                 &unknown_error_message(directive_name),
-                &[directive.start.clone()],
+                &[directive.start],
             );
         }
     }

--- a/juniper/src/validation/rules/known_directives.rs
+++ b/juniper/src/validation/rules/known_directives.rs
@@ -1,4 +1,6 @@
-use crate::ast::{Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType};
+use crate::ast::{
+    Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType,
+};
 use crate::parser::Spanning;
 use crate::schema::model::DirectiveLocation;
 use crate::validation::{ValidatorContext, Visitor};
@@ -121,10 +123,7 @@ where
                 }
             }
         } else {
-            ctx.report_error(
-                &unknown_error_message(directive_name),
-                &[directive.start],
-            );
+            ctx.report_error(&unknown_error_message(directive_name), &[directive.start]);
         }
     }
 }

--- a/juniper/src/validation/rules/known_directives.rs
+++ b/juniper/src/validation/rules/known_directives.rs
@@ -1,8 +1,8 @@
-use ast::{Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType};
-use parser::Spanning;
-use schema::model::DirectiveLocation;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType};
+use crate::parser::Spanning;
+use crate::schema::model::DirectiveLocation;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct KnownDirectives {
     location_stack: Vec<DirectiveLocation>,
@@ -144,10 +144,10 @@ fn misplaced_error_message(directive_name: &str, location: &DirectiveLocation) -
 mod tests {
     use super::{factory, misplaced_error_message, unknown_error_message};
 
-    use parser::SourcePosition;
-    use schema::model::DirectiveLocation;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::schema::model::DirectiveLocation;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn with_no_directives() {

--- a/juniper/src/validation/rules/known_fragment_names.rs
+++ b/juniper/src/validation/rules/known_fragment_names.rs
@@ -20,10 +20,7 @@ where
     ) {
         let spread_name = &spread.item.name;
         if !context.is_known_fragment(spread_name.item) {
-            context.report_error(
-                &error_message(spread_name.item),
-                &[spread_name.start],
-            );
+            context.report_error(&error_message(spread_name.item), &[spread_name.start]);
         }
     }
 }

--- a/juniper/src/validation/rules/known_fragment_names.rs
+++ b/juniper/src/validation/rules/known_fragment_names.rs
@@ -1,7 +1,7 @@
-use ast::FragmentSpread;
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::FragmentSpread;
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct KnownFragmentNames;
 
@@ -36,9 +36,9 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn known() {

--- a/juniper/src/validation/rules/known_fragment_names.rs
+++ b/juniper/src/validation/rules/known_fragment_names.rs
@@ -22,7 +22,7 @@ where
         if !context.is_known_fragment(spread_name.item) {
             context.report_error(
                 &error_message(spread_name.item),
-                &[spread_name.start.clone()],
+                &[spread_name.start],
             );
         }
     }

--- a/juniper/src/validation/rules/known_type_names.rs
+++ b/juniper/src/validation/rules/known_type_names.rs
@@ -1,8 +1,8 @@
-use ast::{Fragment, InlineFragment, VariableDefinition};
-use parser::{SourcePosition, Spanning};
+use crate::ast::{Fragment, InlineFragment, VariableDefinition};
+use crate::parser::{SourcePosition, Spanning};
 use std::fmt::Debug;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct KnownTypeNames;
 
@@ -61,9 +61,9 @@ fn error_message(type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn known_type_names_are_valid() {

--- a/juniper/src/validation/rules/known_type_names.rs
+++ b/juniper/src/validation/rules/known_type_names.rs
@@ -49,7 +49,7 @@ fn validate_type<'a, S: Debug>(
     location: &SourcePosition,
 ) {
     if ctx.schema.type_by_name(type_name).is_none() {
-        ctx.report_error(&error_message(type_name), &[location.clone()]);
+        ctx.report_error(&error_message(type_name), &[*location]);
     }
 }
 

--- a/juniper/src/validation/rules/known_type_names.rs
+++ b/juniper/src/validation/rules/known_type_names.rs
@@ -1,8 +1,8 @@
 use crate::ast::{Fragment, InlineFragment, VariableDefinition};
 use crate::parser::{SourcePosition, Spanning};
-use std::fmt::Debug;
 use crate::validation::{ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::fmt::Debug;
 
 pub struct KnownTypeNames;
 

--- a/juniper/src/validation/rules/lone_anonymous_operation.rs
+++ b/juniper/src/validation/rules/lone_anonymous_operation.rs
@@ -35,7 +35,7 @@ where
     ) {
         if let Some(operation_count) = self.operation_count {
             if operation_count > 1 && op.item.name.is_none() {
-                ctx.report_error(error_message(), &[op.start.clone()]);
+                ctx.report_error(error_message(), &[op.start]);
             }
         }
     }

--- a/juniper/src/validation/rules/lone_anonymous_operation.rs
+++ b/juniper/src/validation/rules/lone_anonymous_operation.rs
@@ -1,7 +1,7 @@
-use ast::{Definition, Document, Operation};
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Definition, Document, Operation};
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct LoneAnonymousOperation {
     operation_count: Option<usize>,
@@ -49,9 +49,9 @@ fn error_message() -> &'static str {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn no_operations() {

--- a/juniper/src/validation/rules/mod.rs
+++ b/juniper/src/validation/rules/mod.rs
@@ -24,9 +24,9 @@ mod variables_are_input_types;
 mod variables_in_allowed_position;
 
 use crate::ast::Document;
-use std::fmt::Debug;
 use crate::validation::{visit, MultiVisitorNil, ValidatorContext};
 use crate::value::ScalarValue;
+use std::fmt::Debug;
 
 pub(crate) fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)
 where

--- a/juniper/src/validation/rules/mod.rs
+++ b/juniper/src/validation/rules/mod.rs
@@ -23,10 +23,10 @@ mod unique_variable_names;
 mod variables_are_input_types;
 mod variables_in_allowed_position;
 
-use ast::Document;
+use crate::ast::Document;
 use std::fmt::Debug;
-use validation::{visit, MultiVisitorNil, ValidatorContext};
-use value::ScalarValue;
+use crate::validation::{visit, MultiVisitorNil, ValidatorContext};
+use crate::value::ScalarValue;
 
 pub(crate) fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)
 where

--- a/juniper/src/validation/rules/no_fragment_cycles.rs
+++ b/juniper/src/validation/rules/no_fragment_cycles.rs
@@ -81,8 +81,8 @@ where
                 .entry(current_fragment)
                 .or_insert_with(Vec::new)
                 .push(Spanning::start_end(
-                    &spread.start.clone(),
-                    &spread.end.clone(),
+                    &spread.start,
+                    &spread.end,
                     spread.item.name.item,
                 ));
         }

--- a/juniper/src/validation/rules/no_fragment_cycles.rs
+++ b/juniper/src/validation/rules/no_fragment_cycles.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use ast::{Document, Fragment, FragmentSpread};
-use parser::Spanning;
-use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Document, Fragment, FragmentSpread};
+use crate::parser::Spanning;
+use crate::validation::{RuleError, ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct NoFragmentCycles<'a> {
     current_fragment: Option<&'a str>,
@@ -133,9 +133,9 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn single_reference_is_valid() {

--- a/juniper/src/validation/rules/no_undefined_variables.rs
+++ b/juniper/src/validation/rules/no_undefined_variables.rs
@@ -77,7 +77,7 @@ where
                     .map(|var| {
                         RuleError::new(
                             &error_message(var.item, *op_name),
-                            &[var.start.clone(), pos.clone()],
+                            &[var.start, *pos],
                         )
                     })
                     .collect(),
@@ -93,7 +93,7 @@ where
         let op_name = op.item.name.as_ref().map(|s| s.item);
         self.current_scope = Some(Scope::Operation(op_name));
         self.defined_variables
-            .insert(op_name, (op.start.clone(), HashSet::new()));
+            .insert(op_name, (op.start, HashSet::new()));
     }
 
     fn enter_fragment_definition(
@@ -144,7 +144,7 @@ where
                         .referenced_variables()
                         .iter()
                         .map(|&var_name| {
-                            Spanning::start_end(&value.start.clone(), &value.end.clone(), var_name)
+                            Spanning::start_end(&value.start, &value.end, var_name)
                         })
                         .collect(),
                 );

--- a/juniper/src/validation/rules/no_undefined_variables.rs
+++ b/juniper/src/validation/rules/no_undefined_variables.rs
@@ -1,8 +1,8 @@
 use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
 use crate::parser::{SourcePosition, Spanning};
-use std::collections::{HashMap, HashSet};
 use crate::validation::{RuleError, ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -75,10 +75,7 @@ where
                 unused
                     .into_iter()
                     .map(|var| {
-                        RuleError::new(
-                            &error_message(var.item, *op_name),
-                            &[var.start, *pos],
-                        )
+                        RuleError::new(&error_message(var.item, *op_name), &[var.start, *pos])
                     })
                     .collect(),
             );
@@ -143,9 +140,7 @@ where
                         .item
                         .referenced_variables()
                         .iter()
-                        .map(|&var_name| {
-                            Spanning::start_end(&value.start, &value.end, var_name)
-                        })
+                        .map(|&var_name| Spanning::start_end(&value.start, &value.end, var_name))
                         .collect(),
                 );
         }

--- a/juniper/src/validation/rules/no_undefined_variables.rs
+++ b/juniper/src/validation/rules/no_undefined_variables.rs
@@ -1,8 +1,8 @@
-use ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
-use parser::{SourcePosition, Spanning};
+use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
+use crate::parser::{SourcePosition, Spanning};
 use std::collections::{HashMap, HashSet};
-use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{RuleError, ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -167,9 +167,9 @@ fn error_message(var_name: &str, op_name: Option<&str>) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn all_variables_defined() {

--- a/juniper/src/validation/rules/no_unused_fragments.rs
+++ b/juniper/src/validation/rules/no_unused_fragments.rs
@@ -63,7 +63,7 @@ where
 
         for fragment in &self.defined_fragments {
             if !reachable.contains(&fragment.item) {
-                ctx.report_error(&error_message(fragment.item), &[fragment.start.clone()]);
+                ctx.report_error(&error_message(fragment.item), &[fragment.start]);
             }
         }
     }
@@ -73,7 +73,7 @@ where
         _: &mut ValidatorContext<'a, S>,
         op: &'a Spanning<Operation<S>>,
     ) {
-        let op_name = op.item.name.as_ref().map(|s| s.item.as_ref());
+        let op_name = op.item.name.as_ref().map(|s| s.item);
         self.current_scope = Some(Scope::Operation(op_name));
     }
 

--- a/juniper/src/validation/rules/no_unused_fragments.rs
+++ b/juniper/src/validation/rules/no_unused_fragments.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use ast::{Definition, Document, Fragment, FragmentSpread, Operation};
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Definition, Document, Fragment, FragmentSpread, Operation};
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -109,9 +109,9 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn all_fragment_names_are_used() {

--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -1,8 +1,8 @@
 use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
 use crate::parser::Spanning;
-use std::collections::{HashMap, HashSet};
 use crate::validation::{RuleError, ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -75,9 +75,7 @@ where
                 def_vars
                     .iter()
                     .filter(|var| !used.contains(var.item))
-                    .map(|var| {
-                        RuleError::new(&error_message(var.item, *op_name), &[var.start])
-                    })
+                    .map(|var| RuleError::new(&error_message(var.item, *op_name), &[var.start]))
                     .collect(),
             );
         }

--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -1,8 +1,8 @@
-use ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
-use parser::Spanning;
+use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
+use crate::parser::Spanning;
 use std::collections::{HashMap, HashSet};
-use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{RuleError, ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -155,9 +155,9 @@ fn error_message(var_name: &str, op_name: Option<&str>) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn uses_all_variables() {

--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -76,7 +76,7 @@ where
                     .iter()
                     .filter(|var| !used.contains(var.item))
                     .map(|var| {
-                        RuleError::new(&error_message(var.item, *op_name), &[var.start.clone()])
+                        RuleError::new(&error_message(var.item, *op_name), &[var.start])
                     })
                     .collect(),
             );

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -1,13 +1,13 @@
-use ast::{Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type};
-use parser::{SourcePosition, Spanning};
-use schema::meta::{Field as FieldType, MetaType};
+use crate::ast::{Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type};
+use crate::parser::{SourcePosition, Spanning};
+use crate::schema::meta::{Field as FieldType, MetaType};
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug)]
 struct Conflict(ConflictReason, Vec<SourcePosition>, Vec<SourcePosition>);
@@ -740,17 +740,17 @@ mod tests {
     use super::ConflictReasonMessage::*;
     use super::{error_message, factory, ConflictReason};
 
-    use executor::Registry;
-    use schema::meta::MetaType;
-    use types::base::GraphQLType;
-    use types::scalars::{EmptyMutation, ID};
+    use crate::executor::Registry;
+    use crate::schema::meta::MetaType;
+    use crate::types::base::GraphQLType;
+    use crate::types::scalars::{EmptyMutation, ID};
 
-    use parser::SourcePosition;
-    use validation::{
+    use crate::parser::SourcePosition;
+    use crate::validation::{
         expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
         expect_passes_rule_with_schema, RuleError,
     };
-    use value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
     #[test]
     fn unique_fields() {

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -375,8 +375,8 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                             name1, name2
                         )),
                     ),
-                    vec![ast1.start.clone()],
-                    vec![ast2.start.clone()],
+                    vec![ast1.start],
+                    vec![ast2.start],
                 ));
             }
 
@@ -386,8 +386,8 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                         response_name.to_owned(),
                         ConflictReasonMessage::Message("they have differing arguments".to_owned()),
                     ),
-                    vec![ast1.start.clone()],
-                    vec![ast2.start.clone()],
+                    vec![ast1.start],
+                    vec![ast2.start],
                 ));
             }
         }
@@ -405,8 +405,8 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                             t1, t2
                         )),
                     ),
-                    vec![ast1.start.clone()],
-                    vec![ast2.start.clone()],
+                    vec![ast1.start],
+                    vec![ast2.start],
                 ));
             }
         }
@@ -415,9 +415,9 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
         {
             let conflicts = self.find_conflicts_between_sub_selection_sets(
                 mutually_exclusive,
-                t1.map(|t| t.innermost_name()),
+                t1.map(Type::innermost_name),
                 s1,
-                t2.map(|t| t.innermost_name()),
+                t2.map(Type::innermost_name),
                 s2,
                 ctx,
             );
@@ -509,7 +509,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                 response_name.to_owned(),
                 ConflictReasonMessage::Nested(conflicts.iter().map(|c| c.0.clone()).collect()),
             ),
-            vec![pos1.clone()]
+            vec![*pos1]
                 .into_iter()
                 .chain(
                     conflicts
@@ -517,7 +517,7 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                         .flat_map(|&Conflict(_, ref fs1, _)| fs1.clone()),
                 )
                 .collect(),
-            vec![pos2.clone()]
+            vec![*pos2]
                 .into_iter()
                 .chain(
                     conflicts
@@ -539,8 +539,8 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
                 let ct1 = ctx.schema.concrete_type_by_name(n1);
                 let ct2 = ctx.schema.concrete_type_by_name(n2);
 
-                if ct1.map(|ct| ct.is_leaf()).unwrap_or(false)
-                    || ct2.map(|ct| ct.is_leaf()).unwrap_or(false)
+                if ct1.map(MetaType::is_leaf).unwrap_or(false)
+                    || ct2.map(MetaType::is_leaf).unwrap_or(false)
                 {
                     n1 != n2
                 } else {

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -1,13 +1,15 @@
-use crate::ast::{Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type};
+use crate::ast::{
+    Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type,
+};
 use crate::parser::{SourcePosition, Spanning};
 use crate::schema::meta::{Field as FieldType, MetaType};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
 
 #[derive(Debug)]
 struct Conflict(ConflictReason, Vec<SourcePosition>, Vec<SourcePosition>);

--- a/juniper/src/validation/rules/possible_fragment_spreads.rs
+++ b/juniper/src/validation/rules/possible_fragment_spreads.rs
@@ -1,11 +1,11 @@
 use std::fmt::Debug;
 
-use ast::{Definition, Document, FragmentSpread, InlineFragment};
-use parser::Spanning;
-use schema::meta::MetaType;
+use crate::ast::{Definition, Document, FragmentSpread, InlineFragment};
+use crate::parser::Spanning;
+use crate::schema::meta::MetaType;
 use std::collections::HashMap;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct PossibleFragmentSpreads<'a, S: Debug + 'a> {
     fragment_types: HashMap<&'a str, &'a MetaType<'a, S>>,
@@ -99,9 +99,9 @@ fn error_message(frag_name: Option<&str>, parent_type_name: &str, frag_type: &st
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn of_the_same_object() {

--- a/juniper/src/validation/rules/possible_fragment_spreads.rs
+++ b/juniper/src/validation/rules/possible_fragment_spreads.rs
@@ -50,7 +50,7 @@ where
                         parent_type.name().unwrap_or("<unknown>"),
                         frag_type.name().unwrap_or("<unknown>"),
                     ),
-                    &[frag.start.clone()],
+                    &[frag.start],
                 );
             }
         }
@@ -72,7 +72,7 @@ where
                         parent_type.name().unwrap_or("<unknown>"),
                         frag_type.name().unwrap_or("<unknown>"),
                     ),
-                    &[spread.start.clone()],
+                    &[spread.start],
                 );
             }
         }

--- a/juniper/src/validation/rules/possible_fragment_spreads.rs
+++ b/juniper/src/validation/rules/possible_fragment_spreads.rs
@@ -3,9 +3,9 @@ use std::fmt::Debug;
 use crate::ast::{Definition, Document, FragmentSpread, InlineFragment};
 use crate::parser::Spanning;
 use crate::schema::meta::MetaType;
-use std::collections::HashMap;
 use crate::validation::{ValidatorContext, Visitor};
 use crate::value::ScalarValue;
+use std::collections::HashMap;
 
 pub struct PossibleFragmentSpreads<'a, S: Debug + 'a> {
     fragment_types: HashMap<&'a str, &'a MetaType<'a, S>>,

--- a/juniper/src/validation/rules/provided_non_null_arguments.rs
+++ b/juniper/src/validation/rules/provided_non_null_arguments.rs
@@ -1,9 +1,9 @@
-use ast::{Directive, Field};
-use parser::Spanning;
-use schema::meta::Field as FieldType;
-use schema::model::DirectiveType;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Directive, Field};
+use crate::parser::Spanning;
+use crate::schema::meta::Field as FieldType;
+use crate::schema::model::DirectiveType;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct ProvidedNonNullArguments;
 
@@ -98,9 +98,9 @@ fn directive_error_message(directive_name: &str, arg_name: &str, type_name: &str
 mod tests {
     use super::{directive_error_message, factory, field_error_message};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn ignores_unknown_arguments() {

--- a/juniper/src/validation/rules/provided_non_null_arguments.rs
+++ b/juniper/src/validation/rules/provided_non_null_arguments.rs
@@ -38,7 +38,7 @@ where
                             &meta_arg.name,
                             &format!("{}", meta_arg.arg_type),
                         ),
-                        &[field.start.clone()],
+                        &[field.start],
                     );
                 }
             }
@@ -72,7 +72,7 @@ where
                             &meta_arg.name,
                             &format!("{}", meta_arg.arg_type),
                         ),
-                        &[directive.start.clone()],
+                        &[directive.start],
                     );
                 }
             }

--- a/juniper/src/validation/rules/scalar_leafs.rs
+++ b/juniper/src/validation/rules/scalar_leafs.rs
@@ -1,7 +1,7 @@
-use ast::Field;
-use parser::Spanning;
-use validation::{RuleError, ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::Field;
+use crate::parser::Spanning;
+use crate::validation::{RuleError, ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct ScalarLeafs;
 
@@ -57,9 +57,9 @@ fn required_error_message(field_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{factory, no_allowed_error_message, required_error_message};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn valid_scalar_selection() {

--- a/juniper/src/validation/rules/scalar_leafs.rs
+++ b/juniper/src/validation/rules/scalar_leafs.rs
@@ -22,11 +22,11 @@ where
             match (field_type.is_leaf(), &field.item.selection_set) {
                 (true, &Some(_)) => Some(RuleError::new(
                     &no_allowed_error_message(field_name, &format!("{}", field_type_literal)),
-                    &[field.start.clone()],
+                    &[field.start],
                 )),
                 (false, &None) => Some(RuleError::new(
                     &required_error_message(field_name, &format!("{}", field_type_literal)),
-                    &[field.start.clone()],
+                    &[field.start],
                 )),
                 _ => None,
             }

--- a/juniper/src/validation/rules/unique_argument_names.rs
+++ b/juniper/src/validation/rules/unique_argument_names.rs
@@ -36,11 +36,11 @@ where
             Entry::Occupied(e) => {
                 ctx.report_error(
                     &error_message(arg_name.item),
-                    &[e.get().clone(), arg_name.start.clone()],
+                    &[e.get().clone(), arg_name.start],
                 );
             }
             Entry::Vacant(e) => {
-                e.insert(arg_name.start.clone());
+                e.insert(arg_name.start);
             }
         }
     }

--- a/juniper/src/validation/rules/unique_argument_names.rs
+++ b/juniper/src/validation/rules/unique_argument_names.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use ast::{Directive, Field, InputValue};
-use parser::{SourcePosition, Spanning};
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Directive, Field, InputValue};
+use crate::parser::{SourcePosition, Spanning};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueArgumentNames<'a> {
     known_names: HashMap<&'a str, SourcePosition>,
@@ -54,9 +54,9 @@ fn error_message(arg_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn no_arguments_on_field() {

--- a/juniper/src/validation/rules/unique_fragment_names.rs
+++ b/juniper/src/validation/rules/unique_fragment_names.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use ast::Fragment;
-use parser::{SourcePosition, Spanning};
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::Fragment;
+use crate::parser::{SourcePosition, Spanning};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueFragmentNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -46,9 +46,9 @@ fn duplicate_message(frag_name: &str) -> String {
 mod tests {
     use super::{duplicate_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn no_fragments() {

--- a/juniper/src/validation/rules/unique_fragment_names.rs
+++ b/juniper/src/validation/rules/unique_fragment_names.rs
@@ -28,11 +28,11 @@ where
             Entry::Occupied(e) => {
                 context.report_error(
                     &duplicate_message(f.item.name.item),
-                    &[e.get().clone(), f.item.name.start.clone()],
+                    &[e.get().clone(), f.item.name.start],
                 );
             }
             Entry::Vacant(e) => {
-                e.insert(f.item.name.start.clone());
+                e.insert(f.item.name.start);
             }
         }
     }

--- a/juniper/src/validation/rules/unique_input_field_names.rs
+++ b/juniper/src/validation/rules/unique_input_field_names.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use ast::InputValue;
-use parser::{SourcePosition, Spanning};
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::InputValue;
+use crate::parser::{SourcePosition, Spanning};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueInputFieldNames<'a> {
     known_name_stack: Vec<HashMap<&'a str, SourcePosition>>,
@@ -64,9 +64,9 @@ fn error_message(field_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn input_object_with_fields() {

--- a/juniper/src/validation/rules/unique_input_field_names.rs
+++ b/juniper/src/validation/rules/unique_input_field_names.rs
@@ -45,11 +45,11 @@ where
                 Entry::Occupied(e) => {
                     ctx.report_error(
                         &error_message(&field_name.item),
-                        &[e.get().clone(), field_name.start.clone()],
+                        &[e.get().clone(), field_name.start],
                     );
                 }
                 Entry::Vacant(e) => {
-                    e.insert(field_name.start.clone());
+                    e.insert(field_name.start);
                 }
             }
         }

--- a/juniper/src/validation/rules/unique_operation_names.rs
+++ b/juniper/src/validation/rules/unique_operation_names.rs
@@ -29,11 +29,11 @@ where
                 Entry::Occupied(e) => {
                     ctx.report_error(
                         &error_message(op_name.item),
-                        &[e.get().clone(), op.start.clone()],
+                        &[e.get().clone(), op.start],
                     );
                 }
                 Entry::Vacant(e) => {
-                    e.insert(op.start.clone());
+                    e.insert(op.start);
                 }
             }
         }

--- a/juniper/src/validation/rules/unique_operation_names.rs
+++ b/juniper/src/validation/rules/unique_operation_names.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use ast::Operation;
-use parser::{SourcePosition, Spanning};
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::Operation;
+use crate::parser::{SourcePosition, Spanning};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueOperationNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -48,9 +48,9 @@ fn error_message(op_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn no_operations() {

--- a/juniper/src/validation/rules/unique_operation_names.rs
+++ b/juniper/src/validation/rules/unique_operation_names.rs
@@ -27,10 +27,7 @@ where
         if let Some(ref op_name) = op.item.name {
             match self.names.entry(op_name.item) {
                 Entry::Occupied(e) => {
-                    ctx.report_error(
-                        &error_message(op_name.item),
-                        &[e.get().clone(), op.start],
-                    );
+                    ctx.report_error(&error_message(op_name.item), &[e.get().clone(), op.start]);
                 }
                 Entry::Vacant(e) => {
                     e.insert(op.start);

--- a/juniper/src/validation/rules/unique_variable_names.rs
+++ b/juniper/src/validation/rules/unique_variable_names.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use ast::{Operation, VariableDefinition};
-use parser::{SourcePosition, Spanning};
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Operation, VariableDefinition};
+use crate::parser::{SourcePosition, Spanning};
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueVariableNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -54,9 +54,9 @@ fn error_message(var_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn unique_variable_names() {

--- a/juniper/src/validation/rules/unique_variable_names.rs
+++ b/juniper/src/validation/rules/unique_variable_names.rs
@@ -36,11 +36,11 @@ where
             Entry::Occupied(e) => {
                 ctx.report_error(
                     &error_message(var_name.item),
-                    &[e.get().clone(), var_name.start.clone()],
+                    &[e.get().clone(), var_name.start],
                 );
             }
             Entry::Vacant(e) => {
-                e.insert(var_name.start.clone());
+                e.insert(var_name.start);
             }
         }
     }

--- a/juniper/src/validation/rules/variables_are_input_types.rs
+++ b/juniper/src/validation/rules/variables_are_input_types.rs
@@ -1,7 +1,7 @@
-use ast::VariableDefinition;
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::VariableDefinition;
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 pub struct UniqueVariableNames;
 
@@ -43,9 +43,9 @@ fn error_message(var_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn input_types_are_valid() {

--- a/juniper/src/validation/rules/variables_are_input_types.rs
+++ b/juniper/src/validation/rules/variables_are_input_types.rs
@@ -25,7 +25,7 @@ where
             if !var_type.is_input() {
                 ctx.report_error(
                     &error_message(var_name.item, &format!("{}", var_def.var_type.item)),
-                    &[var_def.var_type.start.clone()],
+                    &[var_def.var_type.start],
                 );
             }
         }

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
-use ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition};
-use parser::Spanning;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition};
+use crate::parser::Spanning;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -161,9 +161,9 @@ fn error_message(var_name: &str, type_name: &str, expected_type_name: &str) -> S
 mod tests {
     use super::{error_message, factory};
 
-    use parser::SourcePosition;
-    use validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use value::DefaultScalarValue;
+    use crate::parser::SourcePosition;
+    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
+    use crate::value::DefaultScalarValue;
 
     #[test]
     fn boolean_into_boolean() {

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -47,7 +47,7 @@ impl<'a, S: Debug> VariableInAllowedPosition<'a, S> {
             for &(ref var_name, ref var_type) in usages {
                 if let Some(&&(ref var_def_name, ref var_def)) = var_defs
                     .iter()
-                    .find(|&&&(ref n, _)| &n.item == var_name.item)
+                    .find(|&&&(ref n, _)| n.item == var_name.item)
                 {
                     let expected_type = match (&var_def.default_value, &var_def.var_type.item) {
                         (&Some(_), &Type::List(ref inner)) => Type::NonNullList(inner.clone()),
@@ -64,7 +64,7 @@ impl<'a, S: Debug> VariableInAllowedPosition<'a, S> {
                                 &format!("{}", expected_type),
                                 &format!("{}", var_type),
                             ),
-                            &[var_def_name.start.clone(), var_name.start.clone()],
+                            &[var_def_name.start, var_name.start],
                         );
                     }
                 }

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -1,12 +1,12 @@
-use ast::{FromInputValue, InputValue};
-use executor::Registry;
-use parser::parse_document_source;
-use schema::meta::{EnumValue, MetaType};
-use schema::model::{DirectiveLocation, DirectiveType, RootNode};
-use types::base::GraphQLType;
-use types::scalars::ID;
-use validation::{visit, MultiVisitorNil, RuleError, ValidatorContext, Visitor};
-use value::{ScalarRefValue, ScalarValue};
+use crate::ast::{FromInputValue, InputValue};
+use crate::executor::Registry;
+use crate::parser::parse_document_source;
+use crate::schema::meta::{EnumValue, MetaType};
+use crate::schema::model::{DirectiveLocation, DirectiveType, RootNode};
+use crate::types::base::GraphQLType;
+use crate::types::scalars::ID;
+use crate::validation::{visit, MultiVisitorNil, RuleError, ValidatorContext, Visitor};
+use crate::value::{ScalarRefValue, ScalarValue};
 
 struct Being;
 struct Pet;

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -1,3 +1,5 @@
+use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+
 use crate::ast::{FromInputValue, InputValue};
 use crate::executor::Registry;
 use crate::parser::parse_document_source;
@@ -27,7 +29,7 @@ struct ComplicatedArgs;
 
 pub(crate) struct QueryRoot;
 
-#[derive(Debug, GraphQLInputObjectInternal)]
+#[derive(Debug, GraphQLInputObject)]
 struct TestInput {
     id: i32,
     name: String,

--- a/juniper/src/validation/traits.rs
+++ b/juniper/src/validation/traits.rs
@@ -1,10 +1,10 @@
-use ast::{
+use crate::ast::{
     Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
     Selection, VariableDefinition,
 };
-use parser::Spanning;
-use validation::ValidatorContext;
-use value::ScalarValue;
+use crate::parser::Spanning;
+use crate::validation::ValidatorContext;
+use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub trait Visitor<'a, S>

--- a/juniper/src/validation/visitor.rs
+++ b/juniper/src/validation/visitor.rs
@@ -1,14 +1,14 @@
 use std::borrow::Cow;
 
-use ast::{
+use crate::ast::{
     Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread, InlineFragment,
     InputValue, Operation, OperationType, Selection, Type, VariableDefinitions,
 };
-use parser::Spanning;
-use schema::meta::Argument;
-use validation::multi_visitor::MultiVisitorCons;
-use validation::{ValidatorContext, Visitor};
-use value::ScalarValue;
+use crate::parser::Spanning;
+use crate::schema::meta::Argument;
+use crate::validation::multi_visitor::MultiVisitorCons;
+use crate::validation::{ValidatorContext, Visitor};
+use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub fn visit<'a, A, B, S>(
@@ -353,7 +353,7 @@ fn enter_input_value<'a, S, V>(
     S: ScalarValue,
     V: Visitor<'a, S>,
 {
-    use InputValue::*;
+    use crate::InputValue::*;
 
     let start = &input_value.start;
     let end = &input_value.end;
@@ -376,7 +376,7 @@ fn exit_input_value<'a, S, V>(
     S: ScalarValue,
     V: Visitor<'a, S>,
 {
-    use InputValue::*;
+    use crate::InputValue::*;
 
     let start = &input_value.start;
     let end = &input_value.end;

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -1,5 +1,5 @@
-use ast::{InputValue, ToInputValue};
-use parser::Spanning;
+use crate::ast::{InputValue, ToInputValue};
+use crate::parser::Spanning;
 mod object;
 mod scalar;
 

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -242,8 +242,8 @@ where
 /// Here are some examples; the resulting JSON will look just like what you
 /// passed in.
 /// ```rust
-/// #[macro_use] extern crate juniper;
-/// # use juniper::{Value, DefaultScalarValue};
+/// extern crate juniper;
+/// # use juniper::{Value, DefaultScalarValue, graphql_value};
 /// # type V = Value<DefaultScalarValue>;
 ///
 /// # fn main() {

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -39,25 +39,25 @@ where
     }
 
     /// Construct an integer value.
-    #[deprecated(since = "0.11", note = "Use `Value::scalar` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::scalar` instead")]
     pub fn int(i: i32) -> Self {
         Self::scalar(i)
     }
 
     /// Construct a floating point value.
-    #[deprecated(since = "0.11", note = "Use `Value::scalar` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::scalar` instead")]
     pub fn float(f: f64) -> Self {
         Self::scalar(f)
     }
 
     /// Construct a string value.
-    #[deprecated(since = "0.11", note = "Use `Value::scalar` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::scalar` instead")]
     pub fn string(s: &str) -> Self {
         Self::scalar(s.to_owned())
     }
 
     /// Construct a boolean value.
-    #[deprecated(since = "0.11", note = "Use `Value::scalar` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::scalar` instead")]
     pub fn boolean(b: bool) -> Self {
         Self::scalar(b)
     }
@@ -102,12 +102,12 @@ where
     }
 
     /// View the underlying float value, if present.
-    #[deprecated(since = "0.11", note = "Use `Value::as_scalar_value` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::as_scalar_value` instead")]
     pub fn as_float_value(&self) -> Option<f64>
     where
         for<'a> &'a S: ScalarRefValue<'a>,
     {
-        self.as_scalar_value::<f64>().map(|v| *v)
+        self.as_scalar_value::<f64>().cloned()
     }
 
     /// View the underlying object value, if present.
@@ -143,7 +143,7 @@ where
     }
 
     /// View the underlying string value, if present.
-    #[deprecated(since = "0.11", note = "Use `Value::as_scalar_value` instead")]
+    #[deprecated(since = "0.11.0", note = "Use `Value::as_scalar_value` instead")]
     pub fn as_string_value<'a>(&'a self) -> Option<&'a str>
     where
         Option<&'a String>: From<&'a S>,

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -1,4 +1,4 @@
-use parser::{ParseError, ScalarToken};
+use crate::parser::{ParseError, ScalarToken};
 use serde::de;
 use serde::ser::Serialize;
 use std::fmt::{self, Debug, Display};

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -2,6 +2,7 @@ use crate::parser::{ParseError, ScalarToken};
 use serde::de;
 use serde::ser::Serialize;
 use std::fmt::{self, Debug, Display};
+use juniper_codegen::GraphQLScalarValueInternal as GraphQLScalarValue;
 
 /// The result of converting a string into a scalar value
 pub type ParseScalarResult<'a, S = DefaultScalarValue> = Result<S, ParseError<'a>>;
@@ -18,7 +19,7 @@ pub trait ParseScalarValue<S = DefaultScalarValue> {
 /// The main objective of this abstraction is to allow other libraries to
 /// replace the default representation with something that better fits thei
 /// needs.
-/// There is a custom derive (`#[derive(GraphQLScalarValue)]`) available that implements
+/// There is a custom derive (`#[derive(juniper::GraphQLScalarValue)]`) available that implements
 /// most of the required traits automatically for a enum representing a scalar value.
 /// This derives needs a additional annotation of the form
 /// `#[juniper(visitor = "VisitorType")]` to specify a type that implements
@@ -31,14 +32,13 @@ pub trait ParseScalarValue<S = DefaultScalarValue> {
 /// The following example introduces an new variant that is able to store 64 bit integers.
 ///
 /// ```
-/// # #[macro_use]
 /// # extern crate juniper;
 /// # extern crate serde;
 /// # use serde::{de, Deserialize, Deserializer};
 /// # use juniper::ScalarValue;
 /// # use std::fmt;
 /// #
-/// #[derive(Debug, Clone, PartialEq, GraphQLScalarValue)]
+/// #[derive(Debug, Clone, PartialEq, juniper::GraphQLScalarValue)]
 /// enum MyScalarValue {
 ///     Int(i32),
 ///     Long(i64),
@@ -252,7 +252,7 @@ where
 /// The default scalar value representation in juniper
 ///
 /// This types closely follows the graphql specification.
-#[derive(Debug, PartialEq, Clone, GraphQLScalarValueInternal)]
+#[derive(Debug, PartialEq, Clone, GraphQLScalarValue)]
 #[allow(missing_docs)]
 pub enum DefaultScalarValue {
     Int(i32),

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -1,8 +1,8 @@
 use crate::parser::{ParseError, ScalarToken};
+use juniper_codegen::GraphQLScalarValueInternal as GraphQLScalarValue;
 use serde::de;
 use serde::ser::Serialize;
 use std::fmt::{self, Debug, Display};
-use juniper_codegen::GraphQLScalarValueInternal as GraphQLScalarValue;
 
 /// The result of converting a string into a scalar value
 pub type ParseScalarResult<'a, S = DefaultScalarValue> = Result<S, ParseError<'a>>;

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -9,6 +9,7 @@ description = "Internal custom derive trait for Juniper GraphQL"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper"
 repository = "https://github.com/graphql-rust/juniper"
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 
+use quote::quote;
 use syn::{self, Data, DeriveInput, Fields, Variant};
 
 use crate::util::*;

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -1,9 +1,8 @@
 use proc_macro2::TokenStream;
 
-use syn;
-use syn::{Data, DeriveInput, Fields, Variant};
+use syn::{self, Data, DeriveInput, Fields, Variant};
 
-use util::*;
+use crate::util::*;
 
 #[derive(Default, Debug)]
 struct EnumAttrs {
@@ -165,7 +164,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
         // Build value.
         let name = var_attrs
             .name
-            .unwrap_or(::util::to_upper_snake_case(&variant.ident.to_string()));
+            .unwrap_or(crate::util::to_upper_snake_case(&variant.ident.to_string()));
         let descr = match var_attrs.description {
             Some(s) => quote! { Some(#s.to_string())  },
             None => quote! { None },

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
-use syn::{self, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta};
+use quote::{quote, ToTokens};
+use syn::{self, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta, parse_quote};
 
 use crate::util::*;
 
@@ -183,7 +183,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput, is_internal: bool) -> TokenStre
                 Some(quote! { Default::default() })
             } else {
                 match field_attrs.default_expr {
-                    Some(ref def) => match ::proc_macro::TokenStream::from_str(def) {
+                    Some(ref def) => match proc_macro::TokenStream::from_str(def) {
                         Ok(t) => match syn::parse::<syn::Expr>(t) {
                             Ok(e) => {
                                 let mut tokens = TokenStream::new();

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{self, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta, parse_quote};
+use syn::{self, parse_quote, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta};
 
 use crate::util::*;
 

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -4,7 +4,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{self, Data, DeriveInput, Field, Fields, Ident, Meta, NestedMeta};
 
-use util::*;
+use crate::util::*;
 
 #[derive(Default, Debug)]
 struct ObjAttrs {
@@ -170,7 +170,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput, is_internal: bool) -> TokenStre
             }
             None => {
                 // Note: auto camel casing when no custom name specified.
-                ::util::to_camel_case(&field_ident.to_string())
+                crate::util::to_camel_case(&field_ident.to_string())
             }
         };
         let field_description = match field_attrs.description {

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
-use syn::{self, Data, DeriveInput, Field, Fields, Ident, parse_quote};
 use quote::quote;
+use syn::{self, parse_quote, Data, DeriveInput, Field, Fields, Ident};
 
 use crate::util::*;
 

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Span, TokenStream};
-use syn::{self, Data, DeriveInput, Field, Fields, Ident};
+use syn::{self, Data, DeriveInput, Field, Fields, Ident, parse_quote};
+use quote::quote;
 
 use crate::util::*;
 

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,8 +1,7 @@
 use proc_macro2::{Span, TokenStream};
-use syn;
-use syn::{Data, DeriveInput, Field, Fields, Ident};
+use syn::{self, Data, DeriveInput, Field, Fields, Ident};
 
-use util::*;
+use crate::util::*;
 
 #[derive(Default, Debug)]
 struct ObjAttrs {
@@ -179,7 +178,7 @@ pub fn impl_object(ast: &syn::DeriveInput) -> TokenStream {
             }
             None => {
                 // Note: auto camel casing when no custom name specified.
-                ::util::to_camel_case(&field_ident.to_string())
+                crate::util::to_camel_case(&field_ident.to_string())
             }
         };
         let build_description = match field_attrs.description {

--- a/juniper_codegen/src/derive_scalar_value.rs
+++ b/juniper_codegen/src/derive_scalar_value.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 
+use quote::quote;
 use syn::{self, Data, Fields, Ident, Variant};
 
 pub fn impl_scalar_value(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -7,14 +7,6 @@
 #![recursion_limit = "1024"]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
 
 mod derive_enum;
 mod derive_input_object;

--- a/juniper_codegen/src/util.rs
+++ b/juniper_codegen/src/util.rs
@@ -206,7 +206,7 @@ pub(crate) fn to_upper_snake_case(s: &str) -> String {
 
 #[doc(hidden)]
 pub fn is_valid_name(field_name: &str) -> bool {
-    lazy_static! {
+    lazy_static::lazy_static! {
         static ref GRAPHQL_NAME_SPEC: Regex = Regex::new("^[_A-Za-z][_0-9A-Za-z]*$").unwrap();
     }
     GRAPHQL_NAME_SPEC.is_match(field_name)

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -6,6 +6,7 @@ description = "Juniper GraphQL integration with Hyper"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper_hyper"
 repository = "https://github.com/graphql-rust/juniper"
+edition = "2018"
 
 [dependencies]
 serde = "1.0"

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -1,15 +1,5 @@
-#[macro_use]
-extern crate futures;
-extern crate hyper;
-extern crate juniper;
-#[macro_use]
-extern crate serde_derive;
 #[cfg(test)]
 extern crate reqwest;
-extern crate serde_json;
-extern crate tokio;
-extern crate tokio_threadpool;
-extern crate url;
 
 use futures::future::Either;
 use hyper::header::HeaderValue;
@@ -204,7 +194,7 @@ fn new_html_response(code: StatusCode) -> Response<Body> {
     resp
 }
 
-#[derive(Deserialize)]
+#[derive(serde_derive::Deserialize)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
 enum GraphQLRequest<S = DefaultScalarValue>
@@ -232,7 +222,7 @@ where
     {
         match self {
             GraphQLRequest::Single(request) => Either::A(future::poll_fn(move || {
-                let res = try_ready!(tokio_threadpool::blocking(
+                let res = futures::try_ready!(tokio_threadpool::blocking(
                     || request.execute(&root_node, &context)
                 ));
                 let is_ok = res.is_ok();
@@ -246,7 +236,7 @@ where
                         let root_node = root_node.clone();
                         let context = context.clone();
                         future::poll_fn(move || {
-                            let res = try_ready!(tokio_threadpool::blocking(
+                            let res = futures::try_ready!(tokio_threadpool::blocking(
                                 || request.execute(&root_node, &context)
                             ));
                             let is_ok = res.is_ok();

--- a/juniper_iron/Cargo.toml
+++ b/juniper_iron/Cargo.toml
@@ -9,6 +9,7 @@ description = "Iron integration for juniper"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper_iron"
 repository = "https://github.com/graphql-rust/juniper"
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.2" }

--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -23,7 +23,7 @@ the schema on an HTTP endpoint supporting both GET and POST requests:
 
 ```rust,no_run
 extern crate iron;
-# #[macro_use] extern crate juniper;
+# extern crate juniper;
 # extern crate juniper_iron;
 # use std::collections::HashMap;
 
@@ -37,7 +37,7 @@ use juniper::{Context, EmptyMutation};
 # struct QueryRoot;
 # struct Database { users: HashMap<String, User> }
 #
-# graphql_object!(User: Database |&self| {
+# juniper::graphql_object!(User: Database |&self| {
 #     field id() -> FieldResult<&String> {
 #         Ok(&self.id)
 #     }
@@ -53,7 +53,7 @@ use juniper::{Context, EmptyMutation};
 #     }
 # });
 #
-# graphql_object!(QueryRoot: Database |&self| {
+# juniper::graphql_object!(QueryRoot: Database |&self| {
 #     field user(&executor, id: String) -> FieldResult<Option<&User>> {
 #         Ok(executor.context().users.get(&id))
 #     }
@@ -101,18 +101,12 @@ supported.
 
 */
 
-#[macro_use]
-extern crate iron;
 #[cfg(test)]
 extern crate iron_test;
-extern crate juniper;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
 #[cfg(test)]
 extern crate url;
-extern crate urlencoded;
 
+use iron::itry;
 use iron::method;
 use iron::middleware::Handler;
 use iron::mime::Mime;
@@ -130,7 +124,7 @@ use juniper::http;
 use juniper::serde::Deserialize;
 use juniper::{DefaultScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue};
 
-#[derive(Deserialize)]
+#[derive(serde_derive::Deserialize)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
 enum GraphQLBatchRequest<S = DefaultScalarValue>
@@ -141,7 +135,7 @@ where
     Batch(Vec<http::GraphQLRequest<S>>),
 }
 
-#[derive(Serialize)]
+#[derive(serde_derive::Serialize)]
 #[serde(untagged)]
 enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
 where

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -9,6 +9,7 @@ description = "Juniper GraphQL integration with Rocket"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper_rocket"
 repository = "https://github.com/graphql-rust/juniper"
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0.2" }

--- a/juniper_rocket/examples/rocket_server.rs
+++ b/juniper_rocket/examples/rocket_server.rs
@@ -1,10 +1,5 @@
 #![feature(decl_macro, proc_macro_hygiene)]
 
-extern crate juniper;
-extern crate juniper_rocket;
-#[macro_use]
-extern crate rocket;
-
 use rocket::response::content;
 use rocket::State;
 
@@ -13,12 +8,12 @@ use juniper::{EmptyMutation, RootNode};
 
 type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
 
-#[get("/")]
+#[rocket::get("/")]
 fn graphiql() -> content::Html<String> {
     juniper_rocket::graphiql_source("/graphql")
 }
 
-#[get("/graphql?<request>")]
+#[rocket::get("/graphql?<request>")]
 fn get_graphql_handler(
     context: State<Database>,
     request: juniper_rocket::GraphQLRequest,
@@ -27,7 +22,7 @@ fn get_graphql_handler(
     request.execute(&schema, &context)
 }
 
-#[post("/graphql", data = "<request>")]
+#[rocket::post("/graphql", data = "<request>")]
 fn post_graphql_handler(
     context: State<Database>,
     request: juniper_rocket::GraphQLRequest,
@@ -45,7 +40,7 @@ fn main() {
         ))
         .mount(
             "/",
-            routes![graphiql, get_graphql_handler, post_graphql_handler],
+            rocket::routes![graphiql, get_graphql_handler, post_graphql_handler],
         )
         .launch();
 }

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -38,12 +38,6 @@ Check the LICENSE file for details.
 
 #![feature(decl_macro, proc_macro_hygiene)]
 
-extern crate juniper;
-extern crate rocket;
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-
 use std::error::Error;
 use std::io::{Cursor, Read};
 
@@ -66,7 +60,7 @@ use juniper::RootNode;
 use juniper::ScalarRefValue;
 use juniper::ScalarValue;
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde_derive::Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
 enum GraphQLBatchRequest<S = DefaultScalarValue>
@@ -77,7 +71,7 @@ where
     Batch(Vec<http::GraphQLRequest<S>>),
 }
 
-#[derive(Serialize)]
+#[derive(serde_derive::Serialize)]
 #[serde(untagged)]
 enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
 where
@@ -191,7 +185,7 @@ impl GraphQLResponse {
     /// #
     /// # extern crate juniper;
     /// # extern crate juniper_rocket;
-    /// # #[macro_use] extern crate rocket;
+    /// # extern crate rocket;
     /// #
     /// # use rocket::http::Cookies;
     /// # use rocket::request::Form;
@@ -203,7 +197,7 @@ impl GraphQLResponse {
     /// #
     /// # type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
     /// #
-    /// #[get("/graphql?<request..>")]
+    /// #[rocket::get("/graphql?<request..>")]
     /// fn get_graphql_handler(
     ///     mut cookies: Cookies,
     ///     context: State<Database>,

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -6,6 +6,7 @@ description = "Juniper GraphQL integration with Warp"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper_warp"
 repository = "https://github.com/graphql-rust/juniper"
+edition = "2018"
 
 [dependencies]
 warp = "0.1.8"

--- a/juniper_warp/examples/warp_server.rs
+++ b/juniper_warp/examples/warp_server.rs
@@ -1,15 +1,10 @@
 #![deny(warnings)]
 
-extern crate env_logger;
-#[macro_use]
-extern crate log as irrelevant_log;
-extern crate juniper;
-extern crate juniper_warp;
-extern crate warp;
+extern crate log;
 
 use juniper::tests::model::Database;
 use juniper::{EmptyMutation, RootNode};
-use warp::{http::Response, log, Filter};
+use warp::{http::Response, Filter};
 
 type Schema = RootNode<'static, Database, EmptyMutation<Database>>;
 
@@ -21,7 +16,7 @@ fn main() {
     ::std::env::set_var("RUST_LOG", "warp_server");
     env_logger::init();
 
-    let log = log("warp_server");
+    let log = warp::log("warp_server");
 
     let homepage = warp::path::end().map(|| {
         Response::builder()
@@ -31,7 +26,7 @@ fn main() {
             ))
     });
 
-    info!("Listening on 127.0.0.1:8080");
+    log::info!("Listening on 127.0.0.1:8080");
 
     let state = warp::any().map(move || Database::new());
     let graphql_filter = juniper_warp::make_graphql_filter(schema(), state.boxed());

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -39,27 +39,13 @@ Check the LICENSE file for details.
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-#[macro_use]
-extern crate failure;
-extern crate futures;
-extern crate juniper;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_threadpool;
-extern crate warp;
-
-#[cfg(test)]
-extern crate percent_encoding;
-
 use futures::{future::poll_fn, Future};
 use juniper::{DefaultScalarValue, InputValue, ScalarRefValue, ScalarValue};
 use serde::Deserialize;
 use std::sync::Arc;
 use warp::{filters::BoxedFilter, Filter};
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, serde_derive::Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
 enum GraphQLBatchRequest<S = DefaultScalarValue>
@@ -98,7 +84,7 @@ where
     }
 }
 
-#[derive(Serialize)]
+#[derive(serde_derive::Serialize)]
 #[serde(untagged)]
 enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
 where
@@ -132,7 +118,6 @@ where
 ///
 /// ```
 /// # extern crate juniper_warp;
-/// # #[macro_use]
 /// # extern crate juniper;
 /// # extern crate warp;
 /// #
@@ -149,7 +134,7 @@ where
 ///
 /// struct QueryRoot;
 ///
-/// graphql_object! (QueryRoot: ExampleContext |&self| {
+/// juniper::graphql_object! (QueryRoot: ExampleContext |&self| {
 ///     field say_hello(&executor) -> String {
 ///         let context = executor.context();
 ///
@@ -226,7 +211,7 @@ where
 
                     let graphql_request = juniper::http::GraphQLRequest::new(
                         request.remove("query").ok_or_else(|| {
-                            format_err!("Missing GraphQL query string in query parameters")
+                            failure::format_err!("Missing GraphQL query string in query parameters")
                         })?,
                         request.get("operation_name").map(|s| s.to_owned()),
                         variables,


### PR DESCRIPTION
Note this also bumps the minimum version to `1.31`, which fits with our "last 3 versions" rule though since 1.34 is out.