### PR TITLE
Loosen constraints on uuid version.

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -42,7 +42,7 @@ serde_derive = { version = "1.0.2" }
 chrono = { version = "0.4.0", optional = true }
 serde_json = { version="1.0.2", optional = true }
 url = { version = "2", optional = true }
-uuid = { version = "0.7", optional = true }
+uuid = { version = ">= 0.7, < 0.8", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"


### PR DESCRIPTION
The `uuid` maintainers have started releasing in the `0.8` version train.  I've relaxed the version requirements on `juniper`'s dependencies to allow juniper users to specify a different version in their `Cargo.toml` and still have the integration work.