### PR TITLE
Add note on complex fields impl block in doc

### DIFF
--- a/docs/book/content/types/objects/complex_fields.md
+++ b/docs/book/content/types/objects/complex_fields.md
@@ -25,6 +25,14 @@ impl Person {
     }
 }
 
+// Note that this syntax generates an implementation of the GraphQLType trait,
+// the base impl of your struct can still be written like usual:
+impl Person {
+    pub fn hidden_from_graphql(&self) {
+        // [...]
+    }
+}
+
 # fn main() { }
 ```
 


### PR DESCRIPTION
Adding a small note in doc to avoid confusion about `impl` block for complex fields.
See #482