### PR TITLE
docs(quickstart): Fix juniper version so the examples work

### DIFF
--- a/docs/book/content/quickstart.md
+++ b/docs/book/content/quickstart.md
@@ -8,7 +8,7 @@ This page will give you a short introduction to the concepts in Juniper.
 
 ```toml
 [dependencies]
-juniper = "0.11"
+juniper = "0.14"
 ```
 
 ## Schema example


### PR DESCRIPTION
Got the error

```
error[E0433]: failed to resolve: could not find `object` in `juniper`
  --> server/src/main.rs:20:12
   |
20 | #[juniper::object(
   |            ^^^^^^ could not find `object` in `juniper`
```

due to the wrong version mentioned in the quickstart docs. This should fix it!