### PR TITLE
Add subscriptions connection_init behaviour

### DIFF
--- a/examples/warp_subscriptions/src/main.rs
+++ b/examples/warp_subscriptions/src/main.rs
@@ -165,7 +165,7 @@ async fn main() {
              ctx: Context,
              coordinator: Arc<Coordinator<'static, _, _, _, _, _>>| {
                 ws.on_upgrade(|websocket| -> Pin<Box<dyn Future<Output = ()> + Send>> {
-                    graphql_subscriptions(websocket, coordinator, ctx)
+                    graphql_subscriptions(websocket, coordinator, ctx, None)
                         .map(|r| {
                             if let Err(e) = r {
                                 println!("Websocket error: {}", e);

--- a/juniper_warp/CHANGELOG.md
+++ b/juniper_warp/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update `playground_filter` to support subscription endpoint URLs
 - Update `warp` to 0.2
 - Rename synchronous `execute` to `execute_sync`, add asynchronous `execute`
+- Add `graphql_subscriptions` on_connect handler
 
 # [[0.5.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_warp-0.5.2)
 


### PR DESCRIPTION
This implements a reply and `on_connect` handler to GQL_CONNECTION_INIT based on [Apollo subscriptions transport ws Protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/faa219cff7b6f9873cae59b490da46684d7bea19/PROTOCOL.md)

This lets the client send a `connection_init` message with a custom payload to the server. The server handles this with a `on_connect` closure.
It replies `GQL_CONNECTION_ACK` if the connection is established and `GQL_CONNECTION_ERROR` if refused (with an error provided by `on_connect`).

I'm a bit sceptical about the `#[allow(dead_code)]` I added, but I thought it may be useful to keep `type_name` in the struct `WsPayload`.

- [x] Ensure proper formatting
- [x] Run all tests
- [x] Update the CHANGELOG

An example to use this would be (based on [this](https://github.com/graphql-rust/juniper/blob/adc8d7be2d593fcdc32f918c33eeab2f11916563/examples/warp_subscriptions/src/main.rs#L168-L174))
```rust
graphql_subscriptions(
    websocket,
    coordinator,
    ctx,
    Some(|payload: &Value| {
        if let Some(token) = payload["authorization"].as_str() {
            if token == "foobar" {
                return Ok(())
            }
        }
        Err("Connection prohibited".to_string())
    }),
)
.map(|r| {
    if let Err(e) = r {
        println!("Websocket error: {}", e);
    }
})
.boxed()
```

With an apollographql client one could use 
```js
options: {
  connectionParams: {
    authorization: "foobar",
  },
},
```
as options for `apollo-link-ws` `WebSocketLink` ([see apollo docs](https://www.apollographql.com/docs/react/data/subscriptions/#authentication-over-websocket)).
(for apollo server this would be: [Apollo Server Websocket Authentification](https://www.apollographql.com/docs/graphql-subscriptions/authentication/))