### PR TITLE
Warning about normal methods in juniper::object impl blocks

### DIFF
--- a/docs/book/content/types/objects/complex_fields.md
+++ b/docs/book/content/types/objects/complex_fields.md
@@ -3,7 +3,9 @@
 If you've got a struct that can't be mapped directly to GraphQL, that contains
 computed fields or circular structures, you have to use a more powerful tool:
 the `object` procedural macro. This macro lets you define GraphQL object
-fields in a Rust `impl` block for a type. Continuing with the
+fields in a Rust `impl` block for a type. Note that only GraphQL fields
+can be specified in this `impl` block. If you want to define normal methods on the struct,
+you have to do so in a separate, normal `impl` block. Continuing with the
 example from the last chapter, this is how you would define `Person` using the
 macro:
 


### PR DESCRIPTION
There's a comment [here](https://docs.rs/juniper/0.14.2/juniper/attr.object.html) that only GraphQL fields can be specified in `#[juniper::object]` impl block, yet in the book it was not specified, I needed help to get the idea of separating my `new` method in another impl block.

I simply copied that information in the book because it feels important; one would not know of this only by reading the book.