### PR TITLE
Fix subscriptions with custom scalars

### DIFF
--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -4,7 +4,7 @@ use juniper::{
     execute,
     parser::{ParseError, ScalarToken, Spanning, Token},
     serde::de,
-    EmptyMutation, EmptySubscription, InputValue, Object, ParseScalarResult, RootNode, ScalarValue,
+    EmptyMutation, FieldResult, InputValue, Object, ParseScalarResult, RootNode, ScalarValue,
     Value, Variables,
 };
 use std::fmt;
@@ -172,6 +172,17 @@ impl TestType {
     }
 }
 
+struct TestSubscriptionType;
+
+#[juniper::graphql_subscription(
+    Scalar = MyScalarValue
+)]
+impl TestSubscriptionType {
+    async fn foo() -> std::pin::Pin<Box<dyn futures::Stream<Item = FieldResult<i32, MyScalarValue>> + Send>> {
+        Box::pin(futures::stream::empty())
+    }
+}
+
 async fn run_variable_query<F>(query: &str, vars: Variables<MyScalarValue>, f: F)
 where
     F: Fn(&Object<MyScalarValue>) -> (),
@@ -179,7 +190,7 @@ where
     let schema = RootNode::new(
         TestType,
         EmptyMutation::<()>::new(),
-        EmptySubscription::<()>::new(),
+        TestSubscriptionType,
     );
 
     let (result, errs) = execute(query, None, &schema, &vars, &())

--- a/integration_tests/juniper_tests/src/custom_scalar.rs
+++ b/integration_tests/juniper_tests/src/custom_scalar.rs
@@ -178,7 +178,9 @@ struct TestSubscriptionType;
     Scalar = MyScalarValue
 )]
 impl TestSubscriptionType {
-    async fn foo() -> std::pin::Pin<Box<dyn futures::Stream<Item = FieldResult<i32, MyScalarValue>> + Send>> {
+    async fn foo(
+    ) -> std::pin::Pin<Box<dyn futures::Stream<Item = FieldResult<i32, MyScalarValue>> + Send>>
+    {
         Box::pin(futures::stream::empty())
     }
 }
@@ -187,11 +189,7 @@ async fn run_variable_query<F>(query: &str, vars: Variables<MyScalarValue>, f: F
 where
     F: Fn(&Object<MyScalarValue>) -> (),
 {
-    let schema = RootNode::new(
-        TestType,
-        EmptyMutation::<()>::new(),
-        TestSubscriptionType,
-    );
+    let schema = RootNode::new(TestType, EmptyMutation::<()>::new(), TestSubscriptionType);
 
     let (result, errs) = execute(query, None, &schema, &vars, &())
         .await

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -1218,7 +1218,7 @@ impl GraphQLTypeDefiniton {
                             });
                             Ok(
                                 ::juniper::Value::Scalar::<
-                                    ::juniper::ValuesStream
+                                    ::juniper::ValuesStream::<#scalar>
                                 >(Box::pin(f))
                             )
                         })


### PR DESCRIPTION
This makes the `graphql_subscription` macro work with custom scalars and adds a test.