### PR TITLE
Fix juniper_warp subscriptions

### DIFF
--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -440,7 +440,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: juniper::GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Clone + Send + Sync + 'static,
+        CtxT: Send + Sync + 'static,
         S: ScalarValue + Send + Sync + 'static,
     {
         let (sink_tx, sink_rx) = websocket.split();

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -418,7 +418,7 @@ pub mod subscriptions {
     };
 
     use anyhow::anyhow;
-    use futures::{channel::mpsc, Future, StreamExt as _, TryStreamExt as _};
+    use futures::{channel::mpsc, Future, StreamExt as _, TryFutureExt as _, TryStreamExt as _};
     use juniper::{http::GraphQLRequest, InputValue, ScalarValue, SubscriptionCoordinator as _};
     use juniper_subscriptions::Coordinator;
     use serde::{Deserialize, Serialize};
@@ -453,25 +453,28 @@ pub mod subscriptions {
         );
 
         let context = Arc::new(context);
-        let running = Arc::new(AtomicBool::new(false));
         let got_close_signal = Arc::new(AtomicBool::new(false));
         let got_close_signal2 = got_close_signal.clone();
+
+        struct SubscriptionState {
+            should_stop: AtomicBool,
+        }
+        let subscription_states = HashMap::<String, Arc<SubscriptionState>>::new();
 
         sink_rx
             .map_err(move |e| {
                 got_close_signal2.store(true, Ordering::Relaxed);
                 anyhow!("Websocket error: {}", e)
             })
-            .try_fold((), move |_, msg| {
+            .try_fold(subscription_states, move |mut subscription_states, msg| {
                 let coordinator = coordinator.clone();
                 let context = context.clone();
-                let running = running.clone();
                 let got_close_signal = got_close_signal.clone();
                 let ws_tx = ws_tx.clone();
 
                 async move {
                     if msg.is_close() {
-                        return Ok(());
+                        return Ok(subscription_states);
                     }
 
                     let msg = msg
@@ -483,17 +486,19 @@ pub mod subscriptions {
                     match request.type_name.as_str() {
                         "connection_init" => {}
                         "start" => {
-                            {
-                                let closed = got_close_signal.load(Ordering::Relaxed);
-                                if closed {
-                                    return Ok(());
-                                }
-
-                                if running.load(Ordering::Relaxed) {
-                                    return Ok(());
-                                }
-                                running.store(true, Ordering::Relaxed);
+                            if got_close_signal.load(Ordering::Relaxed) {
+                                return Ok(subscription_states);
                             }
+
+                            let request_id = request.id.clone().unwrap_or("1".to_owned());
+
+                            if let Some(existing) = subscription_states.get(&request_id) {
+                                existing.should_stop.store(true, Ordering::Relaxed);
+                            }
+                            let state = Arc::new(SubscriptionState {
+                                should_stop: AtomicBool::new(false),
+                            });
+                            subscription_states.insert(request_id.clone(), state.clone());
 
                             let ws_tx = ws_tx.clone();
 
@@ -507,8 +512,6 @@ pub mod subscriptions {
 
                             tokio::task::spawn(async move {
                                 let payload = request.payload.unwrap();
-
-                                let request_id = request.id.unwrap_or("1".to_owned());
 
                                 let graphql_request = GraphQLRequest::<S>::new(
                                     payload.query.unwrap(),
@@ -546,8 +549,9 @@ pub mod subscriptions {
                                 values_stream
                                     .take_while(move |response| {
                                         let request_id = request_id.clone();
-                                        let closed = got_close_signal.load(Ordering::Relaxed);
-                                        if !closed {
+                                        let should_stop = state.should_stop.load(Ordering::Relaxed)
+                                            || got_close_signal.load(Ordering::Relaxed);
+                                        if !should_stop {
                                             let mut response_text = serde_json::to_string(
                                                 &response,
                                             )
@@ -563,16 +567,19 @@ pub mod subscriptions {
                                             ))));
                                         }
 
-                                        async move { !closed }
+                                        async move { !should_stop }
                                     })
                                     .for_each(|_| async {})
                                     .await;
                             });
                         }
                         "stop" => {
-                            got_close_signal.store(true, Ordering::Relaxed);
-
                             let request_id = request.id.unwrap_or("1".to_owned());
+                            if let Some(existing) = subscription_states.get(&request_id) {
+                                existing.should_stop.store(true, Ordering::Relaxed);
+                                subscription_states.remove(&request_id);
+                            }
+
                             let close_message = format!(
                                 r#"{{"type":"complete","id":"{}","payload":null}}"#,
                                 request_id
@@ -585,9 +592,10 @@ pub mod subscriptions {
                         _ => {}
                     }
 
-                    Ok(())
+                    Ok(subscription_states)
                 }
             })
+            .map_ok(|_| ())
     }
 
     #[derive(Deserialize)]

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -498,7 +498,7 @@ pub mod subscriptions {
                             let state = Arc::new(SubscriptionState {
                                 should_stop: AtomicBool::new(false),
                             });
-                            subscription_states.insert(request_id.clone(), state.clone());
+                            subscription_states.insert(request_id, state.clone());
 
                             let ws_tx = ws_tx.clone();
 

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -417,6 +417,7 @@ pub mod subscriptions {
         },
     };
 
+    use anyhow::anyhow;
     use futures::{channel::mpsc, Future, StreamExt as _, TryStreamExt as _};
     use juniper::{http::GraphQLRequest, InputValue, ScalarValue, SubscriptionCoordinator as _};
     use juniper_subscriptions::Coordinator;


### PR DESCRIPTION
* Previously, the `juniper_warp` crate would not even compile with the "subscriptions" feature due to a missing `use anyhow::anyhow`. This PR adds that.
* The `context` argument to `graphql_subscriptions` previously required `Clone`. That was unnecessary and made the function unusable with perfectly valid context types. This PR just removes that constraint.
* Previously, as soon as a subscription was stopped, the "got_close_signal" boolean would be set, and the WebSocket connection would be rendered unusable. This meant that multiple subscriptions on a single WebSocket connection were completely broken (and worse yet, completely silent). This PR adds a `HashMap` of subscription states (currently just an atomic boolean) to make it possible to stop subscriptions without interrupting others or breaking the entire connection.

This entire module (`juniper_warp::subscriptions`) probably needs a rewrite, but these fixes make it at least work and are hopefully uncontentious enough to be merged in some form sooner rather than later.

Also of note: If CI were to build the example code, it would have caught at least the first issue. :-/