### PR TITLE
Relax redundant 'static lifetime bounds on ScalarValue in juniper_subscriptions::Coordinator

### DIFF
--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -134,7 +134,7 @@ where
     'req: 'a,
     'rn: 'a,
     'ctx: 'a,
-    S: ScalarValue + Send + Sync + 'static,
+    S: ScalarValue + Send + Sync,
     QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,
     QueryT::TypeInfo: Send + Sync,
     MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,

--- a/juniper_subscriptions/Cargo.toml
+++ b/juniper_subscriptions/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "juniper_subscriptions"
 version = "0.14.2"
+edition = "2018"
 authors = ["nWacky <gosha.evtushenko@gmail.com>"]
 description = "Juniper SubscriptionCoordinator and SubscriptionConnection implementations"
 license = "BSD-2-Clause"
 documentation = "https://docs.rs/juniper_subscriptions"
 repository = "https://github.com/graphql-rust/juniper"
-edition = "2018"
-
 
 [dependencies]
 futures = "0.3.1"

--- a/juniper_subscriptions/src/lib.rs
+++ b/juniper_subscriptions/src/lib.rs
@@ -25,7 +25,7 @@ use juniper::{
 /// - handles subscription start
 pub struct Coordinator<'a, QueryT, MutationT, SubscriptionT, CtxT, S>
 where
-    S: ScalarValue + Send + Sync + 'static,
+    S: ScalarValue + Send + Sync,
     QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,
     QueryT::TypeInfo: Send + Sync,
     MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,
@@ -40,7 +40,7 @@ where
 impl<'a, QueryT, MutationT, SubscriptionT, CtxT, S>
     Coordinator<'a, QueryT, MutationT, SubscriptionT, CtxT, S>
 where
-    S: ScalarValue + Send + Sync + 'static,
+    S: ScalarValue + Send + Sync,
     QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,
     QueryT::TypeInfo: Send + Sync,
     MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + Sync,

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -594,7 +594,7 @@ pub mod subscriptions {
     #[serde(bound = "GraphQLPayload<S>: Deserialize<'de>")]
     struct WsPayload<S>
     where
-        S: ScalarValue + Send + Sync + 'static,
+        S: ScalarValue + Send + Sync,
     {
         id: Option<String>,
         #[serde(rename(deserialize = "type"))]
@@ -606,7 +606,7 @@ pub mod subscriptions {
     #[serde(bound = "InputValue<S>: Deserialize<'de>")]
     struct GraphQLPayload<S>
     where
-        S: ScalarValue + Send + Sync + 'static,
+        S: ScalarValue + Send + Sync,
     {
         variables: Option<InputValue<S>>,
         extensions: Option<HashMap<String, String>>,


### PR DESCRIPTION
This is a small refactoring to cut off redundant stuff, which complicates downstream implementations.