### PR TITLE
(codegen) Respect mut modifier on arguments in object proc macro

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - No changes yet
 
+- Allow `mut` arguments for resolver functions in `#[object]` macros [#402](https://github.com/graphql-rust/juniper/pull/402)
+
 # [[0.13.0] 2019-07-19](https://github.com/graphql-rust/juniper/releases/tag/juniper-0.13.0)
 
 ### newtype ScalarValue derive

--- a/juniper/src/macros/tests/impl_object.rs
+++ b/juniper/src/macros/tests/impl_object.rs
@@ -101,6 +101,13 @@ impl<'a> Query {
     fn with_lifetime_child(&self) -> WithLifetime<'a> {
         WithLifetime { value: "blub" }
     }
+
+    fn with_mut_arg(mut arg: bool) -> bool {
+        if arg {
+            arg = !arg;
+        }
+        arg
+    }
 }
 
 #[derive(Default)]
@@ -216,6 +223,19 @@ fn object_introspect() {
                     "description": None,
                     "args": [],
                 },
+                {
+                    "name": "withMutArg",
+                    "description": None,
+                    "args": [
+                        {
+                            "name": "arg",
+                            "description": None,
+                            "type": {
+                                "name": None,
+                            },
+                        }
+                    ],
+                },
             ]
         })
     );
@@ -241,6 +261,7 @@ fn object_query() {
         withLifetimeChild {
             value
         }
+        withMutArg(arg: true)
     }
     "#;
     let schema = RootNode::new(Query { b: true }, EmptyMutation::<Context>::new());
@@ -264,6 +285,7 @@ fn object_query() {
             "argWithDescription": true,
             "withContextChild": { "ctx": true },
             "withLifetimeChild": { "value": "blub" },
+            "withMutArg": false,
         })
     );
 }


### PR DESCRIPTION
This commit forwards `mut` declaration of arguments in a #[juniper::object] macro invocation
to the generated code.

Closes #399