### PR TITLE
feat(juniper_codegen): add conversions for enum variants to strings

### DIFF
--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -147,6 +147,7 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
     let mut resolves = TokenStream::new();
     let mut from_inputs = TokenStream::new();
     let mut to_inputs = TokenStream::new();
+    let mut to_strings = TokenStream::new();
 
     for variant in variants {
         match variant.fields {
@@ -204,6 +205,11 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
             &#ident::#var_ident =>
                 #juniper_path::InputValue::scalar(#name.to_string()),
         });
+
+        // Build to_strings clause.
+        to_strings.extend(quote! {
+            &#ident::#var_ident => #name.to_string(),
+        })
     }
 
     #[cfg(feature = "async")]
@@ -281,6 +287,14 @@ pub fn impl_enum(ast: &syn::DeriveInput, is_internal: bool) -> TokenStream {
             fn to_input_value(&self) -> #juniper_path::InputValue<__S> {
                 match self {
                     #to_inputs
+                }
+            }
+        }
+
+        impl From<#ident> for String {
+            fn from(&self) -> String {
+                match self {
+                    #to_strings
                 }
             }
         }


### PR DESCRIPTION
Hi!

This PR expands the `GraphQLEnum` derive macro to provide conversions from enum variants into strings. Currently, the macro only provides conversions for `InputValue`, but in my usage it became necessary to map enum variants into `Value::scalar::<String>` types so that they can be used in GraphQL responses, specifically as the second parameter of `FieldError::new`. Mapping enum variants to strings directly, rather than a Juniper type, is an artifact of my not knowing much.

I'm new to Rust and even newer to Juniper, so this PR is intended for review and discussion, and I am happy to incorporate any feedback. 