### PR TITLE
Relax Default impl constraint

### DIFF
--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -324,7 +324,7 @@ where
 ///
 /// If you instantiate `RootNode` with this as the mutation, no mutation will be
 /// generated for the schema.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct EmptyMutation<T> {
     phantom: PhantomData<T>,
 }
@@ -370,11 +370,18 @@ where
 {
 }
 
+impl<T> Default for EmptyMutation<T> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
 /// Utillity type to define read-only schemas
 ///
 /// If you instantiate `RootNode` with this as the subscription,
 /// no subscriptions will be generated for the schema.
-#[derive(Default)]
 pub struct EmptySubscription<T> {
     phantom: PhantomData<T>,
 }
@@ -418,6 +425,14 @@ where
     Self::Context: Send + Sync,
     T: Send + Sync,
 {
+}
+
+impl<T> Default for EmptySubscription<T> {
+    fn default() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -496,4 +496,11 @@ mod tests {
         fn check_if_send<T: Send>() {}
         check_if_send::<EmptySubscription<()>>();
     }
+
+    #[test]
+    fn default_is_invariant_over_type() {
+        struct Bar;
+        let _ = EmptySubscription::<Bar>::default();
+        let _ = EmptyMutation::<Bar>::default();
+    }
 }


### PR DESCRIPTION
For EmptyMutation and EmptySubscription. The built-in derive
expects `T: Default`, which is not necessary for a PhantomData
wrapper.