### PR TITLE
Derive macro for tagged enums (GraphQLUnion)

### DIFF
--- a/docs/book/content/types/unions.md
+++ b/docs/book/content/types/unions.md
@@ -194,9 +194,7 @@ impl Character {
 This example is similar to `Enums (Impl)`. To successfully use the
 derive macro, ensure that each variant of the enum has a different
 type. Since each variant is different, the device macro provides
-`std::convert::Into<T>` converter for each _used_ variant. Fields
-which are skipped by using `#[graphql(skip)]` do not have a
-`std::convert::Into<T>` converter.
+`std::convert::Into<T>` converter for each variant.
 
 ```rust
 #[derive(juniper::GraphQLObject)]

--- a/docs/book/content/types/unions.md
+++ b/docs/book/content/types/unions.md
@@ -3,10 +3,11 @@
 From a server's point of view, GraphQL unions are similar to interfaces: the
 only exception is that they don't contain fields on their own.
 
-In Juniper, the `graphql_union!` has identical syntax to the [interface
-macro](interfaces.md), but does not support defining fields. Therefore, the same
-considerations about using traits, placeholder types, or enums still apply to
-unions.
+In Juniper, the `graphql_union!` has identical syntax to the
+[interface macro](interfaces.md), but does not support defining
+fields. Therefore, the same considerations about using traits,
+placeholder types, or enums still apply to unions. For simple
+situations, Juniper provides `#[derive(GraphQLUnion)]` for enums.
 
 If we look at the same examples as in the interfaces chapter, we see the
 similarities and the tradeoffs:
@@ -154,7 +155,7 @@ impl GraphQLUnion for Character {
 # fn main() {}
 ```
 
-## Enums
+## Enums (Impl)
 
 ```rust
 #[derive(juniper::GraphQLObject)]
@@ -183,6 +184,37 @@ impl Character {
             Droid => { match *self { Character::Droid(ref d) => Some(d), _ => None } },
         }
     }
+}
+
+# fn main() {}
+```
+
+## Enums (Derive)
+
+This example is similar to `Enums (Impl)`. To successfully use the
+derive macro, ensure that each variant of the enum has a different
+type. Since each variant is different, the device macro provides
+`std::convert::Into<T>` converter for each _used_ variant. Fields
+which are skipped by using `#[graphql(skip)]` do not have a
+`std::convert::Into<T>` converter.
+
+```rust
+#[derive(juniper::GraphQLObject)]
+struct Human {
+    id: String,
+    home_planet: String,
+}
+
+#[derive(juniper::GraphQLObject)]
+struct Droid {
+    id: String,
+    primary_function: String,
+}
+
+#[derive(GraphQLUnion)]
+enum Character {
+    Human(Human),
+    Droid(Droid),
 }
 
 # fn main() {}

--- a/docs/book/content/types/unions.md
+++ b/docs/book/content/types/unions.md
@@ -211,7 +211,7 @@ struct Droid {
     primary_function: String,
 }
 
-#[derive(GraphQLUnion)]
+#[derive(juniper::GraphQLUnion)]
 enum Character {
     Human(Human),
     Droid(Droid),

--- a/integration_tests/juniper_tests/src/codegen/derive_union.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_union.rs
@@ -1,0 +1,92 @@
+// Default Test
+#[derive(juniper::GraphQLObject)]
+pub struct Human {
+    id: String,
+    home_planet: String,
+}
+
+#[derive(juniper::GraphQLObject)]
+pub struct Droid {
+    id: String,
+    primary_function: String,
+}
+
+#[derive(juniper::GraphQLUnion)]
+pub enum Character {
+    One(Human),
+    Two(Droid),
+}
+
+// Context Test
+pub struct CustomContext;
+
+impl juniper::Context for CustomContext {}
+
+#[derive(juniper::GraphQLObject)]
+#[graphql(Context = CustomContext)]
+pub struct HumanContext {
+    id: String,
+    home_planet: String,
+}
+
+#[derive(juniper::GraphQLObject)]
+#[graphql(Context = CustomContext)]
+pub struct DroidContext {
+    id: String,
+    primary_function: String,
+}
+
+#[derive(juniper::GraphQLUnion)]
+#[graphql(Context = CustomContext)]
+pub enum CharacterContext {
+    One(HumanContext),
+    Two(DroidContext),
+}
+
+// #[juniper::object] compatibility
+
+pub struct HumanCompat {
+    id: String,
+    home_planet: String,
+}
+
+#[juniper::graphql_object]
+impl HumanCompat {
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn home_planet(&self) -> &String {
+        &self.home_planet
+    }
+}
+
+pub struct DroidCompat {
+    id: String,
+    primary_function: String,
+}
+
+#[juniper::graphql_object]
+impl DroidCompat {
+    fn id(&self) -> &String {
+        &self.id
+    }
+
+    fn primary_function(&self) -> &String {
+        &self.primary_function
+    }
+}
+
+// NOTICE: this can not compile
+// #[derive(juniper::GraphQLUnion)]
+// pub enum CharacterCompatFail {
+//     One(HumanCompat),
+//     Two(DroidCompat),
+// }
+
+#[derive(juniper::GraphQLUnion)]
+#[graphql(Scalar = juniper::DefaultScalarValue)]
+pub enum CharacterCompat {
+    One(HumanCompat),
+    Two(DroidCompat),
+}

--- a/integration_tests/juniper_tests/src/codegen/mod.rs
+++ b/integration_tests/juniper_tests/src/codegen/mod.rs
@@ -2,5 +2,6 @@ mod derive_enum;
 mod derive_input_object;
 mod derive_object;
 mod derive_object_with_raw_idents;
+mod derive_union;
 mod impl_union;
 mod scalar_value_transparent;

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -25,7 +25,7 @@ See [#569](https://github.com/graphql-rust/juniper/pull/569).
 - GraphQLUnion derive support ("#[derive(GraphqQLUnion)]")
   - implements GraphQLAsyncType
 
-See [#](https://github.com/graphql-rust/juniper/pull/).
+See [#618](https://github.com/graphql-rust/juniper/pull/618).
 
 ## Breaking Changes
 

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -20,6 +20,11 @@ See [#419](https://github.com/graphql-rust/juniper/pull/419).
 
 See [#569](https://github.com/graphql-rust/juniper/pull/569).
 
+- GraphQLUnion derive support ("#[derive(GraphqQLUnion)]")
+  - implements GraphQLAsyncType
+
+See [#](https://github.com/graphql-rust/juniper/pull/).
+
 ## Breaking Changes
 
 - `juniper::graphiql` has moved to `juniper::http::graphiql`

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -116,7 +116,7 @@ extern crate bson;
 // functionality automatically.
 pub use juniper_codegen::{
     graphql_object, graphql_subscription, graphql_union, GraphQLEnum, GraphQLInputObject,
-    GraphQLObject, GraphQLScalarValue,
+    GraphQLObject, GraphQLScalarValue, GraphQLUnion,
 };
 // Internal macros are not exported,
 // but declared at the root to make them easier to use.

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -38,7 +38,7 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
 
 
         if field_attrs.skip {
-            None
+            panic!("#[derive(GraphQLUnion)] does not support #[graphql(skip)] on fields");
         } else {
             let field_name = field.ident;
             let name = field_attrs

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -67,11 +67,15 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
                 _ => panic!("#[derive(GraphlQLObject)] all fields of the enum must be unnamed"),
             };
 
+            if field_attrs.description.is_some() {
+                panic!("#[derive(GraphQLUnion)] does not allow documentation of fields");
+            }
+
             Some(util::GraphQLTypeDefinitionField {
                 name,
                 _type,
                 args: Vec::new(),
-                description: field_attrs.description,
+                description: None,
                 deprecation: field_attrs.deprecation,
                 resolver_code,
                 is_type_inferred: true,

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -8,7 +8,7 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
     let enum_fields = match ast.data {
         Data::Enum(data) => data.variants,
         _ => {
-            panic!("#[derive(GraphlQLUnion)] can only be applied to enums");
+            panic!("#[derive(GraphQLUnion)] can only be applied to enums");
         }
     };
 
@@ -21,7 +21,7 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
     };
 
     if !attrs.interfaces.is_empty() {
-        panic!("#[derive(GraphlQLUnion)] does not support interfaces");
+        panic!("#[derive(GraphQLUnion)] does not support interfaces");
     }
 
     let ident = &ast.ident;
@@ -59,12 +59,12 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
                     };
 
                     if iter.next().is_some() {
-                        panic!("#[derive(GraphlQLUnion)] all members must be unnamed with a single element e.g. Some(T)");
+                        panic!("#[derive(GraphQLUnion)] all members must be unnamed with a single element e.g. Some(T)");
                     }
 
                     first.ty.clone()
                 }
-                _ => panic!("#[derive(GraphlQLObject)] all fields of the enum must be unnamed"),
+                _ => panic!("#[derive(GraphQLUnion)] all fields of the enum must be unnamed"),
             };
 
             if field_attrs.description.is_some() {

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -40,14 +40,14 @@ pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStre
         if field_attrs.skip {
             panic!("#[derive(GraphQLUnion)] does not support #[graphql(skip)] on fields");
         } else {
-            let field_name = field.ident;
+            let variant_name = field.ident;
             let name = field_attrs
                 .name
                 .clone()
-                .unwrap_or_else(|| util::to_camel_case(&field_name.to_string()));
+                .unwrap_or_else(|| util::to_camel_case(&variant_name.to_string()));
 
             let resolver_code = quote!(
-                #ident . #field_name
+                #ident :: #variant_name
             );
 
             let _type = match field.fields {

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -1,0 +1,99 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{self, Data, Fields};
+
+use crate::util;
+
+pub fn build_derive_union(ast: syn::DeriveInput, is_internal: bool) -> TokenStream {
+    let enum_fields = match ast.data {
+        Data::Enum(data) => data.variants,
+        _ => {
+            panic!("#[derive(GraphlQLUnion)] can only be applied to enums");
+        }
+    };
+
+    // Parse attributes.
+    let attrs = match util::ObjectAttributes::from_attrs(&ast.attrs) {
+        Ok(a) => a,
+        Err(e) => {
+            panic!("Invalid #[graphql(...)] attribute for enum: {}", e);
+        }
+    };
+
+    if !attrs.interfaces.is_empty() {
+        panic!("#[derive(GraphlQLUnion)] does not support interfaces");
+    }
+
+    let ident = &ast.ident;
+    let name = attrs.name.unwrap_or_else(|| ident.to_string());
+
+    let fields = enum_fields.into_iter().filter_map(|field| {
+        let field_attrs = match util::FieldAttributes::from_attrs(
+            field.attrs,
+            util::FieldAttributeParseMode::Object,
+        ) {
+            Ok(attrs) => attrs,
+            Err(e) => panic!("Invalid #[graphql] attribute for field: \n{}", e),
+        };
+
+
+        if field_attrs.skip {
+            None
+        } else {
+            let field_name = field.ident;
+            let name = field_attrs
+                .name
+                .clone()
+                .unwrap_or_else(|| util::to_camel_case(&field_name.to_string()));
+
+            let resolver_code = quote!(
+                #ident . #field_name
+            );
+
+            let _type = match field.fields {
+                Fields::Unnamed(inner) => {
+                    let mut iter = inner.unnamed.iter();
+                    let first = match iter.next() {
+                        Some(val) => val,
+                        None => unreachable!(),
+                    };
+
+                    if iter.next().is_some() {
+                        panic!("#[derive(GraphlQLUnion)] all members must be unnamed with a single element e.g. Some(T)");
+                    }
+
+                    first.ty.clone()
+                }
+                _ => panic!("#[derive(GraphlQLObject)] all fields of the enum must be unnamed"),
+            };
+
+            Some(util::GraphQLTypeDefinitionField {
+                name,
+                _type,
+                args: Vec::new(),
+                description: field_attrs.description,
+                deprecation: field_attrs.deprecation,
+                resolver_code,
+                is_type_inferred: true,
+                is_async: false,
+            })
+        }
+    });
+
+    let definition = util::GraphQLTypeDefiniton {
+        name,
+        _type: syn::parse_str(&ast.ident.to_string()).unwrap(),
+        context: attrs.context,
+        scalar: attrs.scalar,
+        description: attrs.description,
+        fields: fields.collect(),
+        generics: ast.generics,
+        interfaces: None,
+        include_type_generics: true,
+        generic_scalar: true,
+        no_async: attrs.no_async,
+    };
+
+    let juniper_crate_name = if is_internal { "crate" } else { "juniper" };
+    definition.into_union_tokens(juniper_crate_name)
+}

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -15,6 +15,7 @@ mod derive_enum;
 mod derive_input_object;
 mod derive_object;
 mod derive_scalar_value;
+mod derive_union;
 mod impl_object;
 mod impl_union;
 
@@ -61,6 +62,13 @@ pub fn derive_object(input: TokenStream) -> TokenStream {
 pub fn derive_object_internal(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
     let gen = derive_object::build_derive_object(ast, true);
+    gen.into()
+}
+
+#[proc_macro_derive(GraphQLUnion, attributes(graphql))]
+pub fn derive_union(input: TokenStream) -> TokenStream {
+    let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
+    let gen = derive_union::build_derive_union(ast, false);
     gen.into()
 }
 /// This custom derive macro implements the #[derive(GraphQLScalarValue)]

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -1298,11 +1298,11 @@ impl GraphQLTypeDefiniton {
             .fields
             .iter()
             .map(|field| {
-                let variant_ident = quote::format_ident!("{}", field.name);
                 let var_ty = &field._type;
+                let resolver_code = &field.resolver_code;
 
                 quote!(
-                    Self::#variant_ident(ref x) => <#var_ty as #juniper_crate_name::GraphQLType<#scalar>>::name(&()).unwrap().to_string(),
+                    #resolver_code(ref x) => <#var_ty as #juniper_crate_name::GraphQLType<#scalar>>::name(&()).unwrap().to_string(),
                 )
             });
 
@@ -1316,10 +1316,10 @@ impl GraphQLTypeDefiniton {
             .fields
             .iter()
             .map(|field| {
-                let variant_ident = quote::format_ident!("{}", field.name);
+                let resolver_code = &field.resolver_code;
 
                 quote!(
-                    match self { Self::#variant_ident(ref val) => Some(val), _ => None, }
+                    match self { #resolver_code(ref val) => Some(val), _ => None, }
                 )
             })
             .collect();
@@ -1393,11 +1393,12 @@ impl GraphQLTypeDefiniton {
 
         let convesion_impls = self.fields.iter().map(|field| {
             let variant_ty = &field._type;
-            let variant_ident = quote::format_ident!("{}", field.name);
+            let resolver_code = &field.resolver_code;
+
             quote!(
                 impl std::convert::From<#variant_ty> for #ty {
                     fn from(val: #variant_ty) -> Self {
-                        Self::#variant_ident(val)
+                        #resolver_code(val)
                     }
                 }
             )


### PR DESCRIPTION
Implements derive macros for tagged enums which are translated into GraphQLUnion types. The following features are provided

- The macro implements GraphQLAsyncType. 
- If all variants of the tagged enum have different types, then the derive macro implements `std::convert::From<T>`  converter for these types.

Fixes: https://github.com/graphql-rust/juniper/issues/586