### PR TITLE
Added document validation in the resolve_into_stream method and a test

### DIFF
--- a/integration_tests/async_await/src/main.rs
+++ b/integration_tests/async_await/src/main.rs
@@ -152,4 +152,24 @@ async fn async_field_validation_error() {
     assert!(is_validation_error);
 }
 
+#[tokio::test]
+async fn resolve_into_stream_validation_error() {
+    let schema = RootNode::new(Query, Mutation, Subscription);
+    let doc = r#"
+        subscription {
+            nonExistent
+        }
+    "#;
+    let vars = Default::default();
+    let result = juniper::resolve_into_stream(doc, None, &schema, &vars, &()).await;
+    assert!(result.is_err());
+
+    let error = result.err().unwrap();
+    let is_validation_error = match error {
+        GraphQLError::ValidationError(_) => true,
+        _ => false,
+    };
+    assert!(is_validation_error);
+}
+
 fn main() {}

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -328,6 +328,16 @@ where
     let document: crate::ast::Document<'a, S> =
         parse_document_source(document_source, &root_node.schema)?;
 
+    {
+        let mut ctx = ValidatorContext::new(&root_node.schema, &document);
+        visit_all_rules(&mut ctx, &document);
+
+        let errors = ctx.into_errors();
+        if !errors.is_empty() {
+            return Err(GraphQLError::ValidationError(errors));
+        }
+    }
+
     let operation = get_operation(&document, operation_name)?;
 
     {


### PR DESCRIPTION
Added the validation of operations before executing then, i found that the validation was missing and because of that a panic was ocurring in the request of a subscription.

## PR Checklist

Before submitting a PR, you should follow these steps to prevent redundant churn or CI failures:

- [X] Ensure proper formatting
- [X] Run all tests
- [ ] Update the CHANGELOG