### PR TITLE
Remove GraphQL prefix from derives + add deprecated fallbacks

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
-- No changes yet
+- Rename all derive macros by removing the `GraphQL` prefix.
+  The old names are supported by deprecated fallbacks.
 
 # [[0.13.1] 2019-07-29](https://github.com/graphql-rust/juniper/releases/tag/juniper-0.13.1)
 

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 
 use crate::ast::InputValue;
 use crate::executor::Variables;

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 
 use crate::executor::Variables;
 use crate::schema::model::RootNode;

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+use juniper_codegen::InputObjectInternal as GraphQLInputObject;
 
 use crate::ast::{FromInputValue, InputValue};
 use crate::executor::Variables;

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -1,7 +1,7 @@
 mod enums;
 mod input_object;
 
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 
 // This asserts that the input objects defined public actually became public
 #[allow(unused_imports)]

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+use juniper_codegen::InputObjectInternal as GraphQLInputObject;
 
 use crate::ast::InputValue;
 use crate::executor::Variables;

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -110,14 +110,13 @@ extern crate uuid;
 // This allows users to just depend on juniper and get the derive
 // functionality automatically.
 pub use juniper_codegen::{
-    object, GraphQLEnum, GraphQLInputObject, GraphQLObject, GraphQLScalarValue, ScalarValue,
+    object, Enum, GraphQLEnum, GraphQLInputObject, GraphQLObject, GraphQLScalarValue, InputObject,
+    Object, ScalarValue,
 };
 // Internal macros are not exported,
 // but declared at the root to make them easier to use.
 #[allow(unused_imports)]
-use juniper_codegen::{
-    object_internal, GraphQLEnumInternal, GraphQLInputObjectInternal, GraphQLScalarValueInternal,
-};
+use juniper_codegen::{object_internal, EnumInternal, InputObjectInternal, ScalarValueInternal};
 
 #[macro_use]
 mod value;

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+use juniper_codegen::InputObjectInternal as GraphQLInputObject;
 
 use crate::executor::Variables;
 use crate::schema::model::RootNode;

--- a/juniper/src/parser/tests/value.rs
+++ b/juniper/src/parser/tests/value.rs
@@ -1,8 +1,6 @@
 use indexmap::IndexMap;
 
-use juniper_codegen::{
-    GraphQLEnumInternal as GraphQLEnum, GraphQLInputObjectInternal as GraphQLInputObject,
-};
+use juniper_codegen::{EnumInternal as GraphQLEnum, InputObjectInternal as GraphQLInputObject};
 
 use crate::ast::{FromInputValue, InputValue, Type};
 use crate::parser::value::parse_value_literal;

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use fnv::FnvHashMap;
 
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 
 use crate::ast::Type;
 use crate::executor::{Context, Registry};

--- a/juniper/src/tests/model.rs
+++ b/juniper/src/tests/model.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 use std::collections::HashMap;
 
 #[derive(GraphQLEnum, Copy, Clone, Eq, PartialEq, Debug)]

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 
-use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
+use juniper_codegen::EnumInternal as GraphQLEnum;
 
 use crate::ast::{Directive, FromInputValue, InputValue, Selection};
 use crate::executor::Variables;

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -1,4 +1,4 @@
-use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
+use juniper_codegen::InputObjectInternal as GraphQLInputObject;
 
 use crate::ast::{FromInputValue, InputValue};
 use crate::executor::Registry;

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -1,5 +1,5 @@
 use crate::parser::{ParseError, ScalarToken};
-use juniper_codegen::GraphQLScalarValueInternal as GraphQLScalarValue;
+use juniper_codegen::ScalarValueInternal as GraphQLScalarValue;
 use serde::de;
 use serde::ser::Serialize;
 use std::fmt::{self, Debug, Display};

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -18,14 +18,20 @@ mod util;
 
 use proc_macro::TokenStream;
 
-#[proc_macro_derive(GraphQLEnum, attributes(graphql))]
+#[proc_macro_derive(Enum, attributes(graphql))]
 pub fn derive_enum(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_enum::impl_enum(&ast, false);
     gen.into()
 }
 
-#[proc_macro_derive(GraphQLEnumInternal, attributes(graphql))]
+#[proc_macro_derive(GraphQLEnum, attributes(graphql))]
+#[deprecated(note = "GraphQLEnum has been renamed to Enum")]
+pub fn derive_enum_deprecated(input: TokenStream) -> TokenStream {
+    derive_enum(input)
+}
+
+#[proc_macro_derive(EnumInternal, attributes(graphql))]
 #[doc(hidden)]
 pub fn derive_enum_internal(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
@@ -33,14 +39,20 @@ pub fn derive_enum_internal(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-#[proc_macro_derive(GraphQLInputObject, attributes(graphql))]
+#[proc_macro_derive(InputObject, attributes(graphql))]
 pub fn derive_input_object(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_input_object::impl_input_object(&ast, false);
     gen.into()
 }
 
-#[proc_macro_derive(GraphQLInputObjectInternal, attributes(graphql))]
+#[proc_macro_derive(GraphQLInputObject, attributes(graphql))]
+#[deprecated(note = "GraphQLInputObject has been renamed to InputObject")]
+pub fn derive_input_object_deprecated(input: TokenStream) -> TokenStream {
+    derive_input_object(input)
+}
+
+#[proc_macro_derive(InputObjectInternal, attributes(graphql))]
 #[doc(hidden)]
 pub fn derive_input_object_internal(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
@@ -48,11 +60,17 @@ pub fn derive_input_object_internal(input: TokenStream) -> TokenStream {
     gen.into()
 }
 
-#[proc_macro_derive(GraphQLObject, attributes(graphql))]
+#[proc_macro_derive(Object, attributes(graphql))]
 pub fn derive_object(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_object::build_derive_object(ast, false);
     gen.into()
+}
+
+#[proc_macro_derive(GraphQLObject, attributes(graphql))]
+#[deprecated(note = "GraphQLObject has been renamed to Object")]
+pub fn derive_object_deprecated(input: TokenStream) -> TokenStream {
+    derive_object(input)
 }
 
 /// This custom derive macro implements the #[derive(GraphQLScalarValue)]
@@ -97,20 +115,20 @@ pub fn derive_object(input: TokenStream) -> TokenStream {
 ///
 /// TODO: write documentation.
 ///
-#[proc_macro_derive(GraphQLScalarValue, attributes(graphql))]
+#[proc_macro_derive(ScalarValue, attributes(graphql))]
 pub fn derive_scalar_value(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_scalar_value::impl_scalar_value(&ast, false);
     gen.into()
 }
 
-#[deprecated(note = "ScalarValue has been renamed to GraphQLScalarValue")]
-#[proc_macro_derive(ScalarValue)]
+#[deprecated(note = "GraphQLScalarValue has been renamed to ScalarValue")]
+#[proc_macro_derive(GraphQLScalarValue, attributes(graphql))]
 pub fn derive_scalar_value_deprecated(input: TokenStream) -> TokenStream {
     derive_scalar_value(input)
 }
 
-#[proc_macro_derive(GraphQLScalarValueInternal)]
+#[proc_macro_derive(ScalarValueInternal)]
 #[doc(hidden)]
 pub fn derive_scalar_value_internal(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();


### PR DESCRIPTION
This commit renames all derive macros to a version without the
GraphQL prefix.

The prefix is no longer needed with the 2018 edition,
since they can be specified with the `juniper::` prefix or
imported and conflcits can be avoided.

The old names are still kept around as a deprecated version.