### PR TITLE
Use futures 0.3.1 in async-await

### DIFF
--- a/examples/warp_async/Cargo.toml
+++ b/examples/warp_async/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 log = "0.4.8"
 env_logger = "0.6.2"
 warp = "0.1.19"
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await", "compat"] }
+futures = { version = "0.3.1", features = ["compat"] }
 reqwest = "0.9.19"
 
 juniper_codegen = { git = "https://github.com/graphql-rust/juniper", branch = "async-await", features = ["async"] }

--- a/integration_tests/async_await/Cargo.toml
+++ b/integration_tests/async_await/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 juniper = { path = "../../juniper", features = ["async"] }
-futures-preview = "=0.3.0-alpha.19"
+futures = "=0.3.1"
 tokio = "=0.2.0-alpha.6"

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 path = "benches/bench.rs"
 
 [features]
-async = ["juniper_codegen/async", "futures-preview"]
+async = ["juniper_codegen/async", "futures"]
 expose-test-schema = []
 default = [
     "chrono",
@@ -38,7 +38,7 @@ juniper_codegen = { version = "0.14.1", path = "../juniper_codegen"  }
 async-trait = "0.1.16"
 chrono = { version = "0.4.0", optional = true }
 fnv = "1.0.3"
-futures-preview = { version = "=0.3.0-alpha.19", optional = true }
+futures = { version = "=0.3.1", optional = true }
 indexmap = { version = "1.0.0", features = ["serde-1"] }
 serde = { version = "1.0.8" }
 serde_derive = { version = "1.0.2" }

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -428,7 +428,7 @@ macro_rules! graphql_scalar {
                     info: &'a Self::TypeInfo,
                     selection_set: Option<&'a [$crate::Selection<'a, $crate::__juniper_insert_generic!($($scalar)+)>]>,
                     executor: &'a $crate::Executor<'a, Self::Context, $crate::__juniper_insert_generic!($($scalar)+)>,
-                ) -> futures::future::BoxFuture<'async_trait, $crate::Value<$crate::__juniper_insert_generic!($($scalar)+)>>
+                ) -> $crate::BoxFuture<'async_trait, $crate::Value<$crate::__juniper_insert_generic!($($scalar)+)>>
                 where
                     'a: 'async_trait,
                     Self: 'async_trait,

--- a/juniper_benchmarks/Cargo.toml
+++ b/juniper_benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 
 [dependencies]
 juniper = { path = "../juniper", features = ["async"] }
-futures-preview = "=0.3.0-alpha.19"
+futures = "=0.3.1"
 
 [dev-dependencies]
 criterion = "0.2.11"

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -218,7 +218,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
                 info: &'a Self::TypeInfo,
                 selection_set: Option<&'a [#juniper_path::Selection<__S>]>,
                 executor: &'a #juniper_path::Executor<Self::Context, __S>,
-            ) -> futures::future::BoxFuture<'async_trait, #juniper_path::Value<__S>>
+            ) -> #juniper_path::BoxFuture<'async_trait, #juniper_path::Value<__S>>
              where
                 'a: 'async_trait,
                 Self: 'async_trait

--- a/juniper_codegen/src/util.rs
+++ b/juniper_codegen/src/util.rs
@@ -938,7 +938,7 @@ impl GraphQLTypeDefiniton {
                         field: &'b str,
                         args: &'b #juniper_crate_name::Arguments<#scalar>,
                         executor: &'b #juniper_crate_name::Executor<Self::Context, #scalar>,
-                    ) -> futures::future::BoxFuture<'async_trait, #juniper_crate_name::ExecutionResult<#scalar>>
+                    ) -> #juniper_crate_name::BoxFuture<'async_trait, #juniper_crate_name::ExecutionResult<#scalar>>
                         where
                         #scalar: Send + Sync,
                         'b: 'async_trait,

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.1", default-features = false, path = "../juniper"}
 
-futures03 = { version = "=0.3.0-alpha.19", package = "futures-preview", features = ["compat"] }
+futures = { version = "=0.3.1", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 tokio = "=0.2.0-alpha.6"
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -62,7 +62,7 @@ use juniper::{
 use juniper::GraphQLTypeAsync;
 
 #[cfg(feature = "async")]
-use futures03::future::{FutureExt, TryFutureExt};
+use futures::future::{FutureExt, TryFutureExt};
 
 #[derive(Debug, serde_derive::Deserialize, PartialEq)]
 #[serde(untagged)]
@@ -135,7 +135,7 @@ where
                     .map(|request| request.execute_async(root_node, context))
                     .collect::<Vec<_>>();
 
-                GraphQLBatchResponse::Batch(futures03::future::join_all(futures).await)
+                GraphQLBatchResponse::Batch(futures::future::join_all(futures).await)
             }
         }
     }

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -17,11 +17,12 @@ juniper = { version = "0.14.1", path = "../juniper", default-features = false  }
 serde_json = "1.0.24"
 serde_derive = "1.0.75"
 failure = "0.1.2"
-futures = "0.1.23"
+# TODO: rebase juniper_warp to futures 3 once warp supports it
+futures = "0.1.29"
 serde = "1.0.75"
 tokio-threadpool = "0.1.7"
 
-futures03 = { version = "=0.3.0-alpha.19", optional = true, package = "futures-preview", features = ["compat"] }
+futures03 = { version = "=0.3.1", optional = true, package = "futures", features = ["compat"] }
 
 [dev-dependencies]
 juniper = { version = "0.14.1", path = "../juniper", features = ["expose-test-schema", "serde_json"] }


### PR DESCRIPTION
Rebase `async-await` onto futures 0.3.1:

- Use futures 0.3.1 in all packages except `juniper_warp` (warp supports futures 0.3 only on git)
- Replace all `futures::future::BoxFuture` with `juniper::BoxFuture` in macros