### PR TITLE
Fix `field_execution` and `merge_parallel_inline_fragments` async tests

### DIFF
--- a/juniper/src/executor_tests/executor.rs
+++ b/juniper/src/executor_tests/executor.rs
@@ -53,8 +53,8 @@ mod field_execution {
         }
     }
 
-    #[test]
-    fn test() {
+    #[tokio::test]
+    async fn test() {
         let schema =
             RootNode::<_, _, crate::DefaultScalarValue>::new(DataType, EmptyMutation::<()>::new());
         let doc = r"
@@ -87,8 +87,9 @@ mod field_execution {
             .into_iter()
             .collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -175,8 +176,8 @@ mod merge_parallel_fragments {
         }
     }
 
-    #[test]
-    fn test() {
+    #[tokio::test]
+    async fn test() {
         let schema = RootNode::new(Type, EmptyMutation::<()>::new());
         let doc = r"
           { a, ...FragOne, ...FragTwo }
@@ -191,8 +192,9 @@ mod merge_parallel_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -279,8 +281,8 @@ mod merge_parallel_inline_fragments {
         }
     }
 
-    #[test]
-    fn test() {
+    #[tokio::test]
+    async fn test() {
         let schema = RootNode::new(Type, EmptyMutation::<()>::new());
         let doc = r"
           { a, ...FragOne }
@@ -309,8 +311,9 @@ mod merge_parallel_inline_fragments {
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -399,14 +402,14 @@ mod threads_context_correctly {
         }
     }
 
-    #[test]
-    fn test() {
+    #[tokio::test]
+    async fn test() {
         let schema = RootNode::new(Schema, EmptyMutation::<TestContext>::new());
         let doc = r"{ a }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute_sync(
+        let (result, errs) = crate::execute(
             doc,
             None,
             &schema,
@@ -415,6 +418,7 @@ mod threads_context_correctly {
                 value: "Context value".to_owned(),
             },
         )
+        .await
         .expect("Execution failed");
 
         assert_eq!(errs, []);
@@ -495,8 +499,8 @@ mod dynamic_context_switching {
         }
     }
 
-    #[test]
-    fn test_opt() {
+    #[tokio::test]
+    async fn test_opt() {
         let schema = RootNode::new(Schema, EmptyMutation::<OuterContext>::new());
         let doc = r"{ first: itemOpt(key: 0) { value }, missing: itemOpt(key: 2) { value } }";
 
@@ -521,8 +525,9 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx)
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -548,8 +553,8 @@ mod dynamic_context_switching {
         );
     }
 
-    #[test]
-    fn test_res_success() {
+    #[tokio::test]
+    async fn test_res_success() {
         let schema = RootNode::new(Schema, EmptyMutation::<OuterContext>::new());
         let doc = r"
           {
@@ -578,8 +583,9 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx)
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, vec![]);
 
@@ -602,8 +608,8 @@ mod dynamic_context_switching {
         );
     }
 
-    #[test]
-    fn test_res_fail() {
+    #[tokio::test]
+    async fn test_res_fail() {
         let schema = RootNode::new(Schema, EmptyMutation::<OuterContext>::new());
         let doc = r"
           {
@@ -632,8 +638,9 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx)
+            .await
+            .expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -649,8 +656,8 @@ mod dynamic_context_switching {
         assert_eq!(result, Value::null());
     }
 
-    #[test]
-    fn test_res_opt() {
+    #[tokio::test]
+    async fn test_res_opt() {
         let schema = RootNode::new(Schema, EmptyMutation::<OuterContext>::new());
         let doc = r"
           {
@@ -681,8 +688,9 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx)
+            .await
+            .expect("Execution failed");
 
         assert_eq!(
             errs,
@@ -716,8 +724,8 @@ mod dynamic_context_switching {
         );
     }
 
-    #[test]
-    fn test_always() {
+    #[tokio::test]
+    async fn test_always() {
         let schema = RootNode::new(Schema, EmptyMutation::<OuterContext>::new());
         let doc = r"{ first: itemAlways(key: 0) { value } }";
 
@@ -742,8 +750,9 @@ mod dynamic_context_switching {
             .collect(),
         };
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &ctx).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &ctx)
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -831,15 +840,16 @@ mod propagates_errors_to_nullable_fields {
         }
     }
 
-    #[test]
-    fn nullable_first_level() {
+    #[tokio::test]
+    async fn nullable_first_level() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { nullableErrorField } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -858,15 +868,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn non_nullable_first_level() {
+    #[tokio::test]
+    async fn non_nullable_first_level() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { nonNullableErrorField } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -882,15 +893,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn custom_error_first_level() {
+    #[tokio::test]
+    async fn custom_error_first_level() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { customErrorField } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -906,15 +918,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn nullable_nested_level() {
+    #[tokio::test]
+    async fn nullable_nested_level() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { nullableField { nonNullableErrorField } } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -933,15 +946,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn non_nullable_nested_level() {
+    #[tokio::test]
+    async fn non_nullable_nested_level() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { nonNullableField { nonNullableErrorField } } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -957,15 +971,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn nullable_innermost() {
+    #[tokio::test]
+    async fn nullable_innermost() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inner { nonNullableField { nullableErrorField } } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -984,15 +999,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn non_null_list() {
+    #[tokio::test]
+    async fn non_null_list() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ inners { nonNullableErrorField } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -1008,15 +1024,16 @@ mod propagates_errors_to_nullable_fields {
         );
     }
 
-    #[test]
-    fn non_null_list_of_nullable() {
+    #[tokio::test]
+    async fn non_null_list_of_nullable() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ nullableInners { nonNullableErrorField } }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         println!("Result: {:#?}", result);
 
@@ -1072,16 +1089,17 @@ mod named_operations {
         }
     }
 
-    #[test]
-    fn uses_inline_operation_if_no_name_provided() {
+    #[tokio::test]
+    async fn uses_inline_operation_if_no_name_provided() {
         let schema =
             RootNode::<_, _, crate::DefaultScalarValue>::new(Schema, EmptyMutation::<()>::new());
         let doc = r"{ a }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -1091,15 +1109,16 @@ mod named_operations {
         );
     }
 
-    #[test]
-    fn uses_only_named_operation() {
+    #[tokio::test]
+    async fn uses_only_named_operation() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"query Example { a }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) =
-            crate::execute_sync(doc, None, &schema, &vars, &()).expect("Execution failed");
+        let (result, errs) = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .expect("Execution failed");
 
         assert_eq!(errs, []);
 
@@ -1109,15 +1128,16 @@ mod named_operations {
         );
     }
 
-    #[test]
-    fn uses_named_operation_if_name_provided() {
+    #[tokio::test]
+    async fn uses_named_operation_if_name_provided() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc =
             r"query Example($p: String!) { first: a(p: $p) } query OtherExample { second: a }";
 
         let vars = vec![].into_iter().collect();
 
-        let (result, errs) = crate::execute_sync(doc, Some("OtherExample"), &schema, &vars, &())
+        let (result, errs) = crate::execute(doc, Some("OtherExample"), &schema, &vars, &())
+            .await
             .expect("Execution failed");
 
         assert_eq!(errs, []);
@@ -1128,27 +1148,30 @@ mod named_operations {
         );
     }
 
-    #[test]
-    fn error_if_multiple_operations_provided_but_no_name() {
+    #[tokio::test]
+    async fn error_if_multiple_operations_provided_but_no_name() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"query Example { first: a } query OtherExample { second: a }";
 
         let vars = vec![].into_iter().collect();
 
-        let err = crate::execute_sync(doc, None, &schema, &vars, &()).unwrap_err();
+        let err = crate::execute(doc, None, &schema, &vars, &())
+            .await
+            .unwrap_err();
 
         assert_eq!(err, GraphQLError::MultipleOperationsProvided);
     }
 
-    #[test]
-    fn error_if_unknown_operation_name_provided() {
+    #[tokio::test]
+    async fn error_if_unknown_operation_name_provided() {
         let schema = RootNode::new(Schema, EmptyMutation::<()>::new());
         let doc = r"query Example { first: a } query OtherExample { second: a }";
 
         let vars = vec![].into_iter().collect();
 
-        let err =
-            crate::execute_sync(doc, Some("UnknownExample"), &schema, &vars, &()).unwrap_err();
+        let err = crate::execute(doc, Some("UnknownExample"), &schema, &vars, &())
+            .await
+            .unwrap_err();
 
         assert_eq!(err, GraphQLError::UnknownOperationName);
     }

--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -12,7 +12,7 @@ use crate::BoxFuture;
 
 use super::base::{is_excluded, merge_key_into, Arguments, GraphQLType};
 
-// TODO: docs.
+/// TODO: docs.
 pub trait GraphQLTypeAsync<S>: GraphQLType<S> + Send + Sync
 where
     Self::Context: Send + Sync,
@@ -206,6 +206,8 @@ where
                     continue;
                 }
 
+                println!("WHATEVR");
+
                 // TODO: prevent duplicate boxing.
                 let f = async move {
                     let fragment = &executor
@@ -248,7 +250,14 @@ where
 
                     if let Ok(Value::Object(obj)) = sub_result {
                         for (k, v) in obj {
-                            merge_key_into(&mut object, &k, v);
+                            // TODO: prevent duplicate boxing.
+                            let f = async move {
+                                AsyncValue::Field(AsyncField {
+                                    name: k,
+                                    value: Some(v),
+                                })
+                            };
+                            async_values.push(Box::pin(f));
                         }
                     } else if let Err(e) = sub_result {
                         sub_exec.push_error_at(e, start_pos.clone());
@@ -274,7 +283,7 @@ where
         match item {
             AsyncValue::Field(AsyncField { name, value }) => {
                 if let Some(value) = value {
-                    object.add_field(&name, value);
+                    merge_key_into(&mut object, &name, value);
                 } else {
                     return Value::null();
                 }


### PR DESCRIPTION
The ordering was off when run under async. Not 100% sure I understand this code but this seems
to work.