### PR TITLE
Removed 'compat' feature from futures...

### DIFF
--- a/juniper_subscriptions/Cargo.toml
+++ b/juniper_subscriptions/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 
 [dependencies]
-futures = { version = "=0.3.1", features = ["compat"] }
+futures = "0.3.1"
 juniper = { version = "0.14.2", path = "../juniper", default-features = false }
 
 [dev-dependencies]

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -13,7 +13,7 @@ subscriptions = ["juniper_subscriptions"]
 
 [dependencies]
 warp = "0.2"
-futures = { version = "0.3.1", features = ["compat"] }
+futures = "0.3.1"
 juniper = { version = "0.14.2", path = "../juniper", default-features = false  }
 juniper_subscriptions = { path = "../juniper_subscriptions", optional = true}
 tokio = { version = "0.2", features = ["rt-core", "blocking"] }


### PR DESCRIPTION
...on juniper_subscriptions and juniper_warp, which where not being used, permitting futures versions greater than 0.3.1 to be used.