### PR TITLE
doc: remove outdated examples from third-party integrations list

### DIFF
--- a/docs/book/content/servers/third-party.md
+++ b/docs/book/content/servers/third-party.md
@@ -4,5 +4,3 @@ There are several examples or third party integration crates that are not
 officially maintained by Juniper developers.
 
 - [Actix-Web](https://github.com/actix/examples/tree/master/juniper)
-- [Finchers](https://github.com/finchers-rs/finchers-juniper)
-- [Tsukuyomi](https://github.com/tsukuyomi-rs/tsukuyomi/tree/master/examples/juniper)


### PR DESCRIPTION
...since I've stopped the development both of `tsukuyomi` and `finchers` a few months ago.
