### PR TITLE
Optimize .unwrap_or() and .expect() usages

### DIFF
--- a/juniper/src/macros/common.rs
+++ b/juniper/src/macros/common.rs
@@ -428,7 +428,7 @@ macro_rules! __juniper_parse_field_list {
                     },)*
                 ],
                 $(docstring = $desc,)*
-                deprecated = None$(.unwrap_or(Some($reason)))*,
+                deprecated = None$(.unwrap_or_else(|| Some($reason)))*,
                 $(executor_var = $executor,)*
             },],
             rest = $($rest)*

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -136,7 +136,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
     // Parse attributes.
     let ident = &ast.ident;
     let attrs = EnumAttrs::from_input(ast);
-    let name = attrs.name.unwrap_or(ast.ident.to_string());
+    let name = attrs.name.unwrap_or_else(|| ast.ident.to_string());
 
     let meta_description = match attrs.description {
         Some(descr) => quote! { let meta = meta.description(#descr); },
@@ -165,7 +165,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
         // Build value.
         let name = var_attrs
             .name
-            .unwrap_or(crate::util::to_upper_snake_case(&variant.ident.to_string()));
+            .unwrap_or_else(|| crate::util::to_upper_snake_case(&variant.ident.to_string()));
         let descr = match var_attrs.description {
             Some(s) => quote! { Some(#s.to_string())  },
             None => quote! { None },

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -145,7 +145,7 @@ pub fn impl_input_object(ast: &syn::DeriveInput, is_internal: bool) -> TokenStre
     // Parse attributes.
     let ident = &ast.ident;
     let attrs = ObjAttrs::from_input(ast);
-    let name = attrs.name.unwrap_or(ast.ident.to_string());
+    let name = attrs.name.unwrap_or_else(|| ast.ident.to_string());
     let generics = &ast.generics;
 
     let meta_description = match attrs.description {

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -27,7 +27,8 @@ pub fn build_derive_object(ast: syn::DeriveInput, is_internal: bool) -> TokenStr
     if attrs.interfaces.len() > 0 {
         panic!("Invalid #[graphql(...)] attribute 'interfaces': #[derive(GraphQLObject) does not support 'interfaces'");
     }
-    let name = attrs.name.unwrap_or(ast.ident.to_string());
+    let ident = &ast.ident;
+    let name = attrs.name.unwrap_or_else(|| ident.to_string());
 
     let fields = struct_fields.into_iter().filter_map(|field| {
         let field_attrs = match util::FieldAttributes::from_attrs(
@@ -69,7 +70,7 @@ pub fn build_derive_object(ast: syn::DeriveInput, is_internal: bool) -> TokenStr
         scalar: attrs.scalar,
         description: attrs.description,
         fields: fields.collect(),
-        generics: ast.generics.clone(),
+        generics: ast.generics,
         interfaces: None,
         include_type_generics: true,
         generic_scalar: true,

--- a/juniper_codegen/src/impl_object.rs
+++ b/juniper_codegen/src/impl_object.rs
@@ -176,10 +176,11 @@ pub fn build_object(args: TokenStream, body: TokenStream, is_internal: bool) -> 
                                 let ty = &captured.ty;
                                 // TODO: respect graphql attribute overwrite.
                                 let final_name = util::to_camel_case(&arg_name);
+                                let expect_text = format!("Internal error: missing argument {} - validation must have failed", &final_name);
                                 resolve_parts.push(quote!(
                                     let #arg_ident = args
                                         .get::<#ty>(#final_name)
-                                        .expect(&format!("Internal error: missing argument {} - validation must have failed", #final_name));
+                                        .expect(#expect_text);
                                 ));
                                 args.push(util::GraphQLTypeDefinitionFieldArg {
                                     description: attrs.argument(&arg_name).and_then(|arg| {
@@ -206,9 +207,10 @@ pub fn build_object(args: TokenStream, body: TokenStream, is_internal: bool) -> 
                     })()
                 );
 
+                let ident = &method.sig.ident;
                 let name = attrs
                     .name
-                    .unwrap_or(util::to_camel_case(&method.sig.ident.to_string()));
+                    .unwrap_or_else(|| util::to_camel_case(&ident.to_string()));
 
                 definition.fields.push(util::GraphQLTypeDefinitionField {
                     name,

--- a/juniper_codegen/src/util.rs
+++ b/juniper_codegen/src/util.rs
@@ -644,7 +644,7 @@ impl GraphQLTypeDefiniton {
             .context
             .as_ref()
             .map(|ctx| quote!( #ctx ))
-            .unwrap_or(quote!(()));
+            .unwrap_or_else(|| quote!(()));
 
         let field_definitions = self.fields.iter().map(|field| {
             let args = field.args.iter().map(|arg| {

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -39,9 +39,11 @@ where
                     .uri()
                     .query()
                     .map(|q| gql_request_from_get(q).map(GraphQLRequest::Single))
-                    .unwrap_or(Err(GraphQLRequestError::Invalid(
-                        "'query' parameter is missing".to_string(),
-                    ))),
+                    .unwrap_or_else(|| {
+                        Err(GraphQLRequestError::Invalid(
+                            "'query' parameter is missing".to_string(),
+                        ))
+                    }),
             )
             .and_then(move |gql_req| {
                 execute_request(root_node, context, gql_req).map_err(|_| {

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -257,7 +257,7 @@ fn build_response(
 }
 
 type Response =
-    Box<Future<Item = warp::http::Response<Vec<u8>>, Error = warp::reject::Rejection> + Send>;
+    Box<dyn Future<Item = warp::http::Response<Vec<u8>>, Error = warp::reject::Rejection> + Send>;
 
 /// Create a filter that replies with an HTML page containing GraphiQL. This does not handle routing, so you can mount it on any endpoint.
 ///


### PR DESCRIPTION
This is a minor code improvement.



## What it does

Optimizes usages of `.expect()` and `.unwrap_or()` in non-test code to omit performing redudant operations if any.


## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo make workspace-ci-flow --no-workspace` passes
- [x] CHANGELOG is not updated as there are no changes that affect users