### PR TITLE
[WIP] Relax graphql_object

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/macros.rs
+++ b/integration_tests/juniper_tests/src/codegen/macros.rs
@@ -1,0 +1,18 @@
+struct Query;
+
+macro_rules! macro_from_another_project_exporting_items {
+    () => {
+        pub fn a() {
+            1
+        }
+    
+        pub fn b() {
+            2
+        }
+    }
+}
+
+#[juniper::graphql_object]
+impl Query {
+    macro_from_another_project_exporting_items!();
+}

--- a/integration_tests/juniper_tests/src/codegen/mod.rs
+++ b/integration_tests/juniper_tests/src/codegen/mod.rs
@@ -6,4 +6,5 @@ mod derive_union;
 mod impl_object;
 mod impl_scalar;
 mod impl_union;
+mod macros;
 mod scalar_value_transparent;

--- a/juniper_codegen/src/impl_object.rs
+++ b/juniper_codegen/src/impl_object.rs
@@ -197,7 +197,7 @@ fn create(
             _impl.type_ident.span()
         });
     }
-
+    
     if fields.is_empty() {
         error.not_empty(body_span);
     }


### PR DESCRIPTION
**WIP**

Relax `graphql_object` procedural macro to include `fn` items provided by external declarative macros.

This will allow the inclusion of definitions declared outside of the main project for more reusable and self-contained parts.

```rust
struct Query;

macro_rules! macro_from_another_project_exporting_items {
    () => {
        pub fn a() -> i32 {
            1
        }

        pub fn b(&self) -> i32 {
            2
        }
    }
}

#[juniper::graphql_object]
impl Query {
    macro_from_another_project_exporting_items!();
} 
```

Couldn't personally find another way to build compositions with `Juniper`. Please, tell me if this approach is too "hacky" to be included upstream.