### PR TITLE
Do not use RwLock for async execution

### DIFF
--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -569,7 +569,8 @@ where
     /// Add an error to the execution engine at the current executor location
     #[cfg(feature = "async")]
     pub async fn push_error_async(&self, error: FieldError<S>) {
-        self.push_error_at_async(error, self.location().clone()).await;
+        self.push_error_at_async(error, self.location().clone())
+            .await;
     }
 
     /// Add an error to the execution engine at a specific location


### PR DESCRIPTION
Fixes https://github.com/graphql-rust/juniper/issues/532.

This is pretty janky because `async` isn't an either-or. You can still
execute sync with the `async` feature enabled. I also don't want to require
`futures` if the `async` flag is off and didn't want to add more feature flags for
`tokio` and `async-std`.

I could have implemented an `AsyncExecutor` when the `async` feature is on
but that would have required a lot of plumbing. I will likely come back around
and do that eventually.

If other folks have better ideas, let me know.