### PR TITLE
Implement GraphQLTypeAsync for Arc

### DIFF
--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -216,6 +216,25 @@ where
     }
 }
 
+#[cfg(feature = "async")]
+impl<'e, S, T> crate::GraphQLTypeAsync<S> for std::sync::Arc<T>
+where
+    S: ScalarValue + Send + Sync,
+    T: crate::GraphQLTypeAsync<S>,
+    <T as crate::types::base::GraphQLType<S>>::TypeInfo: Sync + Send,
+    <T as crate::types::base::GraphQLType<S>>::Context: Sync + Send,
+{
+    fn resolve_async<'a>(
+        &'a self,
+        info: &'a Self::TypeInfo,
+        selection_set: Option<&'a [Selection<S>]>,
+        executor: &'a Executor<Self::Context, S>,
+    ) -> crate::BoxFuture<'a, crate::ExecutionResult<S>> {
+        use futures::future;
+        (**self).resolve_async(info, selection_set, executor)
+    }
+}
+
 impl<T, S> ToInputValue<S> for Arc<T>
 where
     S: Debug,

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -210,26 +210,6 @@ where
     }
 }
 
-#[cfg(feature = "async")]
-impl<'e, S, T> crate::GraphQLTypeAsync<S> for std::sync::Arc<T>
-where
-    S: ScalarValue + Send + Sync,
-    T: crate::GraphQLTypeAsync<S>,
-    <T as crate::types::base::GraphQLType<S>>::TypeInfo: Sync + Send,
-    <T as crate::types::base::GraphQLType<S>>::Context: Sync + Send
-{
-    fn resolve_async<'a>(
-        &'a self,
-        info: &'a Self::TypeInfo,
-        selection_set: Option<&'a [Selection<S>]>,
-        executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, crate::ExecutionResult<S>> {
-        use futures::future;
-        (**self).resolve_async(info, selection_set, executor)
-    }
-}
-
-
 impl<'a, S> ToInputValue<S> for &'a str
 where
     S: ScalarValue,

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -210,6 +210,26 @@ where
     }
 }
 
+#[cfg(feature = "async")]
+impl<'e, S, T> crate::GraphQLTypeAsync<S> for std::sync::Arc<T>
+where
+    S: ScalarValue + Send + Sync,
+    T: crate::GraphQLTypeAsync<S>,
+    <T as crate::types::base::GraphQLType<S>>::TypeInfo: Sync + Send,
+    <T as crate::types::base::GraphQLType<S>>::Context: Sync + Send
+{
+    fn resolve_async<'a>(
+        &'a self,
+        info: &'a Self::TypeInfo,
+        selection_set: Option<&'a [Selection<S>]>,
+        executor: &'a Executor<Self::Context, S>,
+    ) -> crate::BoxFuture<'a, crate::ExecutionResult<S>> {
+        use futures::future;
+        (**self).resolve_async(info, selection_set, executor)
+    }
+}
+
+
 impl<'a, S> ToInputValue<S> for &'a str
 where
     S: ScalarValue,


### PR DESCRIPTION
I'm building a GraphQL API using Juniper that proxies another GraphQL
API.  It does a large fetch upfront from the underlying GraphQL API,
transforms it into a different format and then implements some
resolvers that do some further filtering.

One of these resolvers ends up looking like:

```
async fn items(&self, ...) -> Vec<Item> {
    self.items.iter().filter(...).collect()
}
```

This causes us problems as we're returning owned Item's and Item is a
large nested structure that would be expensive to clone.

Our current work around was to put Item into an Arc, as Arc is
comparatively cheap to clone.  So our method becomes:

```
async fn items(&self, ...) -> Vec<Arc<Item>> {
    self.items.iter().filter(...).map(Arc::clone).collect()
}
```

However to support this we needed Arc to implement GraphQLTypeAsync.
This commit adds that support to juniper, by forwarding to the
GraphQLTypeAsync implementation for the contained type.

It's possible that we could have acheived something similar by adding
some lifetimes to our resolver and returning a reference, but using an
Arc was easier for us in this case.  I'm not sure if there's any reason
why this would be a bad addition to Juniper overall?