### PR TITLE
Exclude basic subscriptions example from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
 ]
 exclude = [
   "docs/book/tests",
+  "examples/basic_subscriptions",
   "examples/warp_async",
   "examples/warp_subscriptions",
 ]


### PR DESCRIPTION
Tiny fix required in order to get the basic_subscriptions example to run.