### PR TITLE
Make graphql_object macro supports deriving object field resolvers

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/impl_object_with_derive_fields.rs
+++ b/integration_tests/juniper_tests/src/codegen/impl_object_with_derive_fields.rs
@@ -1,0 +1,418 @@
+#[cfg(test)]
+use fnv::FnvHashMap;
+
+use juniper::{DefaultScalarValue, GraphQLObjectInfo};
+
+#[cfg(test)]
+use juniper::{
+    self, execute, EmptyMutation, EmptySubscription, GraphQLType, Registry, RootNode, Value,
+    Variables,
+};
+
+#[derive(Default)]
+struct Context {
+    value: String,
+}
+
+impl juniper::Context for Context {}
+
+#[derive(GraphQLObjectInfo)]
+#[graphql(scalar = DefaultScalarValue)]
+struct Obj {
+    regular_field: bool,
+
+    #[graphql(name = "renamedField")]
+    renamed_field_orig: i32,
+
+    #[graphql(skip)]
+    skipped_field: i32,
+}
+
+#[juniper::graphql_object(name = "MyObj", description = "obj descr", derive_fields)]
+impl Obj {
+    fn resolve_field() -> &str {
+        "obj::resolve_field"
+    }
+}
+
+#[derive(GraphQLObjectInfo)]
+#[graphql(scalar = DefaultScalarValue)]
+struct Nested {
+    obj: Obj,
+    nested_field: bool,
+}
+
+#[juniper::graphql_object(derive_fields)]
+impl Nested {
+    fn nested_resolve_field() -> &str {
+        "nested::resolve_field"
+    }
+}
+
+#[derive(GraphQLObjectInfo)]
+#[graphql(Context = Context, scalar = DefaultScalarValue)]
+struct WithContext {
+    value: bool,
+}
+
+#[juniper::graphql_object(Context = Context, derive_fields)]
+impl WithContext {
+    fn resolve_field(ctx: &Context) -> &str {
+        ctx.value.as_str()
+    }
+}
+
+// FIXME: Field with lifetime doesn't even work for derive GraphQLObject
+//        due to 'cannot infer an appropriate lifetime'.
+
+// #[derive(GraphQLObjectInfo)]
+// #[graphql(Context = Context, scalar = DefaultScalarValue)]
+// struct WithLifetime<'a> {
+//     value: &'a str,
+// }
+
+// #[juniper::graphql_object(Context = Context)]
+// impl<'a> WithLifetime<'a> {
+//     fn custom_field() -> bool {
+//         true
+//     }
+// }
+
+struct Query;
+
+#[juniper::graphql_object(Context = Context, scalar = DefaultScalarValue)]
+impl Query {
+    fn obj() -> Obj {
+        Obj {
+            regular_field: true,
+            renamed_field_orig: 22,
+            skipped_field: 33,
+        }
+    }
+
+    fn nested(&self) -> Nested {
+        Nested {
+            obj: Obj {
+                regular_field: false,
+                renamed_field_orig: 222,
+                skipped_field: 333,
+            },
+            nested_field: true,
+        }
+    }
+
+    fn with_context(&self) -> WithContext {
+        WithContext { value: true }
+    }
+
+    // fn with_lifetime(&self) -> WithLifetime<'a> {
+    //     WithLifetime { value: "blub" }
+    // }
+}
+
+#[tokio::test]
+async fn test_derived_object_fields() {
+    assert_eq!(
+        <Obj as GraphQLType<DefaultScalarValue>>::name(&()),
+        Some("MyObj")
+    );
+
+    // Verify meta info.
+    let mut registry = Registry::new(FnvHashMap::default());
+    let meta = Obj::meta(&(), &mut registry);
+
+    assert_eq!(meta.name(), Some("MyObj"));
+    assert_eq!(meta.description(), Some(&"obj descr".to_string()));
+
+    let doc = r#"
+        {
+            obj {
+                regularField
+                renamedField
+                resolveField
+            }
+        }"#;
+
+    let schema = RootNode::new(
+        Query,
+        EmptyMutation::<Context>::new(),
+        EmptySubscription::<Context>::new(),
+    );
+
+    let context = Context {
+        value: String::from("context value"),
+    };
+
+    assert_eq!(
+        execute(doc, None, &schema, &Variables::new(), &context).await,
+        Ok((
+            Value::object(
+                vec![(
+                    "obj",
+                    Value::object(
+                        vec![
+                            ("regularField", Value::scalar(true)),
+                            ("renamedField", Value::scalar(22)),
+                            ("resolveField", Value::scalar("obj::resolve_field")),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )]
+                .into_iter()
+                .collect()
+            ),
+            vec![]
+        ))
+    );
+}
+
+#[tokio::test]
+#[should_panic]
+async fn test_cannot_query_skipped_field() {
+    let doc = r#"
+        {
+            obj {
+                skippedField
+            }
+        }"#;
+    let schema = RootNode::new(
+        Query,
+        EmptyMutation::<Context>::new(),
+        EmptySubscription::<Context>::new(),
+    );
+    let context = Context {
+        value: String::from("context value"),
+    };
+    execute(doc, None, &schema, &Variables::new(), &context)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_derived_object_fields_nested() {
+    let doc = r#"
+        {
+            nested {
+                obj {
+                    regularField
+                    renamedField
+                    resolveField
+                }
+                nestedField
+                nestedResolveField
+            }
+        }"#;
+
+    let schema = RootNode::new(
+        Query,
+        EmptyMutation::<Context>::new(),
+        EmptySubscription::<Context>::new(),
+    );
+
+    let context = Context {
+        value: String::from("context value"),
+    };
+
+    assert_eq!(
+        execute(doc, None, &schema, &Variables::new(), &context).await,
+        Ok((
+            Value::object(
+                vec![(
+                    "nested",
+                    Value::object(
+                        vec![
+                            (
+                                "obj",
+                                Value::object(
+                                    vec![
+                                        ("regularField", Value::scalar(false)),
+                                        ("renamedField", Value::scalar(222)),
+                                        ("resolveField", Value::scalar("obj::resolve_field")),
+                                    ]
+                                    .into_iter()
+                                    .collect()
+                                ),
+                            ),
+                            ("nestedField", Value::scalar(true)),
+                            ("nestedResolveField", Value::scalar("nested::resolve_field"))
+                        ]
+                        .into_iter()
+                        .collect()
+                    ),
+                )]
+                .into_iter()
+                .collect()
+            ),
+            vec![]
+        ))
+    );
+}
+
+#[tokio::test]
+async fn test_field_resolver_with_context() {
+    let doc = r#"
+        {
+            withContext {
+                value
+                resolveField
+            }
+        }"#;
+
+    let schema = RootNode::new(
+        Query,
+        EmptyMutation::<Context>::new(),
+        EmptySubscription::<Context>::new(),
+    );
+
+    let context = Context {
+        value: String::from("context value"),
+    };
+
+    assert_eq!(
+        execute(doc, None, &schema, &Variables::new(), &context).await,
+        Ok((
+            Value::object(
+                vec![(
+                    "withContext",
+                    Value::object(
+                        vec![
+                            ("value", Value::scalar(true)),
+                            ("resolveField", Value::scalar("context value")),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )]
+                .into_iter()
+                .collect()
+            ),
+            vec![]
+        ))
+    );
+}
+
+#[tokio::test]
+#[should_panic]
+async fn test_duplicate_object_field() {
+    #[derive(GraphQLObjectInfo)]
+    #[graphql(scalar = DefaultScalarValue)]
+    struct TestObject {
+        value: bool,
+    }
+
+    #[juniper::graphql_object(derive_fields)]
+    impl TestObject {
+        fn value() -> bool {
+            true
+        }
+    }
+
+    struct TestQuery;
+
+    #[juniper::graphql_object(scalar = DefaultScalarValue)]
+    impl TestQuery {
+        fn test(&self) -> TestObject {
+            TestObject { value: false }
+        }
+    }
+
+    let doc = r#"
+        {
+            test {
+                value
+            }
+        }"#;
+    let schema = RootNode::new(
+        TestQuery,
+        EmptyMutation::<()>::new(),
+        EmptySubscription::<()>::new(),
+    );
+    execute(doc, None, &schema, &Variables::new(), &())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic]
+async fn test_duplicate_object_field_with_custom_name() {
+    #[derive(GraphQLObjectInfo)]
+    #[graphql(scalar = DefaultScalarValue)]
+    struct TestObject {
+        #[graphql(name = "renamed")]
+        value: bool,
+    }
+
+    #[juniper::graphql_object(derive_fields)]
+    impl TestObject {
+        fn renamed() -> bool {
+            true
+        }
+    }
+
+    struct TestQuery;
+
+    #[juniper::graphql_object(scalar = DefaultScalarValue)]
+    impl TestQuery {
+        fn test(&self) -> TestObject {
+            TestObject { value: false }
+        }
+    }
+
+    let doc = r#"
+        {
+            test {
+                renamed
+            }
+        }"#;
+    let schema = RootNode::new(
+        TestQuery,
+        EmptyMutation::<()>::new(),
+        EmptySubscription::<()>::new(),
+    );
+    execute(doc, None, &schema, &Variables::new(), &())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic]
+async fn test_duplicate_field_resolver_with_custom_name() {
+    #[derive(GraphQLObjectInfo)]
+    #[graphql(scalar = DefaultScalarValue)]
+    struct TestObject {
+        value: bool,
+    }
+
+    #[juniper::graphql_object(derive_fields)]
+    impl TestObject {
+        #[graphql(name = "value")]
+        fn renamed() -> bool {
+            true
+        }
+    }
+
+    struct TestQuery;
+
+    #[juniper::graphql_object(scalar = DefaultScalarValue)]
+    impl TestQuery {
+        fn test(&self) -> TestObject {
+            TestObject { value: false }
+        }
+    }
+
+    let doc = r#"
+        {
+            test {
+                value
+            }
+        }"#;
+    let schema = RootNode::new(
+        TestQuery,
+        EmptyMutation::<()>::new(),
+        EmptySubscription::<()>::new(),
+    );
+    execute(doc, None, &schema, &Variables::new(), &())
+        .await
+        .unwrap();
+}

--- a/integration_tests/juniper_tests/src/codegen/mod.rs
+++ b/integration_tests/juniper_tests/src/codegen/mod.rs
@@ -4,6 +4,7 @@ mod derive_object;
 mod derive_object_with_raw_idents;
 mod derive_union;
 mod impl_object;
+mod impl_object_with_derive_fields;
 mod impl_scalar;
 mod impl_union;
 mod scalar_value_transparent;

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -32,6 +32,10 @@ See [#618](https://github.com/graphql-rust/juniper/pull/618).
 - Better error messages for all proc macros (see
   [#631](https://github.com/graphql-rust/juniper/pull/631)
 
+- Procedural macro `graphql_object` supports deriving resolvers for fields in
+  struct (see [#553](https://github.com/graphql-rust/juniper/issues/553))
+  - requires derive macro `GraphQLObjectInfo`.
+
 ## Breaking Changes
 
 - `juniper::graphiql` has moved to `juniper::http::graphiql`

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -116,7 +116,7 @@ extern crate bson;
 // functionality automatically.
 pub use juniper_codegen::{
     graphql_object, graphql_scalar, graphql_subscription, graphql_union, GraphQLEnum,
-    GraphQLInputObject, GraphQLObject, GraphQLScalarValue, GraphQLUnion,
+    GraphQLInputObject, GraphQLObject, GraphQLObjectInfo, GraphQLScalarValue, GraphQLUnion,
 };
 // Internal macros are not exported,
 // but declared at the root to make them easier to use.
@@ -178,7 +178,7 @@ pub use crate::{
     },
     types::{
         async_await::GraphQLTypeAsync,
-        base::{Arguments, GraphQLType, TypeKind},
+        base::{Arguments, GraphQLType, GraphQLTypeInfo, TypeKind},
         marker,
         scalars::{EmptyMutation, EmptySubscription, ID},
         subscriptions::{GraphQLSubscriptionType, SubscriptionConnection, SubscriptionCoordinator},

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -143,6 +143,7 @@ pub fn impl_enum(
         generics: syn::Generics::default(),
         interfaces: None,
         include_type_generics: true,
+        include_struct_fields: false,
         generic_scalar: true,
         no_async: attrs.no_async.is_some(),
     };

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -143,6 +143,7 @@ pub fn impl_input_object(
         generics: ast.generics,
         interfaces: None,
         include_type_generics: true,
+        include_struct_fields: false,
         generic_scalar: true,
         no_async: attrs.no_async.is_some(),
     };

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,10 +1,67 @@
 use crate::{
     result::{GraphQLScope, UnsupportedAttribute},
-    util::{self, span_container::SpanContainer},
+    util::{self, duplicate::Duplicate, span_container::SpanContainer},
 };
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{self, ext::IdentExt, spanned::Spanned, Data, Fields};
+
+pub fn create_field_definition(
+    field: syn::Field,
+    error: &GraphQLScope,
+) -> Option<util::GraphQLTypeDefinitionField> {
+    let span = field.span();
+    let field_attrs = match util::FieldAttributes::from_attrs(
+        &field.attrs,
+        util::FieldAttributeParseMode::Object,
+    ) {
+        Ok(attrs) => attrs,
+        Err(e) => {
+            proc_macro_error::emit_error!(e);
+            return None;
+        }
+    };
+
+    if field_attrs.skip.is_some() {
+        return None;
+    }
+
+    let field_name = &field.ident.unwrap();
+    let name = field_attrs
+        .name
+        .clone()
+        .map(SpanContainer::into_inner)
+        .unwrap_or_else(|| util::to_camel_case(&field_name.unraw().to_string()));
+
+    if name.starts_with("__") {
+        error.no_double_underscore(if let Some(name) = field_attrs.name {
+            name.span_ident()
+        } else {
+            field_name.span()
+        });
+    }
+
+    if let Some(default) = field_attrs.default {
+        error.unsupported_attribute_within(default.span_ident(), UnsupportedAttribute::Default);
+    }
+
+    let resolver_code = quote!(
+        &self . #field_name
+    );
+
+    Some(util::GraphQLTypeDefinitionField {
+        name,
+        _type: field.ty,
+        args: Vec::new(),
+        description: field_attrs.description.map(SpanContainer::into_inner),
+        deprecation: field_attrs.deprecation.map(SpanContainer::into_inner),
+        resolver_code,
+        default: None,
+        is_type_inferred: true,
+        is_async: false,
+        span,
+    })
+}
 
 pub fn build_derive_object(
     ast: syn::DeriveInput,
@@ -32,63 +89,16 @@ pub fn build_derive_object(
 
     let fields = struct_fields
         .into_iter()
-        .filter_map(|field| {
-            let span = field.span();
-            let field_attrs = match util::FieldAttributes::from_attrs(
-                &field.attrs,
-                util::FieldAttributeParseMode::Object,
-            ) {
-                Ok(attrs) => attrs,
-                Err(e) => {
-                    proc_macro_error::emit_error!(e);
-                    return None;
-                }
-            };
-
-            if field_attrs.skip.is_some() {
-                return None;
-            }
-
-            let field_name = &field.ident.unwrap();
-            let name = field_attrs
-                .name
-                .clone()
-                .map(SpanContainer::into_inner)
-                .unwrap_or_else(|| util::to_camel_case(&field_name.unraw().to_string()));
-
-            if name.starts_with("__") {
-                error.no_double_underscore(if let Some(name) = field_attrs.name {
-                    name.span_ident()
-                } else {
-                    field_name.span()
-                });
-            }
-
-            if let Some(default) = field_attrs.default {
-                error.unsupported_attribute_within(
-                    default.span_ident(),
-                    UnsupportedAttribute::Default,
-                );
-            }
-
-            let resolver_code = quote!(
-                &self . #field_name
-            );
-
-            Some(util::GraphQLTypeDefinitionField {
-                name,
-                _type: field.ty,
-                args: Vec::new(),
-                description: field_attrs.description.map(SpanContainer::into_inner),
-                deprecation: field_attrs.deprecation.map(SpanContainer::into_inner),
-                resolver_code,
-                default: None,
-                is_type_inferred: true,
-                is_async: false,
-                span,
-            })
-        })
+        .filter_map(|field| create_field_definition(field, &error))
         .collect::<Vec<_>>();
+
+    if let Some(duplicates) = Duplicate::find_by_key(&fields, |field| field.name.as_str()) {
+        error.duplicate(duplicates.iter());
+    }
+
+    if fields.is_empty() {
+        error.not_empty(ast_span);
+    }
 
     // Early abort after checking all fields
     proc_macro_error::abort_if_dirty();
@@ -99,22 +109,12 @@ pub fn build_derive_object(
         });
     }
 
-    if let Some(duplicates) =
-        crate::util::duplicate::Duplicate::find_by_key(&fields, |field| field.name.as_str())
-    {
-        error.duplicate(duplicates.iter());
-    }
-
     if name.starts_with("__") && !is_internal {
         error.no_double_underscore(if let Some(name) = attrs.name {
             name.span_ident()
         } else {
             ident.span()
         });
-    }
-
-    if fields.is_empty() {
-        error.not_empty(ast_span);
     }
 
     // Early abort after GraphQL properties
@@ -130,10 +130,64 @@ pub fn build_derive_object(
         generics: ast.generics,
         interfaces: None,
         include_type_generics: true,
+        include_struct_fields: false,
         generic_scalar: true,
         no_async: attrs.no_async.is_some(),
     };
 
     let juniper_crate_name = if is_internal { "crate" } else { "juniper" };
     Ok(definition.into_tokens(juniper_crate_name))
+}
+
+pub fn build_derive_object_info(
+    ast: syn::DeriveInput,
+    is_internal: bool,
+    error: GraphQLScope,
+) -> syn::Result<TokenStream> {
+    let ast_span = ast.span();
+    let struct_fields = match ast.data {
+        Data::Struct(data) => match data.fields {
+            Fields::Named(fields) => fields.named,
+            _ => return Err(error.custom_error(ast_span, "only named fields are allowed")),
+        },
+        _ => return Err(error.custom_error(ast_span, "can only be applied to structs")),
+    };
+
+    // Parse attributes.
+    let attrs = util::ObjectInfoAttributes::from_attrs(&ast.attrs)?;
+
+    let ident = &ast.ident;
+    let fields = struct_fields
+        .into_iter()
+        .filter_map(|field| create_field_definition(field, &error))
+        .collect::<Vec<_>>();
+
+    if let Some(duplicates) = Duplicate::find_by_key(&fields, |field| field.name.as_str()) {
+        error.duplicate(duplicates.iter());
+    }
+
+    if fields.is_empty() {
+        error.not_empty(ast_span);
+    }
+
+    // Early abort after checking all fields
+    proc_macro_error::abort_if_dirty();
+
+    let definition = util::GraphQLTypeDefiniton {
+        name: ident.unraw().to_string(),
+        _type: syn::parse_str(&ast.ident.to_string()).unwrap(),
+        context: attrs.context.map(SpanContainer::into_inner),
+        scalar: attrs.scalar.map(SpanContainer::into_inner),
+        description: None,
+        fields,
+        generics: ast.generics,
+        interfaces: None,
+        include_type_generics: true,
+        include_struct_fields: false,
+        generic_scalar: true,
+        no_async: false,
+    };
+
+    let juniper_crate_name = if is_internal { "crate" } else { "juniper" };
+    Ok(definition.into_info_tokens(juniper_crate_name))
 }

--- a/juniper_codegen/src/derive_union.rs
+++ b/juniper_codegen/src/derive_union.rs
@@ -173,6 +173,7 @@ pub fn build_derive_union(
         generics: ast.generics,
         interfaces: None,
         include_type_generics: true,
+        include_struct_fields: false,
         generic_scalar: true,
         no_async: attrs.no_async.is_some(),
     };

--- a/juniper_codegen/src/impl_object.rs
+++ b/juniper_codegen/src/impl_object.rs
@@ -226,6 +226,7 @@ fn create(
             None
         },
         include_type_generics: false,
+        include_struct_fields: _impl.attrs.derive_fields.is_some(),
         generic_scalar: false,
         no_async: _impl.attrs.no_async.is_some(),
     };

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -94,6 +94,28 @@ pub fn derive_object_internal(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_error]
+#[proc_macro_derive(GraphQLObjectInfo, attributes(graphql))]
+pub fn derive_object_info(input: TokenStream) -> TokenStream {
+    let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
+    let gen = derive_object::build_derive_object_info(ast, false, GraphQLScope::DeriveObjectInfo);
+    match gen {
+        Ok(gen) => gen.into(),
+        Err(err) => proc_macro_error::abort!(err),
+    }
+}
+
+#[proc_macro_error]
+#[proc_macro_derive(GraphQLObjectInfoInternal, attributes(graphql))]
+pub fn derive_object_info_internal(input: TokenStream) -> TokenStream {
+    let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
+    let gen = derive_object::build_derive_object_info(ast, true, GraphQLScope::DeriveObjectInfo);
+    match gen {
+        Ok(gen) => gen.into(),
+        Err(err) => proc_macro_error::abort!(err),
+    }
+}
+
+#[proc_macro_error]
 #[proc_macro_derive(GraphQLUnion, attributes(graphql))]
 pub fn derive_union(input: TokenStream) -> TokenStream {
     let ast = syn::parse::<syn::DeriveInput>(input).unwrap();
@@ -472,7 +494,7 @@ pub fn graphql_object_internal(args: TokenStream, input: TokenStream) -> TokenSt
 /// struct UserID(String);
 ///
 /// #[juniper::graphql_scalar(
-///     // You can rename the type for GraphQL by specifying the name here.    
+///     // You can rename the type for GraphQL by specifying the name here.
 ///     name = "MyName",
 ///     // You can also specify a description here.
 ///     // If present, doc comments will be ignored.

--- a/juniper_codegen/src/result.rs
+++ b/juniper_codegen/src/result.rs
@@ -10,6 +10,7 @@ pub const GRAPHQL_SPECIFICATION: &'static str = "https://spec.graphql.org/June20
 #[allow(unused_variables)]
 pub enum GraphQLScope {
     DeriveObject,
+    DeriveObjectInfo,
     DeriveInputObject,
     DeriveUnion,
     DeriveEnum,
@@ -22,7 +23,9 @@ pub enum GraphQLScope {
 impl GraphQLScope {
     pub fn specification_section(&self) -> &str {
         match self {
-            GraphQLScope::DeriveObject | GraphQLScope::ImplObject => "#sec-Objects",
+            GraphQLScope::DeriveObject
+            | GraphQLScope::DeriveObjectInfo
+            | GraphQLScope::ImplObject => "#sec-Objects",
             GraphQLScope::DeriveInputObject => "#sec-Input-Objects",
             GraphQLScope::DeriveUnion | GraphQLScope::ImplUnion => "#sec-Unions",
             GraphQLScope::DeriveEnum => "#sec-Enums",
@@ -34,7 +37,9 @@ impl GraphQLScope {
 impl fmt::Display for GraphQLScope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match self {
-            GraphQLScope::DeriveObject | GraphQLScope::ImplObject => "object",
+            GraphQLScope::DeriveObject
+            | GraphQLScope::DeriveObjectInfo
+            | GraphQLScope::ImplObject => "object",
             GraphQLScope::DeriveInputObject => "input object",
             GraphQLScope::DeriveUnion | GraphQLScope::ImplUnion => "union",
             GraphQLScope::DeriveEnum => "enum",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
+edition = "2018"
 merge_imports = true
 use_field_init_shorthand = true


### PR DESCRIPTION
This PR enhance the `graphql_object` macro to optionally derive field resolvers for fields defined in the object type struct.

```rust
#[derive(GraphQLObjectInfo)]
#[graphql(scalar = DefaultScalarValue)]
struct Obj {
    regular_field: bool,
}

#[juniper::graphql_object(derive_fields)]
impl Obj {
    fn custom_field_resolve() -> bool {
        true
    }
}
```

---

Related: #553 