### PR TITLE
Match the list of integrations to the page order

### DIFF
--- a/docs/book/content/servers/index.md
+++ b/docs/book/content/servers/index.md
@@ -7,7 +7,6 @@ To actually get a server up and running, there are multiple official and
 third-party integration crates that will get you there.
 
 - [Official Server Integrations](official.md)
-    - [Hyper](hyper.md)
     - [Warp](warp.md)
     - [Rocket](rocket.md)
     - [Iron](iron.md)

--- a/docs/book/content/servers/official.md
+++ b/docs/book/content/servers/official.md
@@ -3,7 +3,6 @@
 Juniper provides official integration crates for several popular Rust server
 libraries.
 
-
 - [Warp](warp.md)
 - [Rocket](rocket.md)
 - [Iron](iron.md)

--- a/docs/book/content/servers/official.md
+++ b/docs/book/content/servers/official.md
@@ -3,7 +3,8 @@
 Juniper provides official integration crates for several popular Rust server
 libraries.
 
-- [Hyper](hyper.md)
+
 - [Warp](warp.md)
 - [Rocket](rocket.md)
 - [Iron](iron.md)
+- [Hyper](hyper.md)


### PR DESCRIPTION
The lists of official server integrations don't match the reading order in which their corresponding pages appear in the book. This can cause the user to unknowingly skip a section of the book by clicking on the links.

Make the server integrations order match the reading order from the book.

Fixes #547