### PR TITLE
Add debug derive to GraphQLResponse

### DIFF
--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -154,6 +154,7 @@ where
 /// This struct implements Serialize, so you can simply serialize this
 /// to JSON and send it over the wire. Use the `is_ok` method to determine
 /// whether to send a 200 or 400 HTTP status code.
+#[derive(Debug)]
 pub struct GraphQLResponse<'a, S = DefaultScalarValue>(
     Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError<'a>>,
 );


### PR DESCRIPTION
 It's useful to print a debug message after `execute` of its result