### PR TITLE
Remove direct usage of `serde_derive` crate

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -40,8 +40,7 @@ chrono = { version = "0.4.0", optional = true }
 fnv = "1.0.3"
 futures = "0.3.1"
 indexmap = { version = "1.0.0", features = ["serde-1"] }
-serde = { version = "1.0.8" }
-serde_derive = { version = "1.0.2" }
+serde = { version = "1.0.8", features = ["derive"] }
 serde_json = { version="1.0.2", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "0.8", optional = true }

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -4,10 +4,9 @@ pub mod graphiql;
 pub mod playground;
 
 use serde::{
-    de::Deserialize,
-    ser::{self, Serialize, SerializeMap},
+    ser::{self, SerializeMap},
+    Deserialize, Serialize,
 };
-use serde_derive::{Deserialize, Serialize};
 
 use crate::{
     ast::InputValue,
@@ -218,7 +217,7 @@ where
 }
 
 /// Simple wrapper around GraphQLRequest to allow the handling of Batch requests
-#[derive(Debug, serde_derive::Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
 #[serde(bound = "InputValue<S>: Deserialize<'de>")]
 pub enum GraphQLBatchRequest<S = DefaultScalarValue>
@@ -308,7 +307,7 @@ where
 /// This struct implements Serialize, so you can simply serialize this
 /// to JSON and send it over the wire. use the `is_ok` to determine
 /// wheter to send a 200 or 400 HTTP status code.
-#[derive(serde_derive::Serialize)]
+#[derive(Serialize)]
 #[serde(untagged)]
 pub enum GraphQLBatchResponse<'a, S = DefaultScalarValue>
 where

--- a/juniper/src/integrations/serde.rs
+++ b/juniper/src/integrations/serde.rs
@@ -2,8 +2,8 @@ use indexmap::IndexMap;
 use serde::{
     de,
     ser::{self, SerializeMap},
+    Serialize,
 };
-use serde_derive::Serialize;
 
 use std::fmt;
 

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -1,4 +1,4 @@
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{char, convert::From, marker::PhantomData, ops::Deref, u32};
 
 use crate::{

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -17,10 +17,9 @@ actix-web-actors = "2.0.0"
 futures = { version = "0.3.1", features = ["compat"] }
 juniper = { version = "0.14.2", path = "../juniper", default-features = false  }
 tokio = { version = "0.2", features = ["time"] }
+serde = { version = "1.0.75", features = ["derive"] }
 serde_json = "1.0.24"
-serde_derive = "1.0.75"
 failure = "0.1.7"
-serde = "1.0.75"
 
 [dev-dependencies]
 juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }

--- a/juniper_actix/src/lib.rs
+++ b/juniper_actix/src/lib.rs
@@ -55,8 +55,8 @@ use juniper::{
 };
 use serde::Deserialize;
 
-#[serde(deny_unknown_fields)]
 #[derive(Deserialize, Clone, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct GetGraphQLRequest {
     query: String,
     #[serde(rename = "operationName")]

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [dependencies]
-serde = "1.0"
 serde_json = "1.0"
-serde_derive = "1.0"
 url = "2"
 juniper = { version = "0.14.2", default-features = false, path = "../juniper"}
 tokio = "0.2"

--- a/juniper_iron/Cargo.toml
+++ b/juniper_iron/Cargo.toml
@@ -12,9 +12,7 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.2" }
 serde_json = { version = "1.0.2" }
-serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.2", path = "../juniper" }
 futures = "0.3.1"
 

--- a/juniper_iron/examples/iron_server.rs
+++ b/juniper_iron/examples/iron_server.rs
@@ -3,7 +3,6 @@ extern crate juniper;
 extern crate juniper_iron;
 extern crate logger;
 extern crate mount;
-extern crate serde;
 
 use std::env;
 

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -12,11 +12,8 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.2" }
 serde_json = { version = "1.0.2" }
-serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.2", default-features = false, path = "../juniper"}
-
 rocket = { version = "0.4.2", default-features = false }
 
 [dev-dependencies.juniper]

--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -12,15 +12,13 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [dependencies]
-serde = { version = "1.0.2" }
 serde_json = { version = "1.0.2" }
-serde_derive = { version = "1.0.2" }
 juniper = { version = "0.14.2", default-features = false, path = "../juniper" }
 futures = { version = "0.3.1", features = ["compat"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "async", default-features = false }
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 
 [dev-dependencies.juniper]
-version = "0.14.1"
+version = "0.14.2"
 features = ["expose-test-schema", "serde_json"]
 path = "../juniper"

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -17,10 +17,9 @@ futures = "0.3.1"
 juniper = { version = "0.14.2", path = "../juniper", default-features = false  }
 juniper_subscriptions = { path = "../juniper_subscriptions", optional = true}
 tokio = { version = "0.2", features = ["rt-core", "blocking"] }
+serde = { version = "1.0.75", features = ["derive"] }
 serde_json = "1.0.24"
-serde_derive = "1.0.75"
 failure = "0.1.7"
-serde = "1.0.75"
 
 [dev-dependencies]
 juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }


### PR DESCRIPTION
Another minor code improvement to remove direct usages of `serde_derive` crate (which is available via `derive` feature of `serde` crate).

Also, removes unnecessary `serde` deps in `Cargo.toml` of integration crates.