### PR TITLE
Unsubscribe fix

### DIFF
--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -484,7 +484,10 @@ pub mod subscriptions {
                         .map_err(|e| anyhow!("Invalid WsPayload: {}", e))?;
 
                     match request.type_name.as_str() {
-                        "connection_init" => {}
+                        "connection_init" => {
+                            let reply = format!(r#"{{"type":"connection_ack","payload":null}}"#);
+                            let _ = ws_tx.unbounded_send(Some(Ok(Message::text(reply))));
+                        }
                         "start" => {
                             if got_close_signal.load(Ordering::Relaxed) {
                                 return Ok(subscription_states);

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -543,8 +543,6 @@ pub mod subscriptions {
                                         );
                                         let _ = ws_tx
                                             .unbounded_send(Some(Ok(Message::text(close_message))));
-                                        // close channel
-                                        let _ = ws_tx.unbounded_send(None);
                                         return;
                                     }
                                 };
@@ -588,7 +586,12 @@ pub mod subscriptions {
                                 request_id
                             );
                             let _ = ws_tx.unbounded_send(Some(Ok(Message::text(close_message))));
-
+                        }
+                        "connection_terminate" => {
+                            for (request_id, existing) in subscription_states.clone().iter() {
+                                existing.should_stop.store(true, Ordering::Relaxed);
+                                subscription_states.remove(request_id);
+                            }
                             // close channel
                             let _ = ws_tx.unbounded_send(None);
                         }


### PR DESCRIPTION
The current implementation of `juniper_warp` will kill the websocket at the first `stop` call or if a deserialization error is encountered. This means that any running operation (such as a subscription) that is stopped will require the client to reconnect and set up its subscriptions again.

This fix does two things:
1. ACKs a `connection_init` command
1. Only closes the websocket if the client sends a `connection_terminate` command

Both are modeled after the Apollo implementation https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md