### PR TITLE
Add futures dependency

### DIFF
--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -15,17 +15,17 @@ edition = "2018"
 proc-macro = true
 
 [features]
-async = []
+async = ["futures"]
 
 [dependencies]
 proc-macro2 = "1.0.1"
 syn = { version = "1.0.3", features = ["full", "extra-traits", "parsing"] }
 quote = "1.0.2"
 proc-macro-error = "0.3.4"
+futures = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 juniper = { version = "0.14.2", path = "../juniper", features = ["async"] }
-futures = { version = "0.3.1" }
 
 [badges]
 travis-ci = { repository = "graphql-rust/juniper" }


### PR DESCRIPTION
Fixes https://github.com/graphql-rust/juniper/issues/534.

I am not sure if the best way is to have folks bring their own futures for the
derives / macros or to pull it in as a dep explicitly like I have done here.

Because people are filing issues, we will do it this way and see what other issues arise.