### PR TITLE
juniper_codegen: Drop regex & lazy_static dependencies

### DIFF
--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -18,8 +18,6 @@ proc-macro = true
 proc-macro2 = "1.0.1"
 syn = { version = "1.0.3", features = ["full", "extra-traits", "parsing"] }
 quote = "1.0.2"
-regex = { version = "1.3", default-features = false, features = ["std", "perf"] }
-lazy_static = "1.0.0"
 
 [dev-dependencies]
 juniper = { version = "0.13.1", path = "../juniper" }

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 proc-macro2 = "1.0.1"
 syn = { version = "1.0.3", features = ["full", "extra-traits", "parsing"] }
 quote = "1.0.2"
-regex = "1"
+regex = { version = "1.3", default-features = false, features = ["std", "perf"] }
 lazy_static = "1.0.0"
 
 [dev-dependencies]

--- a/juniper_codegen/src/util.rs
+++ b/juniper_codegen/src/util.rs
@@ -1,5 +1,4 @@
 use quote::quote;
-use regex::Regex;
 use std::collections::HashMap;
 use syn::{
     parse, parse_quote, punctuated::Punctuated, Attribute, Lit, Meta, MetaList, MetaNameValue,
@@ -279,10 +278,16 @@ pub(crate) fn to_upper_snake_case(s: &str) -> String {
 
 #[doc(hidden)]
 pub fn is_valid_name(field_name: &str) -> bool {
-    lazy_static::lazy_static! {
-        static ref GRAPHQL_NAME_SPEC: Regex = Regex::new("^[_A-Za-z][_0-9A-Za-z]*$").unwrap();
-    }
-    GRAPHQL_NAME_SPEC.is_match(field_name)
+    let mut chars = field_name.chars();
+
+    match chars.next() {
+        // first char can't be a digit
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => (),
+        // can't be an empty string or any other character
+        _ => return false,
+    };
+
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
https://www.reddit.com/r/rust/comments/cz7u0j/psa_regex_13_permits_disabling_unicodeperformance/

The regex dependency is used in a single place, and it only validates ascii characters:

https://github.com/graphql-rust/juniper/blob/a3caf126b03533ea9b75b64056152500d38ce148/juniper_codegen/src/util.rs#L283

As such, we can drop the unicode support for faster compile times.