### PR TITLE
Update to_camel_case to respect the rust convention of prefixing '_'

### DIFF
--- a/juniper/src/util.rs
+++ b/juniper/src/util.rs
@@ -7,7 +7,13 @@ use std::borrow::Cow;
 pub fn to_camel_case(s: &'_ str) -> Cow<'_, str> {
     let mut dest = Cow::Borrowed(s);
 
-    for (i, part) in s.split('_').enumerate() {
+    // handle '_' to be more friendly with the
+    // _var convention for unused variables
+    let s_iter = if s.starts_with('_') { &s[1..] } else { s }
+        .split('_')
+        .enumerate();
+
+    for (i, part) in s_iter {
         if i > 0 && part.len() == 1 {
             dest += Cow::Owned(part.to_uppercase());
         } else if i > 0 && part.len() > 1 {
@@ -32,7 +38,7 @@ pub fn to_camel_case(s: &'_ str) -> Cow<'_, str> {
 #[test]
 fn test_to_camel_case() {
     assert_eq!(&to_camel_case("test")[..], "test");
-    assert_eq!(&to_camel_case("_test")[..], "Test");
+    assert_eq!(&to_camel_case("_test")[..], "test");
     assert_eq!(&to_camel_case("first_second")[..], "firstSecond");
     assert_eq!(&to_camel_case("first_")[..], "first");
     assert_eq!(&to_camel_case("a_b_c")[..], "aBC");

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -233,7 +233,13 @@ fn get_doc_attr(attrs: &[Attribute]) -> Option<Vec<MetaNameValue>> {
 pub fn to_camel_case(s: &str) -> String {
     let mut dest = String::new();
 
-    for (i, part) in s.split('_').enumerate() {
+    // handle '_' to be more friendly with the
+    // _var convention for unused variables
+    let s_iter = if s.starts_with('_') { &s[1..] } else { s }
+        .split('_')
+        .enumerate();
+
+    for (i, part) in s_iter {
         if i > 0 && part.len() == 1 {
             dest.push_str(&part.to_uppercase());
         } else if i > 0 && part.len() > 1 {
@@ -1874,7 +1880,7 @@ mod test {
     #[test]
     fn test_to_camel_case() {
         assert_eq!(&to_camel_case("test")[..], "test");
-        assert_eq!(&to_camel_case("_test")[..], "Test");
+        assert_eq!(&to_camel_case("_test")[..], "test");
         assert_eq!(&to_camel_case("first_second")[..], "firstSecond");
         assert_eq!(&to_camel_case("first_")[..], "first");
         assert_eq!(&to_camel_case("a_b_c")[..], "aBC");


### PR DESCRIPTION
Rust (and clippy) advocate prefixing unused vars with an underscore. If doing that with juniper,
the expectation (at least personally) is that the variable name won't change. With the current
`to_camel_case` code a leading underscore capitalises. This prevents that by checking for and removing
it.

This is potentially (but unlikely) breaking. Anyone who _does_ have things with a leading underscore can simply capitalise the var to get the same effect, which is enough for me to call it a bug.

Some more discussion is in https://github.com/graphql-rust/juniper/issues/623

There was a similar (unmerged) PR for a different graphql project here: graphql-python/graphene#492 that had the same thought process.