### PR TITLE
Expose the operation name from `juniper_rocket::GraphQLRequest`

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -12,6 +12,7 @@
   The DirectiveLocation::InlineFragment had an invalid literal value,
   which broke third party tools like apollo cli.
 - The return type of `value::object::Object::iter/iter_mut` has changed to `impl Iter` [#312](https://github.com/graphql-rust/juniper/pull/312)
+- Add `GraphQLRequest::operation_name` [#353](https://github.com/graphql-rust/juniper/pull/353)
 
 # [0.11.1] 2018-12-19
 

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -36,7 +36,7 @@ where
     S: ScalarValue,
 {
     /// Returns the `operation_name` associated with this request.
-    fn operation_name(&self) -> Option<&str> {
+    pub fn operation_name(&self) -> Option<&str> {
         self.operation_name.as_ref().map(|oper_name| &**oper_name)
     }
 

--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-- Expose the operation name from `GraphQLRequest`.
+- Expose the operation names from `GraphQLRequest`.
 - Compatibility with the latest `juniper`.
 
 # [0.2.0] 2018-12-17

--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-- No changes yet
+- Expose the operation name from `GraphQLRequest`.
 
 # [0.2.0] 2018-12-17
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -534,14 +534,40 @@ mod tests {
         http_tests::run_http_test_suite(&integration);
     }
 
+    #[test]
+    fn test_operation_names() {
+        #[post("/", data = "<request>")]
+        fn post_graphql_assert_operation_name_handler(
+            context: State<Database>,
+            request: super::GraphQLRequest,
+            schema: State<Schema>,
+        ) -> super::GraphQLResponse {
+            assert_eq!(request.operation_names(), vec![Some("TestQuery")]);
+            request.execute(&schema, &context)
+        }
+
+        let rocket = make_rocket_without_routes()
+            .mount("/", routes![post_graphql_assert_operation_name_handler]);
+        let client = Client::new(rocket).expect("valid rocket");
+
+        let req = client
+            .post("/")
+            .header(ContentType::JSON)
+            .body(r#"{"query": "query TestQuery {hero{name}}", "operationName": "TestQuery"}"#);
+        let resp = make_test_response(&req);
+
+        assert_eq!(resp.status_code, 200);
+    }
+
     fn make_rocket() -> Rocket {
-        rocket::ignite()
-            .manage(Database::new())
-            .manage(Schema::new(
-                Database::new(),
-                EmptyMutation::<Database>::new(),
-            ))
-            .mount("/", routes![post_graphql_handler, get_graphql_handler])
+        make_rocket_without_routes().mount("/", routes![post_graphql_handler, get_graphql_handler])
+    }
+
+    fn make_rocket_without_routes() -> Rocket {
+        rocket::ignite().manage(Database::new()).manage(Schema::new(
+            Database::new(),
+            EmptyMutation::<Database>::new(),
+        ))
     }
 
     fn make_test_response(request: &LocalRequest) -> http_tests::TestResponse {

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -110,16 +110,14 @@ where
 
     pub fn operation_name(&self) -> Option<&str> {
         match self {
-            GraphQLBatchRequest::Single(req) => {
-                req.operation_name()
-            },
+            GraphQLBatchRequest::Single(req) => req.operation_name(),
             GraphQLBatchRequest::Batch(reqs) => {
                 if reqs.len() == 1 {
                     reqs.get(0).and_then(|req| req.operation_name())
                 } else {
                     None
                 }
-            },
+            }
         }
     }
 }

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -108,15 +108,11 @@ where
         }
     }
 
-    pub fn operation_name(&self) -> Option<&str> {
+    pub fn operation_names(&self) -> Vec<Option<&str>> {
         match self {
-            GraphQLBatchRequest::Single(req) => req.operation_name(),
+            GraphQLBatchRequest::Single(req) => vec![req.operation_name()],
             GraphQLBatchRequest::Batch(reqs) => {
-                if reqs.len() == 1 {
-                    reqs.get(0).and_then(|req| req.operation_name())
-                } else {
-                    None
-                }
+                reqs.iter().map(|req| req.operation_name()).collect()
             }
         }
     }
@@ -187,9 +183,11 @@ where
         GraphQLResponse(status, json)
     }
 
-    /// Returns the `operation_name` associated with this request.
-    pub fn operation_name(&self) -> Option<&str> {
-        self.0.operation_name()
+    /// Returns the operation names associated with this request.
+    ///
+    /// For batch requests there will be multiple names.
+    pub fn operation_names(&self) -> Vec<Option<&str>> {
+        self.0.operation_names()
     }
 }
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -107,6 +107,21 @@ where
             ),
         }
     }
+
+    pub fn operation_name(&self) -> Option<&str> {
+        match self {
+            GraphQLBatchRequest::Single(req) => {
+                req.operation_name()
+            },
+            GraphQLBatchRequest::Batch(reqs) => {
+                if reqs.len() == 1 {
+                    reqs.get(0).and_then(|req| req.operation_name())
+                } else {
+                    None
+                }
+            },
+        }
+    }
 }
 
 impl<'a, S> GraphQLBatchResponse<'a, S>
@@ -172,6 +187,11 @@ where
         let json = serde_json::to_string(&response).unwrap();
 
         GraphQLResponse(status, json)
+    }
+
+    /// Returns the `operation_name` associated with this request.
+    pub fn operation_name(&self) -> Option<&str> {
+        self.0.operation_name()
     }
 }
 


### PR DESCRIPTION
> Measuring the runtime of queries will only tell if there are slow
> queries. To find out which queries are slow you need the operation name.
> 
> Getting the operation name was previously not possible from a Rocket
> request handler. This fixes that.

I ran into this issue recently when implementing performance performance
monitoring for an app using juniper-rocket.