### PR TITLE
Add example of how to construct null in graphql_value

### DIFF
--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -250,6 +250,8 @@ where
 ///
 /// # fn main() {
 /// # let _: V =
+/// graphql_value!(None);
+/// # let _: V =
 /// graphql_value!(1234);
 /// # let _: V =
 /// graphql_value!("test");


### PR DESCRIPTION
To find out how to construct a `null` value in `graphql_value` you have to look at the implementation of the macro. With the hope to help others find out quicker how it's done this PR adds another line to the doc of the function