### PR TITLE
Support "Content-Type: application/graphql" (#426)

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -67,6 +67,10 @@ See [#618](https://github.com/graphql-rust/juniper/pull/618).
   `#[graphql(arguments(argA(name = "test")))]`
   (see [#631](https://github.com/graphql-rust/juniper/pull/631))
 
+- Integration tests:
+  Rename `http::tests::HTTPIntegration` as `http::tests::HttpIntegration`
+  and add support for `application/graphql` POST request.
+
 # [[0.14.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper-0.14.2)
 
 - Fix incorrect validation with non-executed operations [#455](https://github.com/graphql-rust/juniper/issues/455)

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `juniper_hyper::graphiql` now requires a second parameter for subscriptions.
 - `juniper_hyper::graphql` now executes the schema asynchronously. For blocking synchronous execution consider `juniper_hyper::graphql_sync` for use.
-- `400 Bad Request` is returned if POST HTTP request contains no or invalid `Content-Type` header.
+- `400 Bad Request` is now returned if POST HTTP request contains no or invalid `Content-Type` header.
 
 # [[0.5.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_hyper-0.5.2)
 

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Breaking Changes
 
-- `juniper_hyper::graphiql` now requires a second parameter for subscriptions
+- `juniper_hyper::graphiql` now requires a second parameter for subscriptions.
+- `juniper_hyper::graphql` now executes the schema asynchronously. For blocking synchronous execution consider `juniper_hyper::graphql_sync` for use.
+- `400 Bad Request` is returned if POST HTTP request contains no or invalid `Content-Type` header.
 
 # [[0.5.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_hyper-0.5.2)
 

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -321,17 +321,30 @@ mod tests {
 
     struct TestHyperIntegration;
 
-    impl http_tests::HTTPIntegration for TestHyperIntegration {
+    impl http_tests::HttpIntegration for TestHyperIntegration {
         fn get(&self, url: &str) -> http_tests::TestResponse {
             let url = format!("http://127.0.0.1:3001/graphql{}", url);
             make_test_response(reqwest::get(&url).expect(&format!("failed GET {}", url)))
         }
 
-        fn post(&self, url: &str, body: &str) -> http_tests::TestResponse {
+        fn post_json(&self, url: &str, body: &str) -> http_tests::TestResponse {
             let url = format!("http://127.0.0.1:3001/graphql{}", url);
             let client = reqwest::Client::new();
             let res = client
                 .post(&url)
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body.to_string())
+                .send()
+                .expect(&format!("failed POST {}", url));
+            make_test_response(res)
+        }
+
+        fn post_graphql(&self, url: &str, body: &str) -> http_tests::TestResponse {
+            let url = format!("http://127.0.0.1:3001/graphql{}", url);
+            let client = reqwest::Client::new();
+            let res = client
+                .post(&url)
+                .header(reqwest::header::CONTENT_TYPE, "application/graphql")
                 .body(body.to_string())
                 .send()
                 .expect(&format!("failed POST {}", url));

--- a/juniper_iron/CHANGELOG.md
+++ b/juniper_iron/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Breaking Changes
 
-- `juniper_iron::GraphiQLHandler::new` now requires a second parameter for subscriptions
+- `juniper_iron::GraphiQLHandler::new` now requires a second parameter for subscriptions.
+- `400 Bad Request` is now returned if POST HTTP request contains no or invalid `Content-Type` header.
 
 # [[0.6.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_iron-0.6.2)
 

--- a/juniper_iron/src/lib.rs
+++ b/juniper_iron/src/lib.rs
@@ -114,10 +114,17 @@ extern crate iron_test;
 #[cfg(test)]
 extern crate url;
 
-use iron::{itry, method, middleware::Handler, mime::Mime, prelude::*, status};
+use iron::{
+    headers::ContentType,
+    itry, method,
+    middleware::Handler,
+    mime::{Mime, TopLevel},
+    prelude::*,
+    status,
+};
 use urlencoded::{UrlDecodingError, UrlEncodedQuery};
 
-use std::{error::Error, fmt, io::Read};
+use std::{error::Error, fmt, io::Read, ops::Deref as _};
 
 use serde_json::error::Error as SerdeError;
 
@@ -228,30 +235,39 @@ where
     }
 
     fn handle_get(&self, req: &mut Request) -> IronResult<GraphQLBatchRequest<S>> {
-        let url_query_string = req
+        let url_query = req
             .get_mut::<UrlEncodedQuery>()
             .map_err(GraphQLIronError::Url)?;
 
-        let input_query = parse_url_param(url_query_string.remove("query"))?
+        let query = parse_url_param(url_query.remove("query"))?
             .ok_or_else(|| GraphQLIronError::InvalidData("No query provided"))?;
-        let operation_name = parse_url_param(url_query_string.remove("operationName"))?;
-        let variables = parse_variable_param(url_query_string.remove("variables"))?;
+        let operation_name = parse_url_param(url_query.remove("operationName"))?;
+        let variables = parse_variable_param(url_query.remove("variables"))?;
 
         Ok(GraphQLBatchRequest::Single(http::GraphQLRequest::new(
-            input_query,
+            query,
             operation_name,
             variables,
         )))
     }
 
-    fn handle_post(&self, req: &mut Request) -> IronResult<GraphQLBatchRequest<S>> {
-        let mut request_payload = String::new();
-        itry!(req.body.read_to_string(&mut request_payload));
+    fn handle_post_json(&self, req: &mut Request) -> IronResult<GraphQLBatchRequest<S>> {
+        let mut payload = String::new();
+        itry!(req.body.read_to_string(&mut payload));
 
         Ok(
-            serde_json::from_str::<GraphQLBatchRequest<S>>(request_payload.as_str())
+            serde_json::from_str::<GraphQLBatchRequest<S>>(payload.as_str())
                 .map_err(GraphQLIronError::Serde)?,
         )
+    }
+
+    fn handle_post_graphql(&self, req: &mut Request) -> IronResult<GraphQLBatchRequest<S>> {
+        let mut payload = String::new();
+        itry!(req.body.read_to_string(&mut payload));
+
+        Ok(GraphQLBatchRequest::Single(http::GraphQLRequest::new(
+            payload, None, None,
+        )))
     }
 
     fn execute_sync(
@@ -313,7 +329,14 @@ where
 
         let graphql_request = match req.method {
             method::Get => self.handle_get(&mut req)?,
-            method::Post => self.handle_post(&mut req)?,
+            method::Post => match req.headers.get::<ContentType>().map(ContentType::deref) {
+                Some(Mime(TopLevel::Application, sub_lvl, _)) => match sub_lvl.as_str() {
+                    "json" => self.handle_post_json(&mut req)?,
+                    "graphql" => self.handle_post_graphql(&mut req)?,
+                    _ => return Ok(Response::with(status::BadRequest)),
+                },
+                _ => return Ok(Response::with(status::BadRequest)),
+            },
             _ => return Ok(Response::with(status::MethodNotAllowed)),
         };
 

--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Compatibility with the latest `juniper`.
 - Rocket integration does not require default features.
+- Support `application/graphql` POST requests.
 
 ## Breaking Changes
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -456,14 +456,23 @@ mod tests {
         client: Client,
     }
 
-    impl http_tests::HTTPIntegration for TestRocketIntegration {
+    impl http_tests::HttpIntegration for TestRocketIntegration {
         fn get(&self, url: &str) -> http_tests::TestResponse {
             let req = &self.client.get(url);
             make_test_response(req)
         }
 
-        fn post(&self, url: &str, body: &str) -> http_tests::TestResponse {
+        fn post_json(&self, url: &str, body: &str) -> http_tests::TestResponse {
             let req = &self.client.post(url).header(ContentType::JSON).body(body);
+            make_test_response(req)
+        }
+
+        fn post_graphql(&self, url: &str, body: &str) -> http_tests::TestResponse {
+            let req = &self
+                .client
+                .post(url)
+                .header(ContentType::new("application", "graphql"))
+                .body(body);
             make_test_response(req)
         }
     }

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -47,7 +47,7 @@ use rocket::{
     request::{FormItems, FromForm, FromFormValue},
     response::{content, Responder, Response},
     Data,
-    Outcome::{Failure, Forward, Success},
+    Outcome::{Forward, Success},
     Request,
 };
 
@@ -271,20 +271,26 @@ where
 {
     type Error = String;
 
-    fn from_data(request: &Request, data: Data) -> FromDataOutcome<Self, Self::Error> {
-        if !request.content_type().map_or(false, |ct| ct.is_json()) {
-            return Forward(data);
-        }
+    fn from_data(req: &Request, data: Data) -> FromDataOutcome<Self, Self::Error> {
+        let content_type = req
+            .content_type()
+            .map(|ct| (ct.top().as_str(), ct.sub().as_str()));
+        let is_json = match content_type {
+            Some(("application", "json")) => true,
+            Some(("application", "graphql")) => false,
+            _ => return Forward(data),
+        };
 
         let mut body = String::new();
-        if let Err(e) = data.open().read_to_string(&mut body) {
-            return Failure((Status::InternalServerError, format!("{:?}", e)));
-        }
+        data.open()
+            .read_to_string(&mut body)
+            .map_err(|e| Err((Status::InternalServerError, format!("{:?}", e))))?;
 
-        match serde_json::from_str(&body) {
-            Ok(value) => Success(GraphQLRequest(value)),
-            Err(failure) => Failure((Status::BadRequest, format!("{}", failure))),
-        }
+        Success(GraphQLRequest(if is_json {
+            serde_json::from_str(&body).map_err(|e| Err((Status::BadRequest, format!("{}", e))))?
+        } else {
+            GraphQLBatchRequest::Single(http::GraphQLRequest::new(body, None, None))
+        }))
     }
 }
 

--- a/juniper_rocket_async/CHANGELOG.md
+++ b/juniper_rocket_async/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Compatibility with the latest `juniper`.
 - Rocket integration does not require default features.
+- Support `application/graphql` POST requests.
 
 # [[0.5.1] 2019-10-24](https://github.com/graphql-rust/juniper/releases/tag/juniper_rocket-0.5.1)
 

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -495,15 +495,25 @@ mod tests {
         client: Client,
     }
 
-    impl http_tests::HTTPIntegration for TestRocketIntegration {
+    impl http_tests::HttpIntegration for TestRocketIntegration {
         fn get(&self, url: &str) -> http_tests::TestResponse {
             let req = self.client.get(url);
             let req = futures::executor::block_on(req.dispatch());
             futures::executor::block_on(make_test_response(req))
         }
 
-        fn post(&self, url: &str, body: &str) -> http_tests::TestResponse {
+        fn post_json(&self, url: &str, body: &str) -> http_tests::TestResponse {
             let req = self.client.post(url).header(ContentType::JSON).body(body);
+            let req = futures::executor::block_on(req.dispatch());
+            futures::executor::block_on(make_test_response(req))
+        }
+
+        fn post_graphql(&self, url: &str, body: &str) -> http_tests::TestResponse {
+            let req = self
+                .client
+                .post(url)
+                .header(ContentType::new("application", "graphql"))
+                .body(body);
             let req = futures::executor::block_on(req.dispatch());
             futures::executor::block_on(make_test_response(req))
         }

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -294,12 +294,17 @@ where
 {
     type Error = String;
 
-    fn from_data(request: &Request, data: Data) -> FromDataFuture<'static, Self, Self::Error> {
+    fn from_data(req: &Request, data: Data) -> FromDataFuture<'static, Self, Self::Error> {
         use tokio::io::AsyncReadExt as _;
 
-        if !request.content_type().map_or(false, |ct| ct.is_json()) {
-            return Box::pin(async move { Forward(data) });
-        }
+        let content_type = req
+            .content_type()
+            .map(|ct| (ct.top().as_str(), ct.sub().as_str()));
+        let is_json = match content_type {
+            Some(("application", "json")) => true,
+            Some(("application", "graphql")) => false,
+            _ => return Box::pin(async move { Forward(data) }),
+        };
 
         Box::pin(async move {
             let mut body = String::new();
@@ -308,10 +313,14 @@ where
                 return Failure((Status::InternalServerError, format!("{:?}", e)));
             }
 
-            match serde_json::from_str(&body) {
-                Ok(value) => Success(GraphQLRequest(value)),
-                Err(failure) => Failure((Status::BadRequest, format!("{}", failure))),
-            }
+            Success(GraphQLRequest(if is_json {
+                match serde_json::from_str(&body) {
+                    Ok(req) => req,
+                    Err(e) => return Failure((Status::BadRequest, format!("{}", e))),
+                }
+            } else {
+                GraphQLBatchRequest::Single(http::GraphQLRequest::new(body, None, None))
+            }))
         })
     }
 }

--- a/juniper_warp/CHANGELOG.md
+++ b/juniper_warp/CHANGELOG.md
@@ -6,10 +6,11 @@ to `juniper` to be reused in other http integrations, since this implementation 
 
 ## Breaking Changes
 
-- Update `playground_filter` to support subscription endpoint URLs
-- Update `warp` to 0.2
+- Update `playground_filter` to support subscription endpoint URLs.
+- Update `warp` to 0.2.
 - Rename synchronous `execute` to `execute_sync`, add asynchronous `execute`
-- `juniper_warp::graphiql_filter` now requires a second parameter for subscriptions
+- `juniper_warp::graphiql_filter` now requires a second parameter for subscriptions.
+- `make_graphql_filter` and `make_graphql_filter_sync` now ignore POST HTTP requests with no or invalid `Content-Type` header.
 
 # [[0.5.2] 2019-12-16](https://github.com/graphql-rust/juniper/releases/tag/juniper_warp-0.5.2)
 

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -12,18 +12,19 @@ edition = "2018"
 subscriptions = ["juniper_subscriptions"]
 
 [dependencies]
-warp = "0.2"
+bytes = "0.5"
+failure = "0.1.7"
 futures = "0.3.1"
 juniper = { version = "0.14.2", path = "../juniper", default-features = false  }
-juniper_subscriptions = { path = "../juniper_subscriptions", optional = true}
-tokio = { version = "0.2", features = ["rt-core", "blocking"] }
+juniper_subscriptions = { path = "../juniper_subscriptions", optional = true }
 serde = { version = "1.0.75", features = ["derive"] }
 serde_json = "1.0.24"
-failure = "0.1.7"
+tokio = { version = "0.2", features = ["blocking", "rt-core"] }
+warp = "0.2"
 
 [dev-dependencies]
-juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }
 env_logger = "0.5.11"
+juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }
 log = "0.4.3"
 percent-encoding = "1.0"
-tokio = { version = "0.2", features = ["rt-core", "macros", "blocking"] }
+tokio = { version = "0.2", features = ["blocking", "macros", "rt-core"] }

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -40,12 +40,16 @@ Check the LICENSE file for details.
 #![deny(warnings)]
 #![doc(html_root_url = "https://docs.rs/juniper_warp/0.2.0")]
 
-use std::{pin::Pin, sync::Arc};
+use std::{collections::HashMap, str, sync::Arc};
 
-use futures::{Future, FutureExt as _, TryFutureExt};
-use juniper::{http::GraphQLBatchRequest, ScalarValue};
+use bytes::Bytes;
+use futures::{FutureExt as _, TryFutureExt};
+use juniper::{
+    http::{GraphQLBatchRequest, GraphQLRequest},
+    ScalarValue,
+};
 use tokio::task;
-use warp::{filters::BoxedFilter, Filter};
+use warp::{body, filters::BoxedFilter, header, http, query, Filter};
 
 /// Make a filter for graphql queries/mutations.
 ///
@@ -110,7 +114,7 @@ use warp::{filters::BoxedFilter, Filter};
 pub fn make_graphql_filter<Query, Mutation, Subscription, Context, S>(
     schema: juniper::RootNode<'static, Query, Mutation, Subscription, S>,
     context_extractor: BoxedFilter<(Context,)>,
-) -> BoxedFilter<(warp::http::Response<Vec<u8>>,)>
+) -> BoxedFilter<(http::Response<Vec<u8>>,)>
 where
     S: ScalarValue + Send + Sync + 'static,
     Context: Send + Sync + 'static,
@@ -122,65 +126,90 @@ where
     Subscription::TypeInfo: Send + Sync,
 {
     let schema = Arc::new(schema);
-    let post_schema = schema.clone();
+    let post_json_schema = schema.clone();
+    let post_graphql_schema = schema.clone();
 
-    let handle_post_request = move |context: Context, request: GraphQLBatchRequest<S>| {
-        let schema = post_schema.clone();
-
-        Box::pin(async move {
-            let res = request.execute(&schema, &context).await;
+    let handle_post_json_request = move |context: Context, req: GraphQLBatchRequest<S>| {
+        let schema = post_json_schema.clone();
+        async move {
+            let resp = req.execute(&schema, &context).await;
 
             Ok::<_, warp::Rejection>(build_response(
-                serde_json::to_vec(&res)
-                    .map(|json| (json, res.is_ok()))
+                serde_json::to_vec(&resp)
+                    .map(|json| (json, resp.is_ok()))
                     .map_err(Into::into),
             ))
-        })
+        }
     };
-
-    let post_filter = warp::post()
+    let post_json_filter = warp::post()
+        .and(header::exact_ignore_case(
+            "content-type",
+            "application/json",
+        ))
         .and(context_extractor.clone())
-        .and(warp::body::json())
-        .and_then(handle_post_request);
+        .and(body::json())
+        .and_then(handle_post_json_request);
 
-    let handle_get_request =
-        move |context: Context, mut request: std::collections::HashMap<String, String>| {
-            let schema = schema.clone();
+    let handle_post_graphql_request = move |context: Context, body: Bytes| {
+        let schema = post_graphql_schema.clone();
+        async move {
+            let query = str::from_utf8(body.as_ref()).map_err(|e| {
+                failure::format_err!("Request body query is not a valid UTF-8 string: {}", e)
+            })?;
+            let req = GraphQLRequest::new(query.into(), None, None);
 
-            async move {
-                let variables = match request.remove("variables") {
-                    None => None,
-                    Some(vs) => serde_json::from_str(&vs)?,
-                };
+            let resp = req.execute(&schema, &context).await;
 
-                let graphql_request = juniper::http::GraphQLRequest::new(
-                    request.remove("query").ok_or_else(|| {
-                        failure::format_err!("Missing GraphQL query string in query parameters")
-                    })?,
-                    request.get("operation_name").map(|s| s.to_owned()),
-                    variables,
-                );
+            Ok((serde_json::to_vec(&resp)?, resp.is_ok()))
+        }
+        .then(|res| async { Ok::<_, warp::Rejection>(build_response(res)) })
+    };
+    let post_graphql_filter = warp::post()
+        .and(header::exact_ignore_case(
+            "content-type",
+            "application/graphql",
+        ))
+        .and(context_extractor.clone())
+        .and(body::bytes())
+        .and_then(handle_post_graphql_request);
 
-                let response = graphql_request.execute(&schema, &context).await;
+    let handle_get_request = move |context: Context, mut qry: HashMap<String, String>| {
+        let schema = schema.clone();
+        async move {
+            let req = GraphQLRequest::new(
+                qry.remove("query").ok_or_else(|| {
+                    failure::format_err!("Missing GraphQL query string in query parameters")
+                })?,
+                qry.remove("operation_name"),
+                qry.remove("variables")
+                    .map(|vs| serde_json::from_str(&vs))
+                    .transpose()?,
+            );
 
-                Ok((serde_json::to_vec(&response)?, response.is_ok()))
-            }
-            .then(|result| async move { Ok::<_, warp::Rejection>(build_response(result)) })
-        };
+            let resp = req.execute(&schema, &context).await;
 
+            Ok((serde_json::to_vec(&resp)?, resp.is_ok()))
+        }
+        .then(|res| async move { Ok::<_, warp::Rejection>(build_response(res)) })
+    };
     let get_filter = warp::get()
         .and(context_extractor)
-        .and(warp::filters::query::query())
+        .and(query::query())
         .and_then(handle_get_request);
 
-    get_filter.or(post_filter).unify().boxed()
+    get_filter
+        .or(post_json_filter)
+        .unify()
+        .or(post_graphql_filter)
+        .unify()
+        .boxed()
 }
 
 /// Make a synchronous filter for graphql endpoint.
 pub fn make_graphql_filter_sync<Query, Mutation, Subscription, Context, S>(
     schema: juniper::RootNode<'static, Query, Mutation, Subscription, S>,
     context_extractor: BoxedFilter<(Context,)>,
-) -> BoxedFilter<(warp::http::Response<Vec<u8>>,)>
+) -> BoxedFilter<(http::Response<Vec<u8>>,)>
 where
     S: ScalarValue + Send + Sync + 'static,
     Context: Send + Sync + 'static,
@@ -189,104 +218,115 @@ where
     Subscription: juniper::GraphQLType<S, Context = Context, TypeInfo = ()> + Send + Sync + 'static,
 {
     let schema = Arc::new(schema);
-    let post_schema = schema.clone();
+    let post_json_schema = schema.clone();
+    let post_graphql_schema = schema.clone();
 
-    let handle_post_request =
-        move |context: Context, request: GraphQLBatchRequest<S>| -> Response {
-            let schema = post_schema.clone();
+    let handle_post_json_request = move |context: Context, req: GraphQLBatchRequest<S>| {
+        let schema = post_json_schema.clone();
+        async move {
+            let res = task::spawn_blocking(move || {
+                let resp = req.execute_sync(&schema, &context);
+                Ok((serde_json::to_vec(&resp)?, resp.is_ok()))
+            })
+            .await?;
 
-            Box::pin(
-                async move {
-                    let result = task::spawn_blocking(move || {
-                        let response = request.execute_sync(&schema, &context);
-                        Ok((serde_json::to_vec(&response)?, response.is_ok()))
-                    })
-                    .await?;
-
-                    Ok(build_response(result))
-                }
-                .map_err(|e: task::JoinError| warp::reject::custom(JoinError(e))),
-            )
-        };
-
-    let post_filter = warp::post()
-        .and(context_extractor.clone())
-        .and(warp::body::json())
-        .and_then(handle_post_request);
-
-    let handle_get_request = move |context: Context,
-                                   mut request: std::collections::HashMap<String, String>|
-          -> Response {
-        let schema = schema.clone();
-
-        Box::pin(
-            async move {
-                let result = task::spawn_blocking(move || {
-                    let variables = match request.remove("variables") {
-                        None => None,
-                        Some(vs) => serde_json::from_str(&vs)?,
-                    };
-
-                    let graphql_request = juniper::http::GraphQLRequest::new(
-                        request.remove("query").ok_or_else(|| {
-                            failure::format_err!("Missing GraphQL query string in query parameters")
-                        })?,
-                        request.get("operation_name").map(|s| s.to_owned()),
-                        variables,
-                    );
-
-                    let response = graphql_request.execute_sync(&schema, &context);
-                    Ok((serde_json::to_vec(&response)?, response.is_ok()))
-                })
-                .await?;
-
-                Ok(build_response(result))
-            }
-            .map_err(|e: task::JoinError| warp::reject::custom(JoinError(e))),
-        )
+            Ok(build_response(res))
+        }
+        .map_err(|e: task::JoinError| warp::reject::custom(JoinError(e)))
     };
+    let post_json_filter = warp::post()
+        .and(header::exact_ignore_case(
+            "content-type",
+            "application/json",
+        ))
+        .and(context_extractor.clone())
+        .and(body::json())
+        .and_then(handle_post_json_request);
 
+    let handle_post_graphql_request = move |context: Context, body: Bytes| {
+        let schema = post_graphql_schema.clone();
+        async move {
+            let res = task::spawn_blocking(move || {
+                let query = str::from_utf8(body.as_ref()).map_err(|e| {
+                    failure::format_err!("Request body is not a valid UTF-8 string: {}", e)
+                })?;
+                let req = GraphQLRequest::new(query.into(), None, None);
+
+                let resp = req.execute_sync(&schema, &context);
+                Ok((serde_json::to_vec(&resp)?, resp.is_ok()))
+            })
+            .await?;
+
+            Ok(build_response(res))
+        }
+        .map_err(|e: task::JoinError| warp::reject::custom(JoinError(e)))
+    };
+    let post_graphql_filter = warp::post()
+        .and(header::exact_ignore_case(
+            "content-type",
+            "application/graphql",
+        ))
+        .and(context_extractor.clone())
+        .and(body::bytes())
+        .and_then(handle_post_graphql_request);
+
+    let handle_get_request = move |context: Context, mut qry: HashMap<String, String>| {
+        let schema = schema.clone();
+        async move {
+            let res = task::spawn_blocking(move || {
+                let req = GraphQLRequest::new(
+                    qry.remove("query").ok_or_else(|| {
+                        failure::format_err!("Missing GraphQL query string in query parameters")
+                    })?,
+                    qry.remove("operation_name"),
+                    qry.remove("variables")
+                        .map(|vs| serde_json::from_str(&vs))
+                        .transpose()?,
+                );
+
+                let resp = req.execute_sync(&schema, &context);
+                Ok((serde_json::to_vec(&resp)?, resp.is_ok()))
+            })
+            .await?;
+
+            Ok(build_response(res))
+        }
+        .map_err(|e: task::JoinError| warp::reject::custom(JoinError(e)))
+    };
     let get_filter = warp::get()
         .and(context_extractor)
-        .and(warp::filters::query::query())
+        .and(query::query())
         .and_then(handle_get_request);
 
-    get_filter.or(post_filter).unify().boxed()
+    get_filter
+        .or(post_json_filter)
+        .unify()
+        .or(post_graphql_filter)
+        .unify()
+        .boxed()
 }
 
-/// Error raised by `tokio_threadpool` if the thread pool
-/// has been shutdown
+/// Error raised by `tokio_threadpool` if the thread pool has been shutdown.
 ///
-/// Wrapper type is needed as inner type does not implement `warp::reject::Reject`
+/// Wrapper type is needed as inner type does not implement `warp::reject::Reject`.
+#[derive(Debug)]
 pub struct JoinError(task::JoinError);
 
 impl warp::reject::Reject for JoinError {}
 
-impl std::fmt::Debug for JoinError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "JoinError({:?})", self.0)
-    }
-}
-
-fn build_response(
-    response: Result<(Vec<u8>, bool), failure::Error>,
-) -> warp::http::Response<Vec<u8>> {
+fn build_response(response: Result<(Vec<u8>, bool), failure::Error>) -> http::Response<Vec<u8>> {
     match response {
-        Ok((body, is_ok)) => warp::http::Response::builder()
+        Ok((body, is_ok)) => http::Response::builder()
             .status(if is_ok { 200 } else { 400 })
             .header("content-type", "application/json")
             .body(body)
             .expect("response is valid"),
-        Err(_) => warp::http::Response::builder()
-            .status(warp::http::StatusCode::INTERNAL_SERVER_ERROR)
+        Err(_) => http::Response::builder()
+            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
             .body(Vec::new())
             .expect("status code is valid"),
     }
 }
-
-type Response = Pin<
-    Box<dyn Future<Output = Result<warp::http::Response<Vec<u8>>, warp::reject::Rejection>> + Send>,
->;
 
 /// Create a filter that replies with an HTML page containing GraphiQL. This does not handle routing, so you can mount it on any endpoint.
 ///
@@ -318,7 +358,7 @@ type Response = Pin<
 pub fn graphiql_filter(
     graphql_endpoint_url: &'static str,
     subscriptions_endpoint: Option<&'static str>,
-) -> warp::filters::BoxedFilter<(warp::http::Response<Vec<u8>>,)> {
+) -> warp::filters::BoxedFilter<(http::Response<Vec<u8>>,)> {
     warp::any()
         .map(move || graphiql_response(graphql_endpoint_url, subscriptions_endpoint))
         .boxed()
@@ -327,8 +367,8 @@ pub fn graphiql_filter(
 fn graphiql_response(
     graphql_endpoint_url: &'static str,
     subscriptions_endpoint: Option<&'static str>,
-) -> warp::http::Response<Vec<u8>> {
-    warp::http::Response::builder()
+) -> http::Response<Vec<u8>> {
+    http::Response::builder()
         .header("content-type", "text/html;charset=utf-8")
         .body(
             juniper::http::graphiql::graphiql_source(graphql_endpoint_url, subscriptions_endpoint)
@@ -341,7 +381,7 @@ fn graphiql_response(
 pub fn playground_filter(
     graphql_endpoint_url: &'static str,
     subscriptions_endpoint_url: Option<&'static str>,
-) -> warp::filters::BoxedFilter<(warp::http::Response<Vec<u8>>,)> {
+) -> warp::filters::BoxedFilter<(http::Response<Vec<u8>>,)> {
     warp::any()
         .map(move || playground_response(graphql_endpoint_url, subscriptions_endpoint_url))
         .boxed()
@@ -350,8 +390,8 @@ pub fn playground_filter(
 fn playground_response(
     graphql_endpoint_url: &'static str,
     subscriptions_endpoint_url: Option<&'static str>,
-) -> warp::http::Response<Vec<u8>> {
-    warp::http::Response::builder()
+) -> http::Response<Vec<u8>> {
+    http::Response::builder()
         .header("content-type", "text/html;charset=utf-8")
         .body(
             juniper::http::playground::playground_source(
@@ -794,7 +834,7 @@ mod tests {
 //    type Schema =
 //        juniper::RootNode<'static, Query, EmptyMutation<Database>, EmptySubscription<Database>>;
 //
-//    fn warp_server() -> warp::filters::BoxedFilter<(warp::http::Response<Vec<u8>>,)> {
+//    fn warp_server() -> warp::filters::BoxedFilter<(http::Response<Vec<u8>>,)> {
 //        let schema: Schema = RootNode::new(
 //            Query,
 //            EmptyMutation::<Database>::new(),
@@ -808,11 +848,11 @@ mod tests {
 //    }
 //
 //    struct TestWarpIntegration {
-//        filter: warp::filters::BoxedFilter<(warp::http::Response<Vec<u8>>,)>,
+//        filter: warp::filters::BoxedFilter<(http::Response<Vec<u8>>,)>,
 //    }
 //
 //    // This can't be implemented with the From trait since TestResponse is not defined in this crate.
-//    fn test_response_from_http_response(response: warp::http::Response<Vec<u8>>) -> TestResponse {
+//    fn test_response_from_http_response(response: http::Response<Vec<u8>>) -> TestResponse {
 //        TestResponse {
 //            status_code: response.status().as_u16() as i32,
 //            body: Some(String::from_utf8(response.body().to_owned()).unwrap()),
@@ -840,7 +880,7 @@ mod tests {
 //                .filter(&self.filter)
 //                .await
 //                .unwrap_or_else(|rejection| {
-//                    warp::http::Response::builder()
+//                    http::Response::builder()
 //                        .status(rejection.status())
 //                        .header("content-type", "application/json")
 //                        .body(Vec::new())
@@ -858,7 +898,7 @@ mod tests {
 //                .filter(&self.filter)
 //                .await
 //                .unwrap_or_else(|rejection| {
-//                    warp::http::Response::builder()
+//                    http::Response::builder()
 //                        .status(rejection.status())
 //                        .header("content-type", "application/json")
 //                        .body(Vec::new())


### PR DESCRIPTION
Fixes #426  
Extends #442

This PR is majorly based on @sd2k's work in #442 and adds support of `Content-Type: application/graphql` POST requests to all integration crates.

Also, some refactorings are made across codebase for better readability, and removing redudant boxing here and there.

### `juniper`
- [x] Refactor `HTTPIntegration` to support `application/graphql` requests:
    - rename `HTTPIntegration` as `HttpIntegration`;
    - rename `post` as `post_json` method;
    - add `post_graphql` method.
- [x] Add `test_graphql_post` and `test_invalid_graphql_post`.
- [x] Update CHANGELOG/docs/examples.

### `juniper_actix`
- [x] Update tests to support new `HttpIntegration`.
- [x] Fix `application/graphql` POST request support:
    - At the moment it deserializes request's body as JSON, which is not correct.
- [x] ~~Update CHANGELOG/docs/examples.~~ (initial release, so not CHANGELOG yet)

### `juniper_hyper`
- [x] Update tests to support new `HttpIntegration`.
- [x] Run tests for both sync and async versions.
- [x] Support `application/graphql` POST request:
    - Return `400 Bad Request` if `Content-Type` is absent or invalid.
- [x] Make async handler a default one (rename `graphql_async` -> `graphql` and `graphql` -> `graphql_sync`).
- [x] Update CHANGELOG/docs/examples.

### `juniper_iron`
- [x] Update tests to support new `HttpIntegration`.
- [x] Support `application/graphql` POST request:
    - Return `400 Bad Request` if `Content-Type` is absent or invalid.
- [x] Update CHANGELOG/docs/examples.

### `juniper_rocket`
- [x] Update tests to support new `HttpIntegration`.
- [x] Support `application/graphql` POST request:
    - Forward request if `Content-Type` is absent or invalid.
- [x] Update CHANGELOG/docs/examples.

### `juniper_rocket_async`
- [x] Update tests to support new `HttpIntegration`.
- [x] Support `application/graphql` POST request:
    - Forward request if `Content-Type` is absent or invalid.
- [x] Update CHANGELOG/docs/examples.

### `juniper_warp`
- [x] Revive `HttpIntegration` tests (were commented).
- [x] Run tests for both sync and async versions.
- [x] Support `application/graphql` POST request:
    - Omit executing request if `Content-Type` is absent or invalid.
- [x] Update CHANGELOG/docs/examples.