### PR TITLE
Add clone() back to request_id to fix compiler error in juniper_warp

### DIFF
--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -498,7 +498,7 @@ pub mod subscriptions {
                             let state = Arc::new(SubscriptionState {
                                 should_stop: AtomicBool::new(false),
                             });
-                            subscription_states.insert(request_id, state.clone());
+                            subscription_states.insert(request_id.clone(), state.clone());
 
                             let ws_tx = ws_tx.clone();
 


### PR DESCRIPTION
It's possible that I don't understand the original reasoning behind commit 54be035 removing `.clone()` here but this PR adding it back allows compilation to succeed and completes the fix of #705 via #707 for me. With this change multiple subscriptions now work on master.

<img width="1086" alt="Screen Shot 2020-07-20 at 9 50 05 AM" src="https://user-images.githubusercontent.com/322706/87958387-17f3e400-ca77-11ea-995b-69e253044a48.png">
