### PR TITLE
Rocket / Skip Default Features

### DIFF
--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Compatibility with the latest `juniper`.
+- Rocket integration does not require default features.
 
 # [[0.5.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_rocket-0.5.2)
 

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1.0.2" }
 serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.2", default-features = false, path = "../juniper"}
 
-rocket = { version = "0.4.0" }
+rocket = { version = "0.4.2", default-features = false }
 
 [dev-dependencies.juniper]
 version = "0.14.2"

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -216,7 +216,7 @@ impl GraphQLResponse {
     ///     request: Form<juniper_rocket::GraphQLRequest>,
     ///     schema: State<Schema>,
     /// ) -> juniper_rocket::GraphQLResponse {
-    ///     if cookies.get_private("user_id").is_none() {
+    ///     if cookies.get("user_id").is_none() {
     ///         let err = FieldError::new("User is not logged in", Value::null());
     ///         return juniper_rocket::GraphQLResponse::error(err);
     ///     }

--- a/juniper_rocket_async/CHANGELOG.md
+++ b/juniper_rocket_async/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Compatibility with the latest `juniper`.
+- Rocket integration does not require default features.
 
 # [[0.5.1] 2019-10-24](https://github.com/graphql-rust/juniper/releases/tag/juniper_rocket-0.5.1)
 

--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -21,7 +21,7 @@ serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.1", default-features = false, path = "../juniper"}
 
 futures = { version = "0.3.1", features = ["compat"] }
-rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async" }
+rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async", default-features = false }
 tokio = "0.2"
 
 [dev-dependencies.juniper]

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -54,8 +54,7 @@ use rocket::{
 use juniper::{http, InputValue};
 
 use juniper::{
-    serde::Deserialize, DefaultScalarValue, FieldError, GraphQLType, RootNode, 
-    ScalarValue,
+    serde::Deserialize, DefaultScalarValue, FieldError, GraphQLType, RootNode, ScalarValue,
 };
 
 #[cfg(feature = "async")]


### PR DESCRIPTION
Rocket integration does not use any of the `default-features` on Rocket, but does not specify `default-features = false`.

This prevents users from using crates that depend on newer version of `ring` library than that which `private-cookies` crate of `Rocket` uses.