### PR TITLE
Enable merge_imports rustfmt setting.

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
@@ -1,8 +1,9 @@
 use fnv::FnvHashMap;
 
-use juniper::DefaultScalarValue;
-use juniper::GraphQLInputObject;
-use juniper::{self, FromInputValue, GraphQLType, InputValue, ToInputValue};
+use juniper::{
+    self, DefaultScalarValue, FromInputValue, GraphQLInputObject, GraphQLType, InputValue,
+    ToInputValue,
+};
 
 #[derive(GraphQLInputObject, Debug, PartialEq)]
 #[graphql(

--- a/integration_tests/juniper_tests/src/codegen/derive_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object.rs
@@ -1,9 +1,8 @@
 #[cfg(test)]
 use fnv::FnvHashMap;
-use juniper::DefaultScalarValue;
-use juniper::GraphQLObject;
 #[cfg(test)]
 use juniper::Object;
+use juniper::{DefaultScalarValue, GraphQLObject};
 
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};

--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -2,11 +2,13 @@ extern crate serde_json;
 
 #[cfg(test)]
 use juniper::parser::Spanning;
-use juniper::parser::{ParseError, ScalarToken, Token};
-use juniper::serde::de;
 #[cfg(test)]
 use juniper::{execute, EmptyMutation, Object, RootNode, Variables};
-use juniper::{InputValue, ParseScalarResult, ScalarValue, Value};
+use juniper::{
+    parser::{ParseError, ScalarToken, Token},
+    serde::de,
+    InputValue, ParseScalarResult, ScalarValue, Value,
+};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, juniper::GraphQLScalarValue)]

--- a/juniper/benches/bench.rs
+++ b/juniper/benches/bench.rs
@@ -4,8 +4,7 @@ extern crate juniper;
 
 use bencher::Bencher;
 
-use juniper::tests::model::Database;
-use juniper::{execute, EmptyMutation, RootNode, Variables};
+use juniper::{execute, tests::model::Database, EmptyMutation, RootNode, Variables};
 
 fn query_type_name(b: &mut Bencher) {
     let database = Database::new();

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -1,14 +1,12 @@
-use std::borrow::Cow;
-use std::fmt;
-use std::hash::Hash;
-use std::slice;
-use std::vec;
+use std::{borrow::Cow, fmt, hash::Hash, slice, vec};
 
 use indexmap::IndexMap;
 
-use crate::executor::Variables;
-use crate::parser::Spanning;
-use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+use crate::{
+    executor::Variables,
+    parser::Spanning,
+    value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
+};
 
 /// A type literal in the syntax tree
 ///

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -1,6 +1,8 @@
-use crate::ast::{Directive, Fragment, InputValue, Selection};
-use crate::parser::Spanning;
-use crate::value::{ScalarRefValue, ScalarValue};
+use crate::{
+    ast::{Directive, Fragment, InputValue, Selection},
+    parser::Spanning,
+    value::{ScalarRefValue, ScalarValue},
+};
 
 use std::collections::HashMap;
 
@@ -388,11 +390,13 @@ impl<'a, S> LookAheadMethods<S> for LookAheadSelection<'a, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::Document;
-    use crate::parser::UnlocatedParseResult;
-    use crate::schema::model::SchemaType;
-    use crate::validation::test_harness::{MutationRoot, QueryRoot};
-    use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+    use crate::{
+        ast::Document,
+        parser::UnlocatedParseResult,
+        schema::model::SchemaType,
+        validation::test_harness::{MutationRoot, QueryRoot},
+        value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
+    };
     use std::collections::HashMap;
 
     fn parse_document_source<S>(q: &str) -> UnlocatedParseResult<Document<S>>
@@ -1395,5 +1399,4 @@ fragment heroFriendNames on Hero {
             panic!("No Operation found");
         }
     }
-
 }

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -1,28 +1,29 @@
-use std::borrow::Cow;
-use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::fmt::Display;
-use std::sync::RwLock;
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap, fmt::Display, sync::RwLock};
 
 use fnv::FnvHashMap;
 
-use crate::ast::{
-    Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
-    ToInputValue, Type,
+use crate::{
+    ast::{
+        Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
+        ToInputValue, Type,
+    },
+    parser::SourcePosition,
+    value::Value,
+    GraphQLError,
 };
-use crate::parser::SourcePosition;
-use crate::value::Value;
-use crate::GraphQLError;
 
-use crate::schema::meta::{
-    Argument, DeprecationStatus, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta,
-    ListMeta, MetaType, NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
+use crate::schema::{
+    meta::{
+        Argument, DeprecationStatus, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta,
+        ListMeta, MetaType, NullableMeta, ObjectMeta, PlaceholderMeta, ScalarMeta, UnionMeta,
+    },
+    model::{RootNode, SchemaType, TypeType},
 };
-use crate::schema::model::{RootNode, SchemaType, TypeType};
 
-use crate::types::base::GraphQLType;
-use crate::types::name::Name;
-use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::{
+    types::{base::GraphQLType, name::Name},
+    value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue},
+};
 
 mod look_ahead;
 

--- a/juniper/src/executor_tests/directives.rs
+++ b/juniper/src/executor_tests/directives.rs
@@ -1,7 +1,9 @@
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 struct TestType;
 

--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -1,13 +1,15 @@
 use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
-use crate::ast::InputValue;
-use crate::executor::Variables;
-use crate::parser::SourcePosition;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::validation::RuleError;
-use crate::value::{DefaultScalarValue, Object, Value};
-use crate::GraphQLError::ValidationError;
+use crate::{
+    ast::InputValue,
+    executor::Variables,
+    parser::SourcePosition,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    validation::RuleError,
+    value::{DefaultScalarValue, Object, Value},
+    GraphQLError::ValidationError,
+};
 
 #[derive(GraphQLEnum, Debug)]
 enum Color {

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -1,8 +1,7 @@
 mod field_execution {
-    use crate::ast::InputValue;
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{
+        ast::InputValue, schema::model::RootNode, types::scalars::EmptyMutation, value::Value,
+    };
 
     struct DataType;
     struct DeepDataType;
@@ -156,9 +155,7 @@ mod field_execution {
 }
 
 mod merge_parallel_fragments {
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{schema::model::RootNode, types::scalars::EmptyMutation, value::Value};
 
     struct Type;
 
@@ -239,9 +236,7 @@ mod merge_parallel_fragments {
 }
 
 mod merge_parallel_inline_fragments {
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{schema::model::RootNode, types::scalars::EmptyMutation, value::Value};
 
     struct Type;
     struct Other;
@@ -383,10 +378,9 @@ mod merge_parallel_inline_fragments {
 }
 
 mod threads_context_correctly {
-    use crate::executor::Context;
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{
+        executor::Context, schema::model::RootNode, types::scalars::EmptyMutation, value::Value,
+    };
 
     struct Schema;
 
@@ -441,11 +435,13 @@ mod threads_context_correctly {
 mod dynamic_context_switching {
     use indexmap::IndexMap;
 
-    use crate::executor::{Context, ExecutionError, FieldError, FieldResult};
-    use crate::parser::SourcePosition;
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{
+        executor::{Context, ExecutionError, FieldError, FieldResult},
+        parser::SourcePosition,
+        schema::model::RootNode,
+        types::scalars::EmptyMutation,
+        value::Value,
+    };
 
     struct Schema;
 
@@ -772,11 +768,13 @@ mod dynamic_context_switching {
 }
 
 mod propagates_errors_to_nullable_fields {
-    use crate::executor::{ExecutionError, FieldError, FieldResult, IntoFieldError};
-    use crate::parser::SourcePosition;
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::{ScalarValue, Value};
+    use crate::{
+        executor::{ExecutionError, FieldError, FieldResult, IntoFieldError},
+        parser::SourcePosition,
+        schema::model::RootNode,
+        types::scalars::EmptyMutation,
+        value::{ScalarValue, Value},
+    };
 
     struct Schema;
     struct Inner;
@@ -1061,10 +1059,9 @@ mod propagates_errors_to_nullable_fields {
 }
 
 mod named_operations {
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
-    use crate::GraphQLError;
+    use crate::{
+        schema::model::RootNode, types::scalars::EmptyMutation, value::Value, GraphQLError,
+    };
 
     struct Schema;
 

--- a/juniper/src/executor_tests/interfaces_unions.rs
+++ b/juniper/src/executor_tests/interfaces_unions.rs
@@ -1,7 +1,5 @@
 mod interface {
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{schema::model::RootNode, types::scalars::EmptyMutation, value::Value};
 
     trait Pet {
         fn name(&self) -> &str;
@@ -157,9 +155,7 @@ mod interface {
 }
 
 mod union {
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{schema::model::RootNode, types::scalars::EmptyMutation, value::Value};
 
     trait Pet {
         fn as_dog(&self) -> Option<&Dog> {

--- a/juniper/src/executor_tests/introspection/enums.rs
+++ b/juniper/src/executor_tests/introspection/enums.rs
@@ -1,9 +1,11 @@
 use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 /*
 

--- a/juniper/src/executor_tests/introspection/input_object.rs
+++ b/juniper/src/executor_tests/introspection/input_object.rs
@@ -1,10 +1,12 @@
 use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
 
-use crate::ast::{FromInputValue, InputValue};
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    ast::{FromInputValue, InputValue},
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 struct Root;
 

--- a/juniper/src/executor_tests/introspection/mod.rs
+++ b/juniper/src/executor_tests/introspection/mod.rs
@@ -7,10 +7,12 @@ use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 #[allow(unused_imports)]
 use self::input_object::{NamedPublic, NamedPublicWithDescription};
 
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{ParseScalarResult, ParseScalarValue, Value};
+use crate::{
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{ParseScalarResult, ParseScalarValue, Value},
+};
 
 #[derive(GraphQLEnum)]
 #[graphql(name = "SampleEnum")]

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,13 +1,15 @@
 use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
 
-use crate::ast::InputValue;
-use crate::executor::Variables;
-use crate::parser::SourcePosition;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::validation::RuleError;
-use crate::value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
-use crate::GraphQLError::ValidationError;
+use crate::{
+    ast::InputValue,
+    executor::Variables,
+    parser::SourcePosition,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    validation::RuleError,
+    value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value},
+    GraphQLError::ValidationError,
+};
 
 #[derive(Debug)]
 struct TestComplexScalar;

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -3,14 +3,18 @@
 pub mod graphiql;
 pub mod playground;
 
-use serde::de::Deserialize;
-use serde::ser::{self, Serialize, SerializeMap};
+use serde::{
+    de::Deserialize,
+    ser::{self, Serialize, SerializeMap},
+};
 use serde_derive::{Deserialize, Serialize};
 
-use crate::ast::InputValue;
-use crate::executor::ExecutionError;
-use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
-use crate::{FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables};
+use crate::{
+    ast::InputValue,
+    executor::ExecutionError,
+    value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
+    FieldError, GraphQLError, GraphQLType, RootNode, Value, Variables,
+};
 
 /// The expected structure of the decoded JSON document for either POST or GET requests.
 ///
@@ -156,8 +160,7 @@ where
 #[cfg(any(test, feature = "expose-test-schema"))]
 #[allow(missing_docs)]
 pub mod tests {
-    use serde_json;
-    use serde_json::Value as Json;
+    use serde_json::{self, Value as Json};
 
     /// Normalized response content we expect to get back from
     /// the http framework integration we are testing.

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -15,9 +15,11 @@
 */
 use chrono::prelude::*;
 
-use crate::parser::{ParseError, ScalarToken, Token};
-use crate::value::{ParseScalarResult, ParseScalarValue};
-use crate::Value;
+use crate::{
+    parser::{ParseError, ScalarToken, Token},
+    value::{ParseScalarResult, ParseScalarValue},
+    Value,
+};
 
 #[doc(hidden)]
 pub static RFC3339_FORMAT: &'static str = "%Y-%m-%dT%H:%M:%S%.f%:z";
@@ -198,13 +200,11 @@ mod test {
 
 #[cfg(test)]
 mod integration_test {
-    use chrono::prelude::*;
-    use chrono::Utc;
+    use chrono::{prelude::*, Utc};
 
-    use crate::executor::Variables;
-    use crate::schema::model::RootNode;
-    use crate::types::scalars::EmptyMutation;
-    use crate::value::Value;
+    use crate::{
+        executor::Variables, schema::model::RootNode, types::scalars::EmptyMutation, value::Value,
+    };
 
     #[test]
     fn test_serialization() {

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -1,15 +1,19 @@
 use indexmap::IndexMap;
-use serde::ser::SerializeMap;
-use serde::{de, ser};
+use serde::{
+    de,
+    ser::{self, SerializeMap},
+};
 use serde_derive::Serialize;
 
 use std::fmt;
 
-use crate::ast::InputValue;
-use crate::executor::ExecutionError;
-use crate::parser::{ParseError, SourcePosition, Spanning};
-use crate::validation::RuleError;
-use crate::{GraphQLError, Object, ScalarValue, Value};
+use crate::{
+    ast::InputValue,
+    executor::ExecutionError,
+    parser::{ParseError, SourcePosition, Spanning},
+    validation::RuleError,
+    GraphQLError, Object, ScalarValue, Value,
+};
 
 #[derive(Serialize)]
 struct SerializeHelper {
@@ -398,11 +402,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::{ExecutionError, GraphQLError};
-    use crate::ast::InputValue;
-    use crate::value::{DefaultScalarValue, Object};
-    use crate::{FieldError, Value};
-    use serde_json::from_str;
-    use serde_json::to_string;
+    use crate::{
+        ast::InputValue,
+        value::{DefaultScalarValue, Object},
+        FieldError, Value,
+    };
+    use serde_json::{from_str, to_string};
 
     #[test]
     fn int() {

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -1,7 +1,9 @@
 use url::Url;
 
-use crate::value::{ParseScalarResult, ParseScalarValue};
-use crate::Value;
+use crate::{
+    value::{ParseScalarResult, ParseScalarValue},
+    Value,
+};
 
 graphql_scalar!(Url where Scalar = <S>{
     description: "Url"

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -149,28 +149,31 @@ mod executor_tests;
 // Needs to be public because macros use it.
 pub use crate::util::to_camel_case;
 
-use crate::executor::execute_validated_query;
-use crate::introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS};
-use crate::parser::{parse_document_source, ParseError, Spanning};
-use crate::validation::{validate_input_values, visit_all_rules, ValidatorContext};
+use crate::{
+    executor::execute_validated_query,
+    introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS},
+    parser::{parse_document_source, ParseError, Spanning},
+    validation::{validate_input_values, visit_all_rules, ValidatorContext},
+};
 
-pub use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue, Type};
-pub use crate::executor::{
-    Applies, LookAheadArgument, LookAheadMethods, LookAheadSelection, LookAheadValue,
-};
-pub use crate::executor::{
-    Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult, FromContext,
-    IntoFieldError, IntoResolvable, Registry, Variables,
-};
-pub use crate::introspection::IntrospectionFormat;
-pub use crate::schema::meta;
-pub use crate::schema::model::RootNode;
-pub use crate::types::base::{Arguments, GraphQLType, TypeKind};
-pub use crate::types::scalars::{EmptyMutation, ID};
-pub use crate::validation::RuleError;
-pub use crate::value::{
-    DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, ScalarRefValue, ScalarValue,
-    Value,
+pub use crate::{
+    ast::{FromInputValue, InputValue, Selection, ToInputValue, Type},
+    executor::{
+        Applies, Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
+        FromContext, IntoFieldError, IntoResolvable, LookAheadArgument, LookAheadMethods,
+        LookAheadSelection, LookAheadValue, Registry, Variables,
+    },
+    introspection::IntrospectionFormat,
+    schema::{meta, model::RootNode},
+    types::{
+        base::{Arguments, GraphQLType, TypeKind},
+        scalars::{EmptyMutation, ID},
+    },
+    validation::RuleError,
+    value::{
+        DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, ScalarRefValue,
+        ScalarValue, Value,
+    },
 };
 
 /// An error that prevented query execution

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -1,9 +1,11 @@
 use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
 
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Value};
+use crate::{
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Value},
+};
 
 struct Root;
 

--- a/juniper/src/macros/tests/field.rs
+++ b/juniper/src/macros/tests/field.rs
@@ -1,8 +1,10 @@
-use crate::ast::InputValue;
-use crate::executor::FieldResult;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    ast::InputValue,
+    executor::FieldResult,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 struct Interface;
 #[derive(Debug)]

--- a/juniper/src/macros/tests/interface.rs
+++ b/juniper/src/macros/tests/interface.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::ast::InputValue;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    ast::InputValue,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 /*
 

--- a/juniper/src/macros/tests/object.rs
+++ b/juniper/src/macros/tests/object.rs
@@ -1,10 +1,12 @@
 use std::marker::PhantomData;
 
-use crate::ast::InputValue;
-use crate::executor::{Context, FieldResult};
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    ast::InputValue,
+    executor::{Context, FieldResult},
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 /*
 

--- a/juniper/src/macros/tests/scalar.rs
+++ b/juniper/src/macros/tests/scalar.rs
@@ -1,7 +1,9 @@
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value};
+use crate::{
+    executor::Variables,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, ParseScalarResult, ParseScalarValue, Value},
+};
 
 struct DefaultName(i32);
 struct OtherOrder(i32);

--- a/juniper/src/macros/tests/union.rs
+++ b/juniper/src/macros/tests/union.rs
@@ -1,9 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::ast::InputValue;
-use crate::schema::model::RootNode;
-use crate::types::scalars::EmptyMutation;
-use crate::value::{DefaultScalarValue, Object, Value};
+use crate::{
+    ast::InputValue,
+    schema::model::RootNode,
+    types::scalars::EmptyMutation,
+    value::{DefaultScalarValue, Object, Value},
+};
 
 /*
 

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -5,14 +5,17 @@ use crate::ast::{
     InputValue, Operation, OperationType, Selection, Type, VariableDefinition, VariableDefinitions,
 };
 
-use crate::parser::value::parse_value_literal;
-use crate::parser::{
-    Lexer, OptionParseResult, ParseError, ParseResult, Parser, Spanning, Token,
-    UnlocatedParseResult,
+use crate::{
+    parser::{
+        value::parse_value_literal, Lexer, OptionParseResult, ParseError, ParseResult, Parser,
+        Spanning, Token, UnlocatedParseResult,
+    },
+    schema::{
+        meta::{Argument, Field as MetaField},
+        model::SchemaType,
+    },
+    value::ScalarValue,
 };
-use crate::schema::meta::{Argument, Field as MetaField};
-use crate::schema::model::SchemaType;
-use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub fn parse_document_source<'a, 'b, S>(

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -1,8 +1,9 @@
-use std::char;
-use std::fmt;
-use std::iter::{Iterator, Peekable};
-use std::result::Result;
-use std::str::CharIndices;
+use std::{
+    char, fmt,
+    iter::{Iterator, Peekable},
+    result::Result,
+    str::CharIndices,
+};
 
 use crate::parser::{SourcePosition, Spanning};
 

--- a/juniper/src/parser/mod.rs
+++ b/juniper/src/parser/mod.rs
@@ -11,6 +11,8 @@ mod tests;
 
 pub use self::document::parse_document_source;
 
-pub use self::lexer::{Lexer, LexerError, ScalarToken, Token};
-pub use self::parser::{OptionParseResult, ParseError, ParseResult, Parser, UnlocatedParseResult};
-pub use self::utils::{SourcePosition, Spanning};
+pub use self::{
+    lexer::{Lexer, LexerError, ScalarToken, Token},
+    parser::{OptionParseResult, ParseError, ParseResult, Parser, UnlocatedParseResult},
+    utils::{SourcePosition, Spanning},
+};

--- a/juniper/src/parser/parser.rs
+++ b/juniper/src/parser/parser.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::result::Result;
+use std::{fmt, result::Result};
 
 use crate::parser::{Lexer, LexerError, Spanning, Token};
 

--- a/juniper/src/parser/tests/document.rs
+++ b/juniper/src/parser/tests/document.rs
@@ -1,11 +1,12 @@
-use crate::ast::{
-    Arguments, Definition, Document, Field, InputValue, Operation, OperationType, Selection,
+use crate::{
+    ast::{
+        Arguments, Definition, Document, Field, InputValue, Operation, OperationType, Selection,
+    },
+    parser::{document::parse_document_source, ParseError, SourcePosition, Spanning, Token},
+    schema::model::SchemaType,
+    validation::test_harness::{MutationRoot, QueryRoot},
+    value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
 };
-use crate::parser::document::parse_document_source;
-use crate::parser::{ParseError, SourcePosition, Spanning, Token};
-use crate::schema::model::SchemaType;
-use crate::validation::test_harness::{MutationRoot, QueryRoot};
-use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
 fn parse_document<S>(s: &str) -> Document<S>
 where

--- a/juniper/src/parser/tests/value.rs
+++ b/juniper/src/parser/tests/value.rs
@@ -4,14 +4,19 @@ use juniper_codegen::{
     GraphQLEnumInternal as GraphQLEnum, GraphQLInputObjectInternal as GraphQLInputObject,
 };
 
-use crate::ast::{FromInputValue, InputValue, Type};
-use crate::parser::value::parse_value_literal;
-use crate::parser::{Lexer, Parser, SourcePosition, Spanning};
-use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::{
+    ast::{FromInputValue, InputValue, Type},
+    parser::{value::parse_value_literal, Lexer, Parser, SourcePosition, Spanning},
+    value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue},
+};
 
-use crate::schema::meta::{Argument, EnumMeta, EnumValue, InputObjectMeta, MetaType, ScalarMeta};
-use crate::schema::model::SchemaType;
-use crate::types::scalars::EmptyMutation;
+use crate::{
+    schema::{
+        meta::{Argument, EnumMeta, EnumValue, InputObjectMeta, MetaType, ScalarMeta},
+        model::SchemaType,
+    },
+    types::scalars::EmptyMutation,
+};
 
 #[derive(GraphQLEnum)]
 enum Enum {

--- a/juniper/src/parser/value.rs
+++ b/juniper/src/parser/value.rs
@@ -1,11 +1,13 @@
 use crate::ast::InputValue;
 
-use crate::parser::{
-    ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token,
+use crate::{
+    parser::{ParseError, ParseResult, Parser, ScalarToken, SourcePosition, Spanning, Token},
+    schema::{
+        meta::{InputObjectMeta, MetaType},
+        model::SchemaType,
+    },
+    value::ScalarValue,
 };
-use crate::schema::meta::{InputObjectMeta, MetaType};
-use crate::schema::model::SchemaType;
-use crate::value::ScalarValue;
 
 pub fn parse_value_literal<'a, 'b, S>(
     parser: &mut Parser<'a>,

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -1,13 +1,17 @@
 //! Types used to describe a `GraphQL` schema
 
-use std::borrow::{Cow, ToOwned};
-use std::fmt;
+use std::{
+    borrow::{Cow, ToOwned},
+    fmt,
+};
 
-use crate::ast::{FromInputValue, InputValue, Type};
-use crate::parser::{ParseError, ScalarToken};
-use crate::schema::model::SchemaType;
-use crate::types::base::TypeKind;
-use crate::value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue};
+use crate::{
+    ast::{FromInputValue, InputValue, Type},
+    parser::{ParseError, ScalarToken},
+    schema::model::SchemaType,
+    types::base::TypeKind,
+    value::{DefaultScalarValue, ParseScalarValue, ScalarRefValue, ScalarValue},
+};
 
 /// Whether an item is deprecated, with context.
 #[derive(Debug, PartialEq, Hash, Clone)]

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -4,14 +4,13 @@ use fnv::FnvHashMap;
 
 use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
-use crate::ast::Type;
-use crate::executor::{Context, Registry};
-use crate::schema::meta::{
-    Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta,
+use crate::{
+    ast::Type,
+    executor::{Context, Registry},
+    schema::meta::{Argument, InterfaceMeta, MetaType, ObjectMeta, PlaceholderMeta, UnionMeta},
+    types::{base::GraphQLType, name::Name},
+    value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
 };
-use crate::types::base::GraphQLType;
-use crate::types::name::Name;
-use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
 
 /// Root query node of a schema
 ///

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -1,13 +1,17 @@
-use crate::ast::Selection;
-use crate::executor::{ExecutionResult, Executor, Registry};
-use crate::types::base::{Arguments, GraphQLType, TypeKind};
-use crate::value::{ScalarRefValue, ScalarValue, Value};
-
-use crate::schema::meta::{
-    Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType, ObjectMeta,
-    UnionMeta,
+use crate::{
+    ast::Selection,
+    executor::{ExecutionResult, Executor, Registry},
+    types::base::{Arguments, GraphQLType, TypeKind},
+    value::{ScalarRefValue, ScalarValue, Value},
 };
-use crate::schema::model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, TypeType};
+
+use crate::schema::{
+    meta::{
+        Argument, EnumMeta, EnumValue, Field, InputObjectMeta, InterfaceMeta, MetaType, ObjectMeta,
+        UnionMeta,
+    },
+    model::{DirectiveLocation, DirectiveType, RootNode, SchemaType, TypeType},
+};
 
 impl<'a, CtxT, S, QueryT, MutationT> GraphQLType<S> for RootNode<'a, QueryT, MutationT, S>
 where
@@ -58,8 +62,7 @@ where
         selection_set: Option<&[Selection<S>]>,
         executor: &Executor<Self::Context, S>,
     ) -> Value<S> {
-        use crate::types::base::resolve_selection_set_into;
-        use crate::value::Object;
+        use crate::{types::base::resolve_selection_set_into, value::Object};
         if let Some(selection_set) = selection_set {
             let mut result = Object::with_capacity(selection_set.len());
             if resolve_selection_set_into(self, info, selection_set, executor, &mut result) {

--- a/juniper/src/tests/introspection_tests.rs
+++ b/juniper/src/tests/introspection_tests.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 
 use super::schema_introspection::*;
-use crate::executor::Variables;
-use crate::introspection::IntrospectionFormat;
-use crate::schema::model::RootNode;
-use crate::tests::model::Database;
-use crate::tests::schema::Query;
-use crate::types::scalars::EmptyMutation;
+use crate::{
+    executor::Variables,
+    introspection::IntrospectionFormat,
+    schema::model::RootNode,
+    tests::{model::Database, schema::Query},
+    types::scalars::EmptyMutation,
+};
 
 #[test]
 fn test_introspection_query_type_name() {

--- a/juniper/src/tests/query_tests.rs
+++ b/juniper/src/tests/query_tests.rs
@@ -1,10 +1,11 @@
-use crate::ast::InputValue;
-use crate::executor::Variables;
-use crate::schema::model::RootNode;
-use crate::tests::model::Database;
-use crate::tests::schema::Query;
-use crate::types::scalars::EmptyMutation;
-use crate::value::Value;
+use crate::{
+    ast::InputValue,
+    executor::Variables,
+    schema::model::RootNode,
+    tests::{model::Database, schema::Query},
+    types::scalars::EmptyMutation,
+    value::Value,
+};
 
 #[test]
 fn test_hero_name() {

--- a/juniper/src/tests/schema.rs
+++ b/juniper/src/tests/schema.rs
@@ -1,7 +1,9 @@
 #![allow(missing_docs)]
 
-use crate::executor::Context;
-use crate::tests::model::{Character, Database, Droid, Episode, Human};
+use crate::{
+    executor::Context,
+    tests::model::{Character, Database, Droid, Episode, Human},
+};
 
 impl Context for Database {}
 

--- a/juniper/src/tests/schema_introspection.rs
+++ b/juniper/src/tests/schema_introspection.rs
@@ -1,4 +1,7 @@
-use crate::value::{self, Value, Value::Null};
+use crate::value::{
+    self,
+    Value::{self, Null},
+};
 
 // Sort a nested schema Value.
 // In particular, lists are sorted by the "name" key of children, if present.

--- a/juniper/src/tests/type_info_tests.rs
+++ b/juniper/src/tests/type_info_tests.rs
@@ -1,11 +1,14 @@
 use indexmap::IndexMap;
 
-use crate::executor::{ExecutionResult, Executor, Registry, Variables};
-use crate::schema::meta::MetaType;
-use crate::schema::model::RootNode;
-use crate::types::base::{Arguments, GraphQLType};
-use crate::types::scalars::EmptyMutation;
-use crate::value::{ScalarRefValue, ScalarValue, Value};
+use crate::{
+    executor::{ExecutionResult, Executor, Registry, Variables},
+    schema::{meta::MetaType, model::RootNode},
+    types::{
+        base::{Arguments, GraphQLType},
+        scalars::EmptyMutation,
+    },
+    value::{ScalarRefValue, ScalarValue, Value},
+};
 
 pub struct NodeTypeInfo {
     name: String,

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -2,13 +2,17 @@ use indexmap::IndexMap;
 
 use juniper_codegen::GraphQLEnumInternal as GraphQLEnum;
 
-use crate::ast::{Directive, FromInputValue, InputValue, Selection};
-use crate::executor::Variables;
-use crate::value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value};
+use crate::{
+    ast::{Directive, FromInputValue, InputValue, Selection},
+    executor::Variables,
+    value::{DefaultScalarValue, Object, ScalarRefValue, ScalarValue, Value},
+};
 
-use crate::executor::{ExecutionResult, Executor, Registry};
-use crate::parser::Spanning;
-use crate::schema::meta::{Argument, MetaType};
+use crate::{
+    executor::{ExecutionResult, Executor, Registry},
+    parser::Spanning,
+    schema::meta::{Argument, MetaType},
+};
 
 /// GraphQL type kind
 ///

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -1,9 +1,13 @@
-use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue};
-use crate::schema::meta::MetaType;
-use crate::value::{ScalarRefValue, ScalarValue, Value};
+use crate::{
+    ast::{FromInputValue, InputValue, Selection, ToInputValue},
+    schema::meta::MetaType,
+    value::{ScalarRefValue, ScalarValue, Value},
+};
 
-use crate::executor::{Executor, Registry};
-use crate::types::base::GraphQLType;
+use crate::{
+    executor::{Executor, Registry},
+    types::base::GraphQLType,
+};
 
 impl<S, T, CtxT> GraphQLType<S> for Option<T>
 where

--- a/juniper/src/types/name.rs
+++ b/juniper/src/types/name.rs
@@ -1,7 +1,9 @@
-use std::borrow::Borrow;
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FmtResult};
-use std::str::FromStr;
+use std::{
+    borrow::Borrow,
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+    str::FromStr,
+};
 
 // Helper functions until the corresponding AsciiExt methods
 // stabilise (https://github.com/rust-lang/rust/issues/39658).

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -1,11 +1,12 @@
 use crate::ast::{FromInputValue, InputValue, Selection, ToInputValue};
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, sync::Arc};
 
-use crate::executor::{ExecutionResult, Executor, Registry};
-use crate::schema::meta::MetaType;
-use crate::types::base::{Arguments, GraphQLType};
-use crate::value::{ScalarRefValue, ScalarValue, Value};
+use crate::{
+    executor::{ExecutionResult, Executor, Registry},
+    schema::meta::MetaType,
+    types::base::{Arguments, GraphQLType},
+    value::{ScalarRefValue, ScalarValue, Value},
+};
 
 impl<S, T, CtxT> GraphQLType<S> for Box<T>
 where

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -1,15 +1,14 @@
 use serde_derive::{Deserialize, Serialize};
-use std::convert::From;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::{char, u32};
+use std::{char, convert::From, marker::PhantomData, ops::Deref, u32};
 
-use crate::ast::{InputValue, Selection, ToInputValue};
-use crate::executor::{Executor, Registry};
-use crate::parser::{LexerError, ParseError, ScalarToken, Token};
-use crate::schema::meta::MetaType;
-use crate::types::base::GraphQLType;
-use crate::value::{ParseScalarResult, ScalarRefValue, ScalarValue, Value};
+use crate::{
+    ast::{InputValue, Selection, ToInputValue},
+    executor::{Executor, Registry},
+    parser::{LexerError, ParseError, ScalarToken, Token},
+    schema::meta::MetaType,
+    types::base::GraphQLType,
+    value::{ParseScalarResult, ScalarRefValue, ScalarValue, Value},
+};
 
 /// An ID as defined by the GraphQL specification
 ///
@@ -316,8 +315,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::ID;
-    use crate::parser::ScalarToken;
-    use crate::value::{DefaultScalarValue, ParseScalarValue};
+    use crate::{
+        parser::ScalarToken,
+        value::{DefaultScalarValue, ParseScalarValue},
+    };
 
     #[test]
     fn test_id_from_string() {

--- a/juniper/src/types/utilities.rs
+++ b/juniper/src/types/utilities.rs
@@ -1,7 +1,11 @@
-use crate::ast::InputValue;
-use crate::schema::meta::{EnumMeta, InputObjectMeta, MetaType};
-use crate::schema::model::{SchemaType, TypeType};
-use crate::value::ScalarValue;
+use crate::{
+    ast::InputValue,
+    schema::{
+        meta::{EnumMeta, InputObjectMeta, MetaType},
+        model::{SchemaType, TypeType},
+    },
+    value::ScalarValue,
+};
 use std::collections::HashSet;
 
 pub fn is_valid_literal_value<S>(

--- a/juniper/src/validation/context.rs
+++ b/juniper/src/validation/context.rs
@@ -1,10 +1,8 @@
-use std::collections::HashSet;
-use std::fmt::Debug;
+use std::{collections::HashSet, fmt::Debug};
 
 use crate::ast::{Definition, Document, Type};
 
-use crate::schema::meta::MetaType;
-use crate::schema::model::SchemaType;
+use crate::schema::{meta::MetaType, model::SchemaType};
 
 use crate::parser::SourcePosition;
 

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -1,13 +1,16 @@
-use std::collections::HashSet;
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
-use crate::ast::{Definition, Document, InputValue, VariableDefinitions};
-use crate::executor::Variables;
-use crate::parser::SourcePosition;
-use crate::schema::meta::{EnumMeta, InputObjectMeta, MetaType, ScalarMeta};
-use crate::schema::model::{SchemaType, TypeType};
-use crate::validation::RuleError;
-use crate::value::{ScalarRefValue, ScalarValue};
+use crate::{
+    ast::{Definition, Document, InputValue, VariableDefinitions},
+    executor::Variables,
+    parser::SourcePosition,
+    schema::{
+        meta::{EnumMeta, InputObjectMeta, MetaType, ScalarMeta},
+        model::{SchemaType, TypeType},
+    },
+    validation::RuleError,
+    value::{ScalarRefValue, ScalarValue},
+};
 
 #[derive(Debug)]
 enum Path<'a> {

--- a/juniper/src/validation/mod.rs
+++ b/juniper/src/validation/mod.rs
@@ -10,12 +10,14 @@ mod visitor;
 #[cfg(test)]
 pub(crate) mod test_harness;
 
-pub use self::context::{RuleError, ValidatorContext};
-pub use self::input_value::validate_input_values;
-pub use self::multi_visitor::MultiVisitorNil;
 pub(crate) use self::rules::visit_all_rules;
-pub use self::traits::Visitor;
-pub use self::visitor::visit;
+pub use self::{
+    context::{RuleError, ValidatorContext},
+    input_value::validate_input_values,
+    multi_visitor::MultiVisitorNil,
+    traits::Visitor,
+    visitor::visit,
+};
 
 #[cfg(test)]
 pub use self::test_harness::{

--- a/juniper/src/validation/multi_visitor.rs
+++ b/juniper/src/validation/multi_visitor.rs
@@ -1,10 +1,12 @@
-use crate::ast::{
-    Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
-    Selection, VariableDefinition,
+use crate::{
+    ast::{
+        Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue,
+        Operation, Selection, VariableDefinition,
+    },
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
 };
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub struct MultiVisitorNil;

--- a/juniper/src/validation/rules/arguments_of_correct_type.rs
+++ b/juniper/src/validation/rules/arguments_of_correct_type.rs
@@ -1,9 +1,11 @@
-use crate::ast::{Directive, Field, InputValue};
-use crate::parser::Spanning;
-use crate::schema::meta::Argument;
-use crate::types::utilities::is_valid_literal_value;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Directive, Field, InputValue},
+    parser::Spanning,
+    schema::meta::Argument,
+    types::utilities::is_valid_literal_value,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::fmt::Debug;
 
 pub struct ArgumentsOfCorrectType<'a, S: Debug + 'a> {
@@ -76,9 +78,11 @@ fn error_message(arg_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn good_null_value() {

--- a/juniper/src/validation/rules/default_values_of_correct_type.rs
+++ b/juniper/src/validation/rules/default_values_of_correct_type.rs
@@ -1,8 +1,10 @@
-use crate::ast::VariableDefinition;
-use crate::parser::Spanning;
-use crate::types::utilities::is_valid_literal_value;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::VariableDefinition,
+    parser::Spanning,
+    types::utilities::is_valid_literal_value,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct DefaultValuesOfCorrectType;
 
@@ -62,9 +64,11 @@ fn non_null_error_message(arg_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{factory, non_null_error_message, type_error_message};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn variables_with_no_default_values() {
@@ -189,5 +193,4 @@ mod tests {
             )],
         );
     }
-
 }

--- a/juniper/src/validation/rules/fields_on_correct_type.rs
+++ b/juniper/src/validation/rules/fields_on_correct_type.rs
@@ -1,8 +1,10 @@
-use crate::ast::Field;
-use crate::parser::Spanning;
-use crate::schema::meta::MetaType;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::Field,
+    parser::Spanning,
+    schema::meta::MetaType,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct FieldsOnCorrectType;
 
@@ -55,9 +57,11 @@ fn error_message(field: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn selection_on_object() {
@@ -356,5 +360,4 @@ mod tests {
         "#,
         );
     }
-
 }

--- a/juniper/src/validation/rules/fragments_on_composite_types.rs
+++ b/juniper/src/validation/rules/fragments_on_composite_types.rs
@@ -1,7 +1,9 @@
-use crate::ast::{Fragment, InlineFragment};
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Fragment, InlineFragment},
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct FragmentsOnCompositeTypes;
 
@@ -73,9 +75,11 @@ fn error_message(fragment_name: Option<&str>, on_type: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn on_object() {

--- a/juniper/src/validation/rules/known_argument_names.rs
+++ b/juniper/src/validation/rules/known_argument_names.rs
@@ -1,8 +1,10 @@
-use crate::ast::{Directive, Field, InputValue};
-use crate::parser::Spanning;
-use crate::schema::meta::Argument;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Directive, Field, InputValue},
+    parser::Spanning,
+    schema::meta::Argument,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::fmt::Debug;
 
 #[derive(Debug)]
@@ -106,9 +108,11 @@ fn directive_error_message(arg_name: &str, directive_name: &str) -> String {
 mod tests {
     use super::{directive_error_message, factory, field_error_message};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn single_arg_is_known() {

--- a/juniper/src/validation/rules/known_directives.rs
+++ b/juniper/src/validation/rules/known_directives.rs
@@ -1,10 +1,10 @@
-use crate::ast::{
-    Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType,
+use crate::{
+    ast::{Directive, Field, Fragment, FragmentSpread, InlineFragment, Operation, OperationType},
+    parser::Spanning,
+    schema::model::DirectiveLocation,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
 };
-use crate::parser::Spanning;
-use crate::schema::model::DirectiveLocation;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
 
 pub struct KnownDirectives {
     location_stack: Vec<DirectiveLocation>,
@@ -143,10 +143,12 @@ fn misplaced_error_message(directive_name: &str, location: &DirectiveLocation) -
 mod tests {
     use super::{factory, misplaced_error_message, unknown_error_message};
 
-    use crate::parser::SourcePosition;
-    use crate::schema::model::DirectiveLocation;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        schema::model::DirectiveLocation,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn with_no_directives() {

--- a/juniper/src/validation/rules/known_fragment_names.rs
+++ b/juniper/src/validation/rules/known_fragment_names.rs
@@ -1,7 +1,9 @@
-use crate::ast::FragmentSpread;
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::FragmentSpread,
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct KnownFragmentNames;
 
@@ -33,9 +35,11 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn known() {

--- a/juniper/src/validation/rules/known_type_names.rs
+++ b/juniper/src/validation/rules/known_type_names.rs
@@ -1,7 +1,9 @@
-use crate::ast::{Fragment, InlineFragment, VariableDefinition};
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Fragment, InlineFragment, VariableDefinition},
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::fmt::Debug;
 
 pub struct KnownTypeNames;
@@ -61,9 +63,11 @@ fn error_message(type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn known_type_names_are_valid() {

--- a/juniper/src/validation/rules/lone_anonymous_operation.rs
+++ b/juniper/src/validation/rules/lone_anonymous_operation.rs
@@ -1,7 +1,9 @@
-use crate::ast::{Definition, Document, Operation};
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Definition, Document, Operation},
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct LoneAnonymousOperation {
     operation_count: Option<usize>,
@@ -49,9 +51,11 @@ fn error_message() -> &'static str {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn no_operations() {

--- a/juniper/src/validation/rules/mod.rs
+++ b/juniper/src/validation/rules/mod.rs
@@ -23,9 +23,11 @@ mod unique_variable_names;
 mod variables_are_input_types;
 mod variables_in_allowed_position;
 
-use crate::ast::Document;
-use crate::validation::{visit, MultiVisitorNil, ValidatorContext};
-use crate::value::ScalarValue;
+use crate::{
+    ast::Document,
+    validation::{visit, MultiVisitorNil, ValidatorContext},
+    value::ScalarValue,
+};
 use std::fmt::Debug;
 
 pub(crate) fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)

--- a/juniper/src/validation/rules/no_fragment_cycles.rs
+++ b/juniper/src/validation/rules/no_fragment_cycles.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{Document, Fragment, FragmentSpread};
-use crate::parser::Spanning;
-use crate::validation::{RuleError, ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Document, Fragment, FragmentSpread},
+    parser::Spanning,
+    validation::{RuleError, ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct NoFragmentCycles<'a> {
     current_fragment: Option<&'a str>,
@@ -133,9 +135,11 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn single_reference_is_valid() {

--- a/juniper/src/validation/rules/no_undefined_variables.rs
+++ b/juniper/src/validation/rules/no_undefined_variables.rs
@@ -1,7 +1,9 @@
-use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{RuleError, ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition},
+    parser::{SourcePosition, Spanning},
+    validation::{RuleError, ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -162,9 +164,11 @@ fn error_message(var_name: &str, op_name: Option<&str>) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn all_variables_defined() {

--- a/juniper/src/validation/rules/no_unused_fragments.rs
+++ b/juniper/src/validation/rules/no_unused_fragments.rs
@@ -1,9 +1,11 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{Definition, Document, Fragment, FragmentSpread, Operation};
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Definition, Document, Fragment, FragmentSpread, Operation},
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -109,9 +111,11 @@ fn error_message(frag_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn all_fragment_names_are_used() {

--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -1,7 +1,9 @@
-use crate::ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition};
-use crate::parser::Spanning;
-use crate::validation::{RuleError, ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Document, Fragment, FragmentSpread, InputValue, Operation, VariableDefinition},
+    parser::Spanning,
+    validation::{RuleError, ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -153,9 +155,11 @@ fn error_message(var_name: &str, op_name: Option<&str>) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn uses_all_variables() {

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -1,15 +1,11 @@
-use crate::ast::{
-    Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type,
+use crate::{
+    ast::{Arguments, Definition, Document, Field, Fragment, FragmentSpread, Selection, Type},
+    parser::{SourcePosition, Spanning},
+    schema::meta::{Field as FieldType, MetaType},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
 };
-use crate::parser::{SourcePosition, Spanning};
-use crate::schema::meta::{Field as FieldType, MetaType};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
-use std::borrow::Borrow;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
+use std::{borrow::Borrow, cell::RefCell, collections::HashMap, fmt::Debug, hash::Hash};
 
 #[derive(Debug)]
 struct Conflict(ConflictReason, Vec<SourcePosition>, Vec<SourcePosition>);
@@ -739,20 +735,25 @@ fn format_reason(reason: &ConflictReasonMessage) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::ConflictReasonMessage::*;
-    use super::{error_message, factory, ConflictReason};
+    use super::{error_message, factory, ConflictReason, ConflictReasonMessage::*};
 
-    use crate::executor::Registry;
-    use crate::schema::meta::MetaType;
-    use crate::types::base::GraphQLType;
-    use crate::types::scalars::{EmptyMutation, ID};
-
-    use crate::parser::SourcePosition;
-    use crate::validation::{
-        expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
-        expect_passes_rule_with_schema, RuleError,
+    use crate::{
+        executor::Registry,
+        schema::meta::MetaType,
+        types::{
+            base::GraphQLType,
+            scalars::{EmptyMutation, ID},
+        },
     };
-    use crate::value::{DefaultScalarValue, ScalarRefValue, ScalarValue};
+
+    use crate::{
+        parser::SourcePosition,
+        validation::{
+            expect_fails_rule, expect_fails_rule_with_schema, expect_passes_rule,
+            expect_passes_rule_with_schema, RuleError,
+        },
+        value::{DefaultScalarValue, ScalarRefValue, ScalarValue},
+    };
 
     #[test]
     fn unique_fields() {

--- a/juniper/src/validation/rules/possible_fragment_spreads.rs
+++ b/juniper/src/validation/rules/possible_fragment_spreads.rs
@@ -1,10 +1,12 @@
 use std::fmt::Debug;
 
-use crate::ast::{Definition, Document, FragmentSpread, InlineFragment};
-use crate::parser::Spanning;
-use crate::schema::meta::MetaType;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Definition, Document, FragmentSpread, InlineFragment},
+    parser::Spanning,
+    schema::meta::MetaType,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 use std::collections::HashMap;
 
 pub struct PossibleFragmentSpreads<'a, S: Debug + 'a> {
@@ -99,9 +101,11 @@ fn error_message(frag_name: Option<&str>, parent_type_name: &str, frag_type: &st
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn of_the_same_object() {
@@ -390,5 +394,4 @@ mod tests {
             )],
         );
     }
-
 }

--- a/juniper/src/validation/rules/provided_non_null_arguments.rs
+++ b/juniper/src/validation/rules/provided_non_null_arguments.rs
@@ -1,9 +1,10 @@
-use crate::ast::{Directive, Field};
-use crate::parser::Spanning;
-use crate::schema::meta::Field as FieldType;
-use crate::schema::model::DirectiveType;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Directive, Field},
+    parser::Spanning,
+    schema::{meta::Field as FieldType, model::DirectiveType},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct ProvidedNonNullArguments;
 
@@ -98,9 +99,11 @@ fn directive_error_message(directive_name: &str, arg_name: &str, type_name: &str
 mod tests {
     use super::{directive_error_message, factory, field_error_message};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn ignores_unknown_arguments() {

--- a/juniper/src/validation/rules/scalar_leafs.rs
+++ b/juniper/src/validation/rules/scalar_leafs.rs
@@ -1,7 +1,9 @@
-use crate::ast::Field;
-use crate::parser::Spanning;
-use crate::validation::{RuleError, ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::Field,
+    parser::Spanning,
+    validation::{RuleError, ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct ScalarLeafs;
 
@@ -57,9 +59,11 @@ fn required_error_message(field_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{factory, no_allowed_error_message, required_error_message};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn valid_scalar_selection() {
@@ -196,5 +200,4 @@ mod tests {
             )],
         );
     }
-
 }

--- a/juniper/src/validation/rules/unique_argument_names.rs
+++ b/juniper/src/validation/rules/unique_argument_names.rs
@@ -1,9 +1,11 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use crate::ast::{Directive, Field, InputValue};
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Directive, Field, InputValue},
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueArgumentNames<'a> {
     known_names: HashMap<&'a str, SourcePosition>,
@@ -54,9 +56,11 @@ fn error_message(arg_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn no_arguments_on_field() {
@@ -260,5 +264,4 @@ mod tests {
             ],
         );
     }
-
 }

--- a/juniper/src/validation/rules/unique_fragment_names.rs
+++ b/juniper/src/validation/rules/unique_fragment_names.rs
@@ -1,9 +1,11 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use crate::ast::Fragment;
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::Fragment,
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueFragmentNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -46,9 +48,11 @@ fn duplicate_message(frag_name: &str) -> String {
 mod tests {
     use super::{duplicate_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn no_fragments() {

--- a/juniper/src/validation/rules/unique_input_field_names.rs
+++ b/juniper/src/validation/rules/unique_input_field_names.rs
@@ -1,9 +1,11 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use crate::ast::InputValue;
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::InputValue,
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueInputFieldNames<'a> {
     known_name_stack: Vec<HashMap<&'a str, SourcePosition>>,
@@ -64,9 +66,11 @@ fn error_message(field_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn input_object_with_fields() {
@@ -170,5 +174,4 @@ mod tests {
             ],
         );
     }
-
 }

--- a/juniper/src/validation/rules/unique_operation_names.rs
+++ b/juniper/src/validation/rules/unique_operation_names.rs
@@ -1,9 +1,11 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use crate::ast::Operation;
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::Operation,
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueOperationNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -45,9 +47,11 @@ fn error_message(op_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn no_operations() {

--- a/juniper/src/validation/rules/unique_variable_names.rs
+++ b/juniper/src/validation/rules/unique_variable_names.rs
@@ -1,9 +1,11 @@
 use std::collections::hash_map::{Entry, HashMap};
 
-use crate::ast::{Operation, VariableDefinition};
-use crate::parser::{SourcePosition, Spanning};
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Operation, VariableDefinition},
+    parser::{SourcePosition, Spanning},
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueVariableNames<'a> {
     names: HashMap<&'a str, SourcePosition>,
@@ -54,9 +56,11 @@ fn error_message(var_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn unique_variable_names() {

--- a/juniper/src/validation/rules/variables_are_input_types.rs
+++ b/juniper/src/validation/rules/variables_are_input_types.rs
@@ -1,7 +1,9 @@
-use crate::ast::VariableDefinition;
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::VariableDefinition,
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 pub struct UniqueVariableNames;
 
@@ -43,9 +45,11 @@ fn error_message(var_name: &str, type_name: &str) -> String {
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn input_types_are_valid() {

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -1,11 +1,15 @@
-use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
 
-use crate::ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition};
-use crate::parser::Spanning;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
+use crate::{
+    ast::{Document, Fragment, FragmentSpread, Operation, Type, VariableDefinition},
+    parser::Spanning,
+    validation::{ValidatorContext, Visitor},
+    value::ScalarValue,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope<'a> {
@@ -161,9 +165,11 @@ fn error_message(var_name: &str, type_name: &str, expected_type_name: &str) -> S
 mod tests {
     use super::{error_message, factory};
 
-    use crate::parser::SourcePosition;
-    use crate::validation::{expect_fails_rule, expect_passes_rule, RuleError};
-    use crate::value::DefaultScalarValue;
+    use crate::{
+        parser::SourcePosition,
+        validation::{expect_fails_rule, expect_passes_rule, RuleError},
+        value::DefaultScalarValue,
+    };
 
     #[test]
     fn boolean_into_boolean() {

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -1,14 +1,17 @@
 use juniper_codegen::GraphQLInputObjectInternal as GraphQLInputObject;
 
-use crate::ast::{FromInputValue, InputValue};
-use crate::executor::Registry;
-use crate::parser::parse_document_source;
-use crate::schema::meta::{EnumValue, MetaType};
-use crate::schema::model::{DirectiveLocation, DirectiveType, RootNode};
-use crate::types::base::GraphQLType;
-use crate::types::scalars::ID;
-use crate::validation::{visit, MultiVisitorNil, RuleError, ValidatorContext, Visitor};
-use crate::value::{ScalarRefValue, ScalarValue};
+use crate::{
+    ast::{FromInputValue, InputValue},
+    executor::Registry,
+    parser::parse_document_source,
+    schema::{
+        meta::{EnumValue, MetaType},
+        model::{DirectiveLocation, DirectiveType, RootNode},
+    },
+    types::{base::GraphQLType, scalars::ID},
+    validation::{visit, MultiVisitorNil, RuleError, ValidatorContext, Visitor},
+    value::{ScalarRefValue, ScalarValue},
+};
 
 struct Being;
 struct Pet;

--- a/juniper/src/validation/traits.rs
+++ b/juniper/src/validation/traits.rs
@@ -1,10 +1,12 @@
-use crate::ast::{
-    Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue, Operation,
-    Selection, VariableDefinition,
+use crate::{
+    ast::{
+        Directive, Document, Field, Fragment, FragmentSpread, InlineFragment, InputValue,
+        Operation, Selection, VariableDefinition,
+    },
+    parser::Spanning,
+    validation::ValidatorContext,
+    value::ScalarValue,
 };
-use crate::parser::Spanning;
-use crate::validation::ValidatorContext;
-use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub trait Visitor<'a, S>

--- a/juniper/src/validation/visitor.rs
+++ b/juniper/src/validation/visitor.rs
@@ -1,14 +1,15 @@
 use std::borrow::Cow;
 
-use crate::ast::{
-    Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread, InlineFragment,
-    InputValue, Operation, OperationType, Selection, Type, VariableDefinitions,
+use crate::{
+    ast::{
+        Arguments, Definition, Directive, Document, Field, Fragment, FragmentSpread,
+        InlineFragment, InputValue, Operation, OperationType, Selection, Type, VariableDefinitions,
+    },
+    parser::Spanning,
+    schema::meta::Argument,
+    validation::{multi_visitor::MultiVisitorCons, ValidatorContext, Visitor},
+    value::ScalarValue,
 };
-use crate::parser::Spanning;
-use crate::schema::meta::Argument;
-use crate::validation::multi_visitor::MultiVisitorCons;
-use crate::validation::{ValidatorContext, Visitor};
-use crate::value::ScalarValue;
 
 #[doc(hidden)]
 pub fn visit<'a, A, B, S>(

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -1,5 +1,7 @@
-use crate::ast::{InputValue, ToInputValue};
-use crate::parser::Spanning;
+use crate::{
+    ast::{InputValue, ToInputValue},
+    parser::Spanning,
+};
 mod object;
 mod scalar;
 

--- a/juniper/src/value/object.rs
+++ b/juniper/src/value/object.rs
@@ -1,5 +1,4 @@
-use std::iter::FromIterator;
-use std::vec::IntoIter;
+use std::{iter::FromIterator, vec::IntoIter};
 
 use super::Value;
 

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -1,7 +1,6 @@
 use crate::parser::{ParseError, ScalarToken};
 use juniper_codegen::GraphQLScalarValueInternal as GraphQLScalarValue;
-use serde::de;
-use serde::ser::Serialize;
+use serde::{de, ser::Serialize};
 use std::fmt::{self, Debug, Display};
 
 /// The result of converting a string into a scalar value

--- a/juniper_hyper/examples/hyper_server.rs
+++ b/juniper_hyper/examples/hyper_server.rs
@@ -5,14 +5,15 @@ extern crate juniper_hyper;
 extern crate pretty_env_logger;
 
 use futures::future;
-use hyper::rt::{self, Future};
-use hyper::service::service_fn;
-use hyper::Method;
-use hyper::{Body, Response, Server, StatusCode};
-use juniper::tests::model::Database;
-use juniper::tests::schema::Query;
-use juniper::EmptyMutation;
-use juniper::RootNode;
+use hyper::{
+    rt::{self, Future},
+    service::service_fn,
+    Body, Method, Response, Server, StatusCode,
+};
+use juniper::{
+    tests::{model::Database, schema::Query},
+    EmptyMutation, RootNode,
+};
 use std::sync::Arc;
 
 fn main() {

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -4,17 +4,17 @@
 extern crate reqwest;
 
 use futures::future::Either;
-use hyper::header::HeaderValue;
-use hyper::rt::Stream;
-use hyper::{header, Body, Method, Request, Response, StatusCode};
-use juniper::http::GraphQLRequest as JuniperGraphQLRequest;
-use juniper::serde::Deserialize;
-use juniper::{DefaultScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue};
+use hyper::{
+    header::{self, HeaderValue},
+    rt::Stream,
+    Body, Method, Request, Response, StatusCode,
+};
+use juniper::{
+    http::GraphQLRequest as JuniperGraphQLRequest, serde::Deserialize, DefaultScalarValue,
+    GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue,
+};
 use serde_json::error::Error as SerdeError;
-use std::error::Error;
-use std::fmt;
-use std::string::FromUtf8Error;
-use std::sync::Arc;
+use std::{error::Error, fmt, string::FromUtf8Error, sync::Arc};
 use tokio::prelude::*;
 use url::form_urlencoded;
 
@@ -307,20 +307,18 @@ impl Error for GraphQLRequestError {
 
 #[cfg(test)]
 mod tests {
-    use futures::{future, future::Either, Future};
-    use hyper::service::service_fn;
-    use hyper::Method;
-    use hyper::{Body, Response, Server, StatusCode};
-    use juniper::http::tests as http_tests;
-    use juniper::tests::model::Database;
-    use juniper::tests::schema::Query;
-    use juniper::EmptyMutation;
-    use juniper::RootNode;
-    use reqwest;
-    use reqwest::Response as ReqwestResponse;
-    use std::sync::Arc;
-    use std::thread;
-    use std::time;
+    use futures::{
+        future::{self, Either},
+        Future,
+    };
+    use hyper::{service::service_fn, Body, Method, Response, Server, StatusCode};
+    use juniper::{
+        http::tests as http_tests,
+        tests::{model::Database, schema::Query},
+        EmptyMutation, RootNode,
+    };
+    use reqwest::{self, Response as ReqwestResponse};
+    use std::{sync::Arc, thread, time};
     use tokio::runtime::Runtime;
 
     struct TestHyperIntegration;

--- a/juniper_iron/examples/iron_server.rs
+++ b/juniper_iron/examples/iron_server.rs
@@ -8,9 +8,10 @@ extern crate serde;
 use std::env;
 
 use iron::prelude::*;
-use juniper::tests::model::Database;
-use juniper::tests::schema::Query;
-use juniper::EmptyMutation;
+use juniper::{
+    tests::{model::Database, schema::Query},
+    EmptyMutation,
+};
 use juniper_iron::{GraphQLHandler, GraphiQLHandler};
 use logger::Logger;
 use mount::Mount;

--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -110,23 +110,17 @@ extern crate iron_test;
 #[cfg(test)]
 extern crate url;
 
-use iron::itry;
-use iron::method;
-use iron::middleware::Handler;
-use iron::mime::Mime;
-use iron::prelude::*;
-use iron::status;
+use iron::{itry, method, middleware::Handler, mime::Mime, prelude::*, status};
 use urlencoded::{UrlDecodingError, UrlEncodedQuery};
 
-use std::error::Error;
-use std::fmt;
-use std::io::Read;
+use std::{error::Error, fmt, io::Read};
 
 use serde_json::error::Error as SerdeError;
 
-use juniper::http;
-use juniper::serde::Deserialize;
-use juniper::{DefaultScalarValue, GraphQLType, InputValue, RootNode, ScalarRefValue, ScalarValue};
+use juniper::{
+    http, serde::Deserialize, DefaultScalarValue, GraphQLType, InputValue, RootNode,
+    ScalarRefValue, ScalarValue,
+};
 
 #[derive(serde_derive::Deserialize)]
 #[serde(untagged)]
@@ -435,15 +429,15 @@ impl From<GraphQLIronError> for IronError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iron::Url;
-    use iron::{Handler, Headers};
+    use iron::{Handler, Headers, Url};
     use iron_test::{request, response};
     use url::percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
 
-    use juniper::http::tests as http_tests;
-    use juniper::tests::model::Database;
-    use juniper::tests::schema::Query;
-    use juniper::EmptyMutation;
+    use juniper::{
+        http::tests as http_tests,
+        tests::{model::Database, schema::Query},
+        EmptyMutation,
+    };
 
     use super::GraphQLHandler;
 

--- a/juniper_rocket/examples/rocket_server.rs
+++ b/juniper_rocket/examples/rocket_server.rs
@@ -1,11 +1,11 @@
 #![feature(decl_macro, proc_macro_hygiene)]
 
-use rocket::response::content;
-use rocket::State;
+use rocket::{response::content, State};
 
-use juniper::tests::model::Database;
-use juniper::tests::schema::Query;
-use juniper::{EmptyMutation, RootNode};
+use juniper::{
+    tests::{model::Database, schema::Query},
+    EmptyMutation, RootNode,
+};
 
 type Schema = RootNode<'static, Query, EmptyMutation<Database>>;
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -39,27 +39,27 @@ Check the LICENSE file for details.
 #![doc(html_root_url = "https://docs.rs/juniper_rocket/0.2.0")]
 #![feature(decl_macro, proc_macro_hygiene)]
 
-use std::error::Error;
-use std::io::{Cursor, Read};
+use std::{
+    error::Error,
+    io::{Cursor, Read},
+};
 
-use rocket::data::{FromDataSimple, Outcome as FromDataOutcome};
-use rocket::http::{ContentType, RawStr, Status};
-use rocket::request::{FormItems, FromForm, FromFormValue};
-use rocket::response::{content, Responder, Response};
-use rocket::Data;
-use rocket::Outcome::{Failure, Forward, Success};
-use rocket::Request;
+use rocket::{
+    data::{FromDataSimple, Outcome as FromDataOutcome},
+    http::{ContentType, RawStr, Status},
+    request::{FormItems, FromForm, FromFormValue},
+    response::{content, Responder, Response},
+    Data,
+    Outcome::{Failure, Forward, Success},
+    Request,
+};
 
-use juniper::http;
-use juniper::InputValue;
+use juniper::{http, InputValue};
 
-use juniper::serde::Deserialize;
-use juniper::DefaultScalarValue;
-use juniper::FieldError;
-use juniper::GraphQLType;
-use juniper::RootNode;
-use juniper::ScalarRefValue;
-use juniper::ScalarValue;
+use juniper::{
+    serde::Deserialize, DefaultScalarValue, FieldError, GraphQLType, RootNode, ScalarRefValue,
+    ScalarValue,
+};
 
 #[derive(Debug, serde_derive::Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -479,18 +479,20 @@ mod fromform_tests {
 #[cfg(test)]
 mod tests {
 
-    use rocket::http::ContentType;
-    use rocket::local::{Client, LocalRequest};
-    use rocket::request::Form;
-    use rocket::Rocket;
-    use rocket::State;
-    use rocket::{self, get, post, routes};
+    use rocket::{
+        self, get,
+        http::ContentType,
+        local::{Client, LocalRequest},
+        post,
+        request::Form,
+        routes, Rocket, State,
+    };
 
-    use juniper::http::tests as http_tests;
-    use juniper::tests::model::Database;
-    use juniper::tests::schema::Query;
-    use juniper::EmptyMutation;
-    use juniper::RootNode;
+    use juniper::{
+        http::tests as http_tests,
+        tests::{model::Database, schema::Query},
+        EmptyMutation, RootNode,
+    };
 
     type Schema = RootNode<'static, Query, EmptyMutation<Database>>;
 

--- a/juniper_warp/examples/warp_server.rs
+++ b/juniper_warp/examples/warp_server.rs
@@ -2,9 +2,10 @@
 
 extern crate log;
 
-use juniper::tests::model::Database;
-use juniper::tests::schema::Query;
-use juniper::{EmptyMutation, RootNode};
+use juniper::{
+    tests::{model::Database, schema::Query},
+    EmptyMutation, RootNode,
+};
 use warp::{http::Response, Filter};
 
 type Schema = RootNode<'static, Query, EmptyMutation<Database>>;

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -308,8 +308,7 @@ fn playground_response(graphql_endpoint_url: &'static str) -> warp::http::Respon
 #[cfg(test)]
 mod tests {
     use super::*;
-    use warp::http;
-    use warp::test::request;
+    use warp::{http, test::request};
 
     #[test]
     fn graphiql_response_does_not_panic() {
@@ -390,9 +389,10 @@ mod tests {
 
     #[test]
     fn graphql_handler_works_json_post() {
-        use juniper::tests::model::Database;
-        use juniper::tests::schema::Query;
-        use juniper::{EmptyMutation, RootNode};
+        use juniper::{
+            tests::{model::Database, schema::Query},
+            EmptyMutation, RootNode,
+        };
 
         type Schema = juniper::RootNode<'static, Query, EmptyMutation<Database>>;
 
@@ -422,9 +422,10 @@ mod tests {
 
     #[test]
     fn batch_requests_work() {
-        use juniper::tests::model::Database;
-        use juniper::tests::schema::Query;
-        use juniper::{EmptyMutation, RootNode};
+        use juniper::{
+            tests::{model::Database, schema::Query},
+            EmptyMutation, RootNode,
+        };
 
         type Schema = juniper::RootNode<'static, Query, EmptyMutation<Database>>;
 
@@ -469,13 +470,12 @@ mod tests {
 #[cfg(test)]
 mod tests_http_harness {
     use super::*;
-    use juniper::http::tests::{run_http_test_suite, HTTPIntegration, TestResponse};
-    use juniper::tests::model::Database;
-    use juniper::tests::schema::Query;
-    use juniper::EmptyMutation;
-    use juniper::RootNode;
-    use warp;
-    use warp::Filter;
+    use juniper::{
+        http::tests::{run_http_test_suite, HTTPIntegration, TestResponse},
+        tests::{model::Database, schema::Query},
+        EmptyMutation, RootNode,
+    };
+    use warp::{self, Filter};
 
     type Schema = juniper::RootNode<'static, Query, EmptyMutation<Database>>;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true


### PR DESCRIPTION
style: Enable rustfmt merge_imports and format

This commit enables the rustfmt merge_imports setting
and formats the whole code base accordingly.

Note that the setting is not stable yet, but will be with Rust 1.38.

In the meantime, running fmt on stable will just leave the
changes alone so no problems should occur.