### PR TITLE
Update crate dependencies

### DIFF
--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro-error = "1.0.2"
-proc-macro2 = "1.0.1"
+proc-macro2 = "1.0.2"
 quote = "1.0.3"
 syn = { version = "1.0.3", features = ["full", "extra-traits", "parsing"] }
 

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Compatibility with the latest `juniper`.
+- Use `reqwest` with TLS provided via `rustls`.
 
 ## Breaking Changes
 

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -14,11 +14,11 @@ url = "2"
 juniper = { version = "0.14.2", default-features = false, path = "../juniper"}
 tokio = "0.2"
 hyper = "0.13"
-futures = { version = "0.3.1" }
+futures = { version = "0.3.5" }
 
 [dev-dependencies]
 pretty_env_logger = "0.2"
-reqwest = "0.9"
+reqwest = { version = "0.10.4", features = [ "rustls-tls", "blocking" ] }
 
 [dev-dependencies.juniper]
 version = "0.14.2"

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -322,7 +322,7 @@ mod tests {
         tests::{model::Database, schema::Query},
         EmptyMutation, EmptySubscription, RootNode,
     };
-    use reqwest::{self, Response as ReqwestResponse};
+    use reqwest::{self, blocking::Response as ReqwestResponse};
     use std::{net::SocketAddr, sync::Arc, thread, time::Duration};
 
     struct TestHyperIntegration {
@@ -332,12 +332,12 @@ mod tests {
     impl http_tests::HttpIntegration for TestHyperIntegration {
         fn get(&self, url: &str) -> http_tests::TestResponse {
             let url = format!("http://127.0.0.1:{}/graphql{}", self.port, url);
-            make_test_response(reqwest::get(&url).expect(&format!("failed GET {}", url)))
+            make_test_response(reqwest::blocking::get(&url).expect(&format!("failed GET {}", url)))
         }
 
         fn post_json(&self, url: &str, body: &str) -> http_tests::TestResponse {
             let url = format!("http://127.0.0.1:{}/graphql{}", self.port, url);
-            let client = reqwest::Client::new();
+            let client = reqwest::blocking::Client::new();
             let res = client
                 .post(&url)
                 .header(reqwest::header::CONTENT_TYPE, "application/json")
@@ -349,7 +349,7 @@ mod tests {
 
         fn post_graphql(&self, url: &str, body: &str) -> http_tests::TestResponse {
             let url = format!("http://127.0.0.1:{}/graphql{}", self.port, url);
-            let client = reqwest::Client::new();
+            let client = reqwest::blocking::Client::new();
             let res = client
                 .post(&url)
                 .header(reqwest::header::CONTENT_TYPE, "application/graphql")
@@ -360,15 +360,15 @@ mod tests {
         }
     }
 
-    fn make_test_response(mut response: ReqwestResponse) -> http_tests::TestResponse {
+    fn make_test_response(response: ReqwestResponse) -> http_tests::TestResponse {
         let status_code = response.status().as_u16() as i32;
-        let body = response.text().unwrap();
         let content_type_header = response.headers().get(reqwest::header::CONTENT_TYPE);
         let content_type = if let Some(ct) = content_type_header {
             format!("{}", ct.to_str().unwrap())
         } else {
             String::default()
         };
+        let body = response.text().unwrap();
 
         http_tests::TestResponse {
             status_code,

--- a/juniper_subscriptions/Cargo.toml
+++ b/juniper_subscriptions/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 
 [dependencies]
-futures = "0.3.1"
+futures = { version = "=0.3.5", features = ["compat"] }
 juniper = { version = "0.14.2", path = "../juniper", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
- reqwest 0.10.4 with rustls-tls to remove transitive OpenSSL
dependency
- futures 0.3.5
- proc-macro2 1.0.2

All tests pass with `cargo make ci-flow`.