### PR TITLE
Give `IntoFieldError::into_field_error` access to the context

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-- No changes yet
+- Give `IntoFieldError::into_field_error` access to the context [#397](https://github.com/graphql-rust/juniper/pull/397)
 
 - Allow `mut` arguments for resolver functions in `#[object]` macros [#402](https://github.com/graphql-rust/juniper/pull/402)
 

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -785,11 +785,11 @@ mod propagates_errors_to_nullable_fields {
         NotFound,
     }
 
-    impl<S> IntoFieldError<S> for CustomError
+    impl<Ctx, S> IntoFieldError<Ctx, S> for CustomError
     where
         S: ScalarValue,
     {
-        fn into_field_error(self) -> FieldError<S> {
+        fn into_field_error(self, _: &Ctx) -> FieldError<S> {
             match self {
                 CustomError::NotFound => {
                     let v: Value<S> = graphql_value!({


### PR DESCRIPTION
Fixes https://github.com/graphql-rust/juniper/issues/391

`IntoFieldError` is useful for sending errors to error tracking services
such as Rollbar or Bugsnag. When you do that it is often useful to
include data accessible via the context such as data about the current
user.

Getting access to the context inside `IntoFieldError` previously required
[wrapping your error][] which lead to a lot of boilerplate. This changes that
so `IntoFieldError` gets passed a reference to the context.

This is a breaking change but I think the small bit of breakage is worth it. I
doubt users have more than one implementation of `IntoFieldError`.

[wrapping your error]: https://github.com/graphql-rust/juniper/issues/391