### PR TITLE
Use caret requirement for specifying 'futures' crate version

### DIFF
--- a/docs/book/tests/Cargo.toml
+++ b/docs/book/tests/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [dependencies]
 juniper = { path = "../../../juniper", features = ["async"] }
 juniper_iron = { path = "../../../juniper_iron" }
-futures = "=0.3.1"
+futures = "0.3.1"
 
 iron = "0.5.0"
 mount = "0.4.0"

--- a/integration_tests/async_await/Cargo.toml
+++ b/integration_tests/async_await/Cargo.toml
@@ -9,5 +9,5 @@ async = []
 
 [dependencies]
 juniper = { path = "../../juniper", features = ["async"] }
-futures = "=0.3.1"
+futures = "0.3.1"
 tokio = { version = "0.2", features = ["rt-core", "time", "macros"] }

--- a/integration_tests/juniper_tests/Cargo.toml
+++ b/integration_tests/juniper_tests/Cargo.toml
@@ -9,7 +9,7 @@ async = ["juniper/async", "futures"]
 
 [dependencies]
 juniper = { path = "../../juniper" }
-futures = { version = "=0.3.1", optional = true }
+futures = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -37,7 +37,7 @@ juniper_codegen = { version = "0.14.2", path = "../juniper_codegen"  }
 
 chrono = { version = "0.4.0", optional = true }
 fnv = "1.0.3"
-futures = { version = "=0.3.1", optional = true }
+futures = { version = "0.3.1", optional = true }
 indexmap = { version = "1.0.0", features = ["serde-1"] }
 serde = { version = "1.0.8" }
 serde_derive = { version = "1.0.2" }

--- a/juniper_benchmarks/Cargo.toml
+++ b/juniper_benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ async = []
 
 [dependencies]
 juniper = { path = "../juniper", features = ["async"] }
-futures =  "=0.3.1"
+futures =  "0.3.1"
 
 [dev-dependencies]
 criterion = "0.2.11"

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro-error = "0.3.4"
 
 [dev-dependencies]
 juniper = { version = "0.14.2", path = "../juniper", features = ["async"] }
-futures = { version = "=0.3.1" }
+futures = { version = "0.3.1" }
 
 [badges]
 travis-ci = { repository = "graphql-rust/juniper" }

--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.1", default-features = false, path = "../juniper"}
 
-futures = { version = "=0.3.1", features = ["compat"] }
+futures = { version = "0.3.1", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
 tokio = "0.2"
 

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.1.29"
 serde = "1.0.75"
 tokio-threadpool = "0.1.7"
 
-futures03 = { version = "=0.3.1", optional = true, package = "futures", features = ["compat"] }
+futures03 = { version = "0.3.1", optional = true, package = "futures", features = ["compat"] }
 
 [dev-dependencies]
 juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }


### PR DESCRIPTION
This PR specifies `futures` dependency crate version as [carret requirement](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements) (`0.3.1`) instead of fixed version (`=0.3.1`) to allow downstream crates naturally upgrade to new `futures` crate version as the want and accordingly to semver.