### PR TITLE
Upgrade uuid to 0.8 version

### DIFF
--- a/docs/book/tests/Cargo.toml
+++ b/docs/book/tests/Cargo.toml
@@ -15,7 +15,7 @@ mount = "0.4.0"
 
 skeptic = "0.13"
 serde_json = "1.0.39"
-uuid = "0.7.4"
+uuid = "0.8"
 
 [build-dependencies]
 skeptic = "0.13"

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.8" }
 serde_derive = { version = "1.0.2" }
 serde_json = { version="1.0.2", optional = true }
 url = { version = "2", optional = true }
-uuid = { version = ">= 0.7, < 0.8", optional = true }
+uuid = { version = "0.8", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"


### PR DESCRIPTION
Fixes #494

This PR upgrades `uuid` to `0.8` version.