### PR TITLE
Update juniper_rocket for async.

### DIFF
--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -5,6 +5,8 @@ use crate::value::{Object, ScalarRefValue, ScalarValue, Value};
 use crate::executor::{ExecutionResult, Executor};
 use crate::parser::Spanning;
 
+use crate::BoxFuture;
+
 use super::base::{is_excluded, merge_key_into, Arguments, GraphQLType};
 
 pub trait GraphQLTypeAsync<S>: GraphQLType<S> + Send + Sync

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -17,7 +17,8 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.13.1" , default-features = false, path = "../juniper"}
 
-rocket = { version = "0.4.0" }
+futures-preview = { version = "0.3.0-alpha.18", features = ["compat"] }
+rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 
 [dev-dependencies.juniper]
 version = "0.13.1"

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -11,13 +11,16 @@ documentation = "https://docs.rs/juniper_rocket"
 repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
+[features]
+async = [ "juniper/async", "futures03" ]
+
 [dependencies]
 serde = { version = "1.0.2" }
 serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.13.1" , default-features = false, path = "../juniper"}
 
-futures-preview = { version = "0.3.0-alpha.18", features = ["compat"] }
+futures03 = { version = "0.3.0-alpha.18", optional = true, package = "futures-preview", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 
 [dev-dependencies.juniper]

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [features]
-async = [ "juniper/async", "futures03" ]
+async = [ "juniper/async" ]
 
 [dependencies]
 serde = { version = "1.0.2" }
@@ -20,7 +20,7 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.13.1" , default-features = false, path = "../juniper"}
 
-futures03 = { version = "0.3.0-alpha.18", optional = true, package = "futures-preview", features = ["compat"] }
+futures03 = { version = "0.3.0-alpha.18", package = "futures-preview", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 
 [dev-dependencies.juniper]


### PR DESCRIPTION
This updates juniper_rocket to support async Juniper & Rocket.  Async rocket is on a completely seperate branch just now, so had to pull that in.  I couldn't hide the futures-preview dependency behind a feature flag as Rocket hasn't put async behind a feature flag as far as I can see.