### PR TITLE
Small fix/typo: unused variable error message

### DIFF
--- a/juniper/src/validation/rules/no_unused_variables.rs
+++ b/juniper/src/validation/rules/no_unused_variables.rs
@@ -143,11 +143,11 @@ where
 fn error_message(var_name: &str, op_name: Option<&str>) -> String {
     if let Some(op_name) = op_name {
         format!(
-            r#"Variable "${}" is not defined by operation "{}""#,
+            r#"Variable "${}" is not used by operation "{}""#,
             var_name, op_name
         )
     } else {
-        format!(r#"Variable "${}" is not defined"#, var_name)
+        format!(r#"Variable "${}" is not used"#, var_name)
     }
 }
 


### PR DESCRIPTION
Was copied from undefined variable error message.