### PR TITLE
Upgrade futures-preview and tokio crates

### DIFF
--- a/examples/warp_async/Cargo.toml
+++ b/examples/warp_async/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 log = "0.4.8"
 env_logger = "0.6.2"
 warp = "0.1.19"
-futures-preview = { version = "0.3.0-alpha.18", features = ["nightly", "async-await", "compat"] }
+futures-preview = { version = "0.3.0-alpha.19", features = ["async-await", "compat"] }
 reqwest = "0.9.19"
 
 juniper_codegen = { git = "https://github.com/graphql-rust/juniper", branch = "async-await", features = ["async"] }

--- a/examples/warp_async/src/main.rs
+++ b/examples/warp_async/src/main.rs
@@ -2,7 +2,7 @@
 //! This example demonstrates async/await usage with warp.
 //! NOTE: this uses tokio 0.1 , not the alpha tokio 0.2.
 
-#![feature(async_await, async_closure)]
+#![feature(async_closure)]
 
 use juniper::{EmptyMutation, RootNode, FieldError};
 use warp::{http::Response, Filter};

--- a/integration_tests/async_await/Cargo.toml
+++ b/integration_tests/async_await/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 juniper = { path = "../../juniper", features = ["async"] }
-futures-preview = "0.3.0-alpha.18"
-tokio = "0.2.0-alpha.2"
+futures-preview = "=0.3.0-alpha.19"
+tokio = "=0.2.0-alpha.6"

--- a/integration_tests/async_await/src/main.rs
+++ b/integration_tests/async_await/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_closure)]
 
 use juniper::{graphql_value, RootNode, Value};
 
@@ -38,7 +38,7 @@ impl User {
 
     async fn delayed() -> bool {
         let when = tokio::clock::now() + std::time::Duration::from_millis(100);
-        tokio::timer::Delay::new(when).await;
+        tokio::timer::delay(when).await;
         true
     }
 }
@@ -65,7 +65,7 @@ impl Query {
 
     async fn delayed() -> bool {
         let when = tokio::clock::now() + std::time::Duration::from_millis(100);
-        tokio::timer::Delay::new(when).await;
+        tokio::timer::delay(when).await;
         true
     }
 }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -45,9 +45,9 @@ serde_json = { version="1.0.2", optional = true }
 url = { version = "1.5.1", optional = true }
 uuid = { version = "0.7", optional = true }
 
-futures-preview = { version = "0.3.0-alpha.18", optional = true, features = ["nightly", "async-await"] }
+futures-preview = { version = "=0.3.0-alpha.19", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"
 serde_json = { version = "1.0.2" }
-tokio = "0.2.0-alpha.2"
+tokio = "=0.2.0-alpha.6"

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -91,7 +91,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 
 #![doc(html_root_url = "https://docs.rs/juniper/0.13.1")]
 #![warn(missing_docs)]
-#![cfg_attr(feature = "async", feature(async_await, async_closure))]
+#![cfg_attr(feature = "async", feature(async_closure))]
 
 #[doc(hidden)]
 pub extern crate serde;

--- a/juniper_benchmarks/Cargo.toml
+++ b/juniper_benchmarks/Cargo.toml
@@ -12,8 +12,8 @@ harness = false
 
 [dependencies]
 juniper = { path = "../juniper", features = ["async"] }
-futures-preview = "0.3.0-alpha.18"
+futures-preview = "=0.3.0-alpha.19"
 
 [dev-dependencies]
 criterion = "0.2.11"
-tokio = "0.2.0-alpha.2"
+tokio = "=0.2.0-alpha.6"

--- a/juniper_benchmarks/src/lib.rs
+++ b/juniper_benchmarks/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_closure)]
 
 use juniper::{
     object, DefaultScalarValue, ExecutionError, FieldError, GraphQLEnum, Value, Variables,

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -20,8 +20,9 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.13.1" , default-features = false, path = "../juniper"}
 
-futures03 = { version = "0.3.0-alpha.18", package = "futures-preview", features = ["compat"] }
+futures03 = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
+tokio = "=0.2.0-alpha.6"
 
 [dev-dependencies.juniper]
 version = "0.13.1"

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -38,18 +38,15 @@ Check the LICENSE file for details.
 
 #![doc(html_root_url = "https://docs.rs/juniper_rocket/0.2.0")]
 #![feature(decl_macro, proc_macro_hygiene)]
-#![cfg_attr(feature = "async", feature(async_await, async_closure))]
+#![cfg_attr(feature = "async", feature(async_closure))]
 
-use std::{
-    error::Error,
-    io::{Cursor, Read},
-};
+use std::{error::Error, io::Cursor};
 
 use rocket::{
-    data::{FromDataSimple, Outcome as FromDataOutcome},
+    data::{FromDataFuture, FromDataSimple},
     http::{ContentType, RawStr, Status},
     request::{FormItems, FromForm, FromFormValue},
-    response::{content, Responder, Response},
+    response::{content, Responder, Response, ResultFuture},
     Data,
     Outcome::{Failure, Forward, Success},
     Request,
@@ -400,8 +397,8 @@ where
     type Error = String;
 
     fn from_data(request: &Request, data: Data) -> FromDataFuture<'static, Self, Self::Error> {
-        use futures03::io::AsyncReadExt;
-        use rocket::AsyncReadExt as _;
+        use tokio::io::AsyncReadExt as _;
+
         if !request.content_type().map_or(false, |ct| ct.is_json()) {
             return Box::pin(async move { Forward(data) });
         }

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.1.23"
 serde = "1.0.75"
 tokio-threadpool = "0.1.7"
 
-futures03 = { version = "0.3.0-alpha.18", optional = true, package = "futures-preview", features = ["compat"] }
+futures03 = { version = "=0.3.0-alpha.19", optional = true, package = "futures-preview", features = ["compat"] }
 
 [dev-dependencies]
 juniper = { version = "0.13.1", path = "../juniper", features = ["expose-test-schema", "serde_json"] }

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -39,7 +39,7 @@ Check the LICENSE file for details.
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![doc(html_root_url = "https://docs.rs/juniper_warp/0.2.0")]
-#![cfg_attr(feature = "async", feature(async_await, async_closure))]
+#![cfg_attr(feature = "async", feature(async_closure))]
 
 use futures::{future::poll_fn, Future};
 use serde::Deserialize;


### PR DESCRIPTION
This PR upgrades `futures-preview` and `tokio` crates to its latest alpha versions. And removes using `#![feature(async_await)]`.