### PR TITLE
Fix scalar and some tests under async

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/derive_enum.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_enum.rs
@@ -4,6 +4,9 @@ use fnv::FnvHashMap;
 #[cfg(test)]
 use juniper::{self, DefaultScalarValue, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
+#[cfg(feature = "async")]
+use futures;
+
 #[derive(juniper::GraphQLEnum, Debug, PartialEq)]
 #[graphql(name = "Some", description = "enum descr")]
 enum SomeEnum {

--- a/integration_tests/juniper_tests/src/codegen/derive_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object.rs
@@ -7,6 +7,9 @@ use juniper::{DefaultScalarValue, GraphQLObject};
 #[cfg(test)]
 use juniper::{self, execute, EmptyMutation, GraphQLType, RootNode, Value, Variables};
 
+#[cfg(feature = "async")]
+use futures;
+
 #[derive(GraphQLObject, Debug, PartialEq)]
 #[graphql(
     name = "MyObj",

--- a/integration_tests/juniper_tests/src/codegen/derive_object_with_raw_idents.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_object_with_raw_idents.rs
@@ -9,6 +9,9 @@ use juniper::{
     GraphQLType, RootNode, Value, Variables,
 };
 
+#[cfg(feature = "async")]
+use futures;
+
 pub struct Query;
 
 #[juniper::graphql_object]

--- a/integration_tests/juniper_tests/src/codegen/impl_union.rs
+++ b/integration_tests/juniper_tests/src/codegen/impl_union.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "async")]
+use futures;
+
 // Trait.
 
 #[derive(juniper::GraphQLObject)]

--- a/integration_tests/juniper_tests/src/codegen/scalar_value_transparent.rs
+++ b/integration_tests/juniper_tests/src/codegen/scalar_value_transparent.rs
@@ -1,4 +1,6 @@
 use fnv::FnvHashMap;
+#[cfg(feature = "async")]
+use futures;
 use juniper::{DefaultScalarValue, FromInputValue, GraphQLType, InputValue, ToInputValue};
 
 #[derive(juniper::GraphQLScalarValue, PartialEq, Eq, Debug)]

--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -1,5 +1,8 @@
 extern crate serde_json;
 
+#[cfg(feature = "async")]
+use futures;
+
 #[cfg(test)]
 use juniper::parser::Spanning;
 #[cfg(test)]

--- a/integration_tests/juniper_tests/src/issue_371.rs
+++ b/integration_tests/juniper_tests/src/issue_371.rs
@@ -1,6 +1,9 @@
 // Original author of this test is <https://github.com/davidpdrsn>.
 use juniper::*;
 
+#[cfg(feature = "async")]
+use futures;
+
 pub struct Context;
 
 impl juniper::Context for Context {}

--- a/integration_tests/juniper_tests/src/issue_398.rs
+++ b/integration_tests/juniper_tests/src/issue_398.rs
@@ -1,6 +1,9 @@
 // Original author of this test is <https://github.com/davidpdrsn>.
 use juniper::*;
 
+#[cfg(feature = "async")]
+use futures;
+
 struct Query;
 
 #[juniper::graphql_object]

--- a/juniper/src/macros/scalar.rs
+++ b/juniper/src/macros/scalar.rs
@@ -409,8 +409,6 @@ macro_rules! graphql_scalar {
             }
         );
 
-
-        #[cfg(feature = "async")]
         $crate::__juniper_impl_trait!(
             impl <$($scalar)+> GraphQLTypeAsync for $name
                 where (

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "async")]
+use futures;
 use serde_derive::{Deserialize, Serialize};
 use std::{char, convert::From, marker::PhantomData, ops::Deref, u32};
 


### PR DESCRIPTION
There is still some weirdness going on. Running async and
non-async tests in `integration_tests/*` works, but running it
from `integration_tests` does not.

Possibly fixes https://github.com/graphql-rust/juniper/issues/506.