### PR TITLE
Use github action to download cargo-make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,20 +54,9 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install cargo-make (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          _build/cargo-make.sh "0.20.0" "x86_64-unknown-linux-musl"
-
-      - name: Install cargo-make (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          _build/cargo-make.sh "0.20.0" "x86_64-apple-darwin"
-
-      - name: Install cargo-make (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          _build\cargo-make.ps1 -version "0.20.0" -target "x86_64-pc-windows-msvc"
+      - uses: davidB/rust-cargo-make@v1
+        with:
+          version: '0.20.0'
 
       - name: Build and run tests
         env:
@@ -127,9 +116,9 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Install cargo-make
-        run: |
-          _build/cargo-make.sh "0.20.0" "x86_64-unknown-linux-musl"
+      - uses: davidB/rust-cargo-make@v1
+        with:
+          version: '0.20.0'
 
       - name: Install cargo-release
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
there is a github action called davidB/rust-cargo-make which downloads a prebuild cargo-make for you.
You can decide not to specify the version, in which case the latest prebuilt version is downloaded, or provide it a version.

**I haven't test it**, but i see this action is used in many projects so it might reduce your need to maintain some shell and powerscript files to implement that and make the workflow simpler.

I kept it with cargo-make 0.20.0 as you have today, but there a lot of new features from 0.20 and some have to do specifically with workspaces.
so you might want to try to drop or change that value.

you can see more info on the github action here: https://github.com/marketplace/actions/rust-cargo-make