### PR TITLE
Add logging

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -37,6 +37,7 @@ fnv = "1.0.3"
 indexmap = { version = "1.0.0", features = ["serde-1"] }
 serde = { version = "1.0.8" }
 serde_derive = { version = "1.0.2" }
+log = { version = "0.4" }
 
 chrono = { version = "0.4.0", optional = true }
 serde_json = { version="1.0.2", optional = true }


### PR DESCRIPTION
As it stands right now, this is an MVP of logging, with just the bare minimum I thought useful (at least at for my work).

Some questions need to be answered:
- Should we treat logging from the perspective of Juniper users or from Juniper's perspective? 
  - e.g. should validation errors be `warn`/`error` or simply `debug` and reserve `warn` and `error` for recoverable errors and unrecoverable errors?
  - In general, how _much_ logging should we do?
- Right now, I just logged the [`execute`](https://github.com/graphql-rust/juniper/blob/5b9a0bd31b2eb6822f1181c8088715e01f821df7/juniper/src/lib.rs#L188) function. Maybe we should go 1+ levels deeper, and for example, log in the [`execute_validated_query`](https://github.com/graphql-rust/juniper/blob/acf4207ff1de862b799360d98a1bfd616b2872cc/juniper/src/executor/mod.rs#L591) function so that users can be more granular and [enable/disable](https://docs.rs/env_logger/0.6.1/env_logger/#enabling-logging) `juniper::executor` etc.
- We might want to add a warning to the docs about  logging sensitive information? We probably shouldn't log requests in case they contain passwords? 
  - I am thinking about creating a `ClearTextPassword` scalar type in my code and making the `Display`/`Debug` impl be something like `[password]`. Perhaps we add something to that effect to the book?

I didn't and probably won't (yet) do much logging of the actual parser because #138...

I am happy to keep adding commits (and squashing?) to this PR and/or do this in chunks and open smaller PRs as I add more logging.

Closes #48.