### PR TITLE
Validate variables of the executed operation only

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+- Fix incorrect validation with non-executed operations [#455](https://github.com/graphql-rust/juniper/issues/455)
 - Correctly handle raw identifiers in field and argument names.
 
 # [[0.14.1] 2019-10-24](https://github.com/graphql-rust/juniper/releases/tag/juniper-0.14.1)

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -4,8 +4,8 @@ use fnv::FnvHashMap;
 
 use crate::{
     ast::{
-        Definition, Document, Fragment, FromInputValue, InputValue, OperationType, Selection,
-        ToInputValue, Type,
+        Definition, Document, Fragment, FromInputValue, InputValue, Operation, OperationType,
+        Selection, ToInputValue, Type,
     },
     parser::SourcePosition,
     value::Value,
@@ -31,6 +31,7 @@ pub use self::look_ahead::{
     Applies, ChildSelection, ConcreteLookAheadSelection, LookAheadArgument, LookAheadMethods,
     LookAheadSelection, LookAheadValue,
 };
+use crate::parser::Spanning;
 
 /// A type registry used to build schemas
 ///
@@ -609,9 +610,9 @@ impl<S> ExecutionError<S> {
     }
 }
 
-pub fn execute_validated_query<'a, QueryT, MutationT, CtxT, S>(
-    document: Document<S>,
-    operation_name: Option<&str>,
+pub fn execute_validated_query<'a, 'b, QueryT, MutationT, CtxT, S>(
+    document: &'b Document<S>,
+    operation: &'b Spanning<Operation<S>>,
     root_node: &RootNode<QueryT, MutationT, S>,
     variables: &Variables<S>,
     context: &CtxT,
@@ -620,39 +621,17 @@ where
     S: ScalarValue,
     QueryT: GraphQLType<S, Context = CtxT>,
     MutationT: GraphQLType<S, Context = CtxT>,
-    for<'b> &'b S: ScalarRefValue<'b>,
+    for<'c> &'c S: ScalarRefValue<'c>,
 {
     let mut fragments = vec![];
-    let mut operation = None;
-
-    for def in document {
+    for def in document.iter() {
         match def {
-            Definition::Operation(op) => {
-                if operation_name.is_none() && operation.is_some() {
-                    return Err(GraphQLError::MultipleOperationsProvided);
-                }
-
-                let move_op = operation_name.is_none()
-                    || op.item.name.as_ref().map(|s| s.item) == operation_name;
-
-                if move_op {
-                    operation = Some(op);
-                }
-            }
             Definition::Fragment(f) => fragments.push(f),
+            _ => (),
         };
     }
 
-    let op = match operation {
-        Some(op) => op,
-        None => return Err(GraphQLError::UnknownOperationName),
-    };
-
-    if op.item.operation_type == OperationType::Subscription {
-        return Err(GraphQLError::IsSubscription);
-    }
-
-    let default_variable_values = op.item.variable_definitions.map(|defs| {
+    let default_variable_values = operation.item.variable_definitions.as_ref().map(|defs| {
         defs.item
             .items
             .iter()
@@ -681,7 +660,7 @@ where
             final_vars = &all_vars;
         }
 
-        let root_type = match op.item.operation_type {
+        let root_type = match operation.item.operation_type {
             OperationType::Query => root_node.schema.query_type(),
             OperationType::Mutation => root_node
                 .schema
@@ -696,16 +675,16 @@ where
                 .map(|f| (f.item.name.item, &f.item))
                 .collect(),
             variables: final_vars,
-            current_selection_set: Some(&op.item.selection_set[..]),
+            current_selection_set: Some(&operation.item.selection_set[..]),
             parent_selection_set: None,
             current_type: root_type,
             schema: &root_node.schema,
             context,
             errors: &errors,
-            field_path: FieldPath::Root(op.start),
+            field_path: FieldPath::Root(operation.start),
         };
 
-        value = match op.item.operation_type {
+        value = match operation.item.operation_type {
             OperationType::Query => executor.resolve_into_value(&root_node.query_info, &root_node),
             OperationType::Mutation => {
                 executor.resolve_into_value(&root_node.mutation_info, &root_node.mutation_type)
@@ -718,6 +697,41 @@ where
     errors.sort();
 
     Ok((value, errors))
+}
+
+pub fn get_operation<'a, 'b, S>(
+    document: &'b Document<'b, S>,
+    operation_name: Option<&str>,
+) -> Result<&'b Spanning<Operation<'b, S>>, GraphQLError<'a>>
+where
+    S: ScalarValue,
+{
+    let mut operation = None;
+    for def in document {
+        match def {
+            Definition::Operation(op) => {
+                if operation_name.is_none() && operation.is_some() {
+                    return Err(GraphQLError::MultipleOperationsProvided);
+                }
+
+                let move_op = operation_name.is_none()
+                    || op.item.name.as_ref().map(|s| s.item) == operation_name;
+
+                if move_op {
+                    operation = Some(op);
+                }
+            }
+            _ => (),
+        };
+    }
+    let op = match operation {
+        Some(op) => op,
+        None => return Err(GraphQLError::UnknownOperationName),
+    };
+    if op.item.operation_type == OperationType::Subscription {
+        return Err(GraphQLError::IsSubscription);
+    }
+    Ok(op)
 }
 
 impl<'r, S> Registry<'r, S>

--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -1067,7 +1067,7 @@ mod named_operations {
 
     #[crate::object_internal]
     impl Schema {
-        fn a() -> &str {
+        fn a(p: Option<String>) -> &str {
             "b"
         }
     }
@@ -1112,7 +1112,8 @@ mod named_operations {
     #[test]
     fn uses_named_operation_if_name_provided() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
-        let doc = r"query Example { first: a } query OtherExample { second: a }";
+        let doc =
+            r"query Example($p: String!) { first: a(p: $p) } query OtherExample { second: a }";
 
         let vars = vec![].into_iter().collect();
 

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -807,50 +807,6 @@ fn allow_non_null_lists_of_non_null_to_contain_values() {
 }
 
 #[test]
-fn does_not_allow_invalid_types_to_be_used_as_values() {
-    let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
-
-    let query = r#"query q($input: TestType!) { fieldWithObjectInput(input: $input) }"#;
-    let vars = vec![(
-        "value".to_owned(),
-        InputValue::list(vec![InputValue::scalar("A"), InputValue::scalar("B")]),
-    )]
-    .into_iter()
-    .collect();
-
-    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
-
-    assert_eq!(error, ValidationError(vec![
-        RuleError::new(
-            r#"Variable "$input" expected value of type "TestType!" which cannot be used as an input type."#,
-            &[SourcePosition::new(8, 0, 8)],
-        ),
-    ]));
-}
-
-#[test]
-fn does_not_allow_unknown_types_to_be_used_as_values() {
-    let schema = RootNode::new(TestType, EmptyMutation::<()>::new());
-
-    let query = r#"query q($input: UnknownType!) { fieldWithObjectInput(input: $input) }"#;
-    let vars = vec![(
-        "value".to_owned(),
-        InputValue::list(vec![InputValue::scalar("A"), InputValue::scalar("B")]),
-    )]
-    .into_iter()
-    .collect();
-
-    let error = crate::execute(query, None, &schema, &vars, &()).unwrap_err();
-
-    assert_eq!(error, ValidationError(vec![
-        RuleError::new(
-            r#"Variable "$input" expected value of type "UnknownType!" which cannot be used as an input type."#,
-            &[SourcePosition::new(8, 0, 8)],
-        ),
-    ]));
-}
-
-#[test]
 fn default_argument_when_not_provided() {
     run_query(r#"{ fieldWithDefaultArgumentValue }"#, |result| {
         assert_eq!(

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -66,8 +66,8 @@ fn validate_var_defs<S>(
                     errors.append(&mut unify_value(name.item, &name.start, v, &ct, schema, Path::Root));
                 }
             }
-            _ => panic!(
-                r#"Variable "${}" expected value of type "{}" which cannot be used as an input type."#,
+            _ => unreachable!(
+                r#"Variable "${}" has invalid input type "{}" after document validation."#,
                 name.item, def.var_type.item,
             ),
         }

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -57,13 +57,19 @@ fn validate_var_defs<S>(
                     errors.push(RuleError::new(
                         &format!(
                             r#"Variable "${}" of required type "{}" was not provided."#,
-                            name.item,
-                            def.var_type.item,
+                            name.item, def.var_type.item,
                         ),
                         &[name.start],
                     ));
                 } else if let Some(v) = values.get(name.item) {
-                    errors.append(&mut unify_value(name.item, &name.start, v, &ct, schema, Path::Root));
+                    errors.append(&mut unify_value(
+                        name.item,
+                        &name.start,
+                        v,
+                        &ct,
+                        schema,
+                        Path::Root,
+                    ));
                 }
             }
             _ => unreachable!(


### PR DESCRIPTION
Fix for #455 

This PR changes a larger number of files than expected. Here is the rationale.

* We want to validate input variables only for the operation selected for execution. The code that extracts the selected operation was already present in `execute_validated_query`. However, we need the result in `validate_input_values` which is called before `execute_validated_query`.
* So, I extracted the code to a `get_operation` method (the naming mimics the GraphQL spec, see https://graphql.github.io/graphql-spec/June2018/#GetOperation() ), meant to be called directly from `execute`. The resulting Operation can be then passed directly to `validate_input_values` instead of the whole document.
* However, the `get_operation` code originally runs after the validation of the document, but `validate_input_values` is run before this validation. Calling `get_operation` before the validation of the document is dangerous, as it could impact the error reporting for invalid documents (say, multiple operations defined with the same name). I thought that it made much more sense to validate the document first, and _then_ the input variables, so I made this change.
* After this change, I got two failing unit tests. However, I realized that _type_ of the input variables was validated twice (once as part of the document validation, and again during input values validation), and these failing tests were actually depending on which of the redundant validations is applied first.
* After checking that the validation of the _type_ of input variables as part of the document validation is already unit-tested, I decided to remove the tests `does_not_allow_invalid_types_to_be_used_as_values` and `does_not_allow_unknown_types_to_be_used_as_values`.


