### PR TITLE
Simplify SubscriptionConnection

### DIFF
--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -186,8 +186,8 @@ pub use crate::{
         marker::{self, GraphQLUnion},
         scalars::{EmptyMutation, EmptySubscription, ID},
         subscriptions::{
-            GraphQLSubscriptionType, GraphQLSubscriptionValue, SubscriptionConnection,
-            SubscriptionCoordinator,
+            ExecutionOutput, GraphQLSubscriptionType, GraphQLSubscriptionValue,
+            SubscriptionConnection, SubscriptionCoordinator,
         },
     },
     validation::RuleError,

--- a/juniper/src/types/subscriptions.rs
+++ b/juniper/src/types/subscriptions.rs
@@ -25,7 +25,7 @@ pub struct ExecutionOutput<S> {
 impl<S> ExecutionOutput<S> {
     /// Creates execution output from data, with no errors.
     pub fn from_data(data: Value<S>) -> Self {
-        Self{
+        Self {
             data,
             errors: vec![],
         }
@@ -82,10 +82,7 @@ where
 ///
 /// It can be treated as [`futures::Stream`] yielding [`GraphQLResponse`]s in
 /// server integration crates.
-pub trait SubscriptionConnection<S>:
-    futures::Stream<Item = ExecutionOutput<S>>
-{
-}
+pub trait SubscriptionConnection<S>: futures::Stream<Item = ExecutionOutput<S>> {}
 
 /// Extension of [`GraphQLValue`] trait with asynchronous [subscription][1] execution logic.
 /// It should be used with [`GraphQLValue`] in order to implement [subscription][1] resolvers on

--- a/juniper/src/types/subscriptions.rs
+++ b/juniper/src/types/subscriptions.rs
@@ -1,11 +1,11 @@
 use futures::{future, stream};
 
 use crate::{
-    http::{GraphQLRequest, GraphQLResponse},
+    http::GraphQLRequest,
     parser::Spanning,
     types::base::{is_excluded, merge_key_into, GraphQLType, GraphQLValue},
-    Arguments, BoxFuture, DefaultScalarValue, Executor, FieldError, Object, ScalarValue, Selection,
-    Value, ValuesStream,
+    Arguments, BoxFuture, DefaultScalarValue, ExecutionError, Executor, FieldError, Object,
+    ScalarValue, Selection, Value, ValuesStream,
 };
 
 /// Global subscription coordinator trait.
@@ -33,7 +33,7 @@ where
 {
     /// Type of [`SubscriptionConnection`]s this [`SubscriptionCoordinator`]
     /// returns
-    type Connection: SubscriptionConnection<'a, S>;
+    type Connection: SubscriptionConnection<S>;
 
     /// Type of error while trying to spawn [`SubscriptionConnection`]
     type Error;
@@ -58,7 +58,7 @@ where
 ///
 /// It can be treated as [`futures::Stream`] yielding [`GraphQLResponse`]s in
 /// server integration crates.
-pub trait SubscriptionConnection<'a, S>: futures::Stream<Item = GraphQLResponse<'a, S>> {}
+pub trait SubscriptionConnection<S>: futures::Stream<Item = (Value<S>, Vec<ExecutionError<S>>)> {}
 
 /// Extension of [`GraphQLValue`] trait with asynchronous [subscription][1] execution logic.
 /// It should be used with [`GraphQLValue`] in order to implement [subscription][1] resolvers on

--- a/juniper/src/types/subscriptions.rs
+++ b/juniper/src/types/subscriptions.rs
@@ -58,7 +58,10 @@ where
 ///
 /// It can be treated as [`futures::Stream`] yielding [`GraphQLResponse`]s in
 /// server integration crates.
-pub trait SubscriptionConnection<S>: futures::Stream<Item = (Value<S>, Vec<ExecutionError<S>>)> {}
+pub trait SubscriptionConnection<S>:
+    futures::Stream<Item = (Value<S>, Vec<ExecutionError<S>>)>
+{
+}
 
 /// Extension of [`GraphQLValue`] trait with asynchronous [subscription][1] execution logic.
 /// It should be used with [`GraphQLValue`] in order to implement [subscription][1] resolvers on

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -427,12 +427,6 @@ pub mod subscriptions {
     use serde::{Deserialize, Serialize};
     use warp::ws::Message;
 
-    #[derive(Serialize)]
-    struct DataPayload<'a, S: ScalarValue> {
-        data: &'a Value<S>,
-        errors: &'a Vec<ExecutionError<S>>,
-    }
-
     /// Listen to incoming messages and do one of the following:
     ///  - execute subscription and return values from stream
     ///  - stop stream and close ws connection
@@ -556,16 +550,13 @@ pub mod subscriptions {
                                 };
 
                                 values_stream
-                                    .take_while(move |(data, errors)| {
+                                    .take_while(move |response| {
                                         let request_id = request_id.clone();
                                         let should_stop = state.should_stop.load(Ordering::Relaxed)
                                             || got_close_signal.load(Ordering::Relaxed);
                                         if !should_stop {
                                             let mut response_text =
-                                                serde_json::to_string(&DataPayload {
-                                                    data,
-                                                    errors,
-                                                })
+                                                serde_json::to_string(&response)
                                                 .unwrap_or(
                                                     "Error deserializing response".to_owned(),
                                                 );

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -555,11 +555,10 @@ pub mod subscriptions {
                                         let should_stop = state.should_stop.load(Ordering::Relaxed)
                                             || got_close_signal.load(Ordering::Relaxed);
                                         if !should_stop {
-                                            let mut response_text =
-                                                serde_json::to_string(&response)
-                                                .unwrap_or(
-                                                    "Error deserializing response".to_owned(),
-                                                );
+                                            let mut response_text = serde_json::to_string(
+                                                &response,
+                                            )
+                                            .unwrap_or("Error deserializing response".to_owned());
 
                                             response_text = format!(
                                                 r#"{{"type":"data","id":"{}","payload":{} }}"#,

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -419,10 +419,7 @@ pub mod subscriptions {
 
     use anyhow::anyhow;
     use futures::{channel::mpsc, Future, StreamExt as _, TryFutureExt as _, TryStreamExt as _};
-    use juniper::{
-        http::GraphQLRequest, ExecutionError, InputValue, ScalarValue,
-        SubscriptionCoordinator as _, Value,
-    };
+    use juniper::{http::GraphQLRequest, InputValue, ScalarValue, SubscriptionCoordinator as _};
     use juniper_subscriptions::Coordinator;
     use serde::{Deserialize, Serialize};
     use warp::ws::Message;

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -419,10 +419,19 @@ pub mod subscriptions {
 
     use anyhow::anyhow;
     use futures::{channel::mpsc, Future, StreamExt as _, TryFutureExt as _, TryStreamExt as _};
-    use juniper::{http::GraphQLRequest, InputValue, ScalarValue, SubscriptionCoordinator as _};
+    use juniper::{
+        http::GraphQLRequest, ExecutionError, InputValue, ScalarValue,
+        SubscriptionCoordinator as _, Value,
+    };
     use juniper_subscriptions::Coordinator;
     use serde::{Deserialize, Serialize};
     use warp::ws::Message;
+
+    #[derive(Serialize)]
+    struct DataPayload<'a, S: ScalarValue> {
+        data: &'a Value<S>,
+        errors: &'a Vec<ExecutionError<S>>,
+    }
 
     /// Listen to incoming messages and do one of the following:
     ///  - execute subscription and return values from stream
@@ -547,15 +556,19 @@ pub mod subscriptions {
                                 };
 
                                 values_stream
-                                    .take_while(move |response| {
+                                    .take_while(move |(data, errors)| {
                                         let request_id = request_id.clone();
                                         let should_stop = state.should_stop.load(Ordering::Relaxed)
                                             || got_close_signal.load(Ordering::Relaxed);
                                         if !should_stop {
-                                            let mut response_text = serde_json::to_string(
-                                                &response,
-                                            )
-                                            .unwrap_or("Error deserializing response".to_owned());
+                                            let mut response_text =
+                                                serde_json::to_string(&DataPayload {
+                                                    data,
+                                                    errors,
+                                                })
+                                                .unwrap_or(
+                                                    "Error deserializing response".to_owned(),
+                                                );
 
                                             response_text = format!(
                                                 r#"{{"type":"data","id":"{}","payload":{} }}"#,


### PR DESCRIPTION
Previously `SubscriptionConnection` was a stream of `GraphQLResponse<'a, S>`, a newtype for:

```rust
Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError<'a>>
```

 This doesn't really make much sense because subscription events cannot have any sort of pre-execution errors and the `GraphQLResponse` is always `Ok`. This is a bit misleading and complicates lifetimes as the output of the stream can otherwise be `'static`.

This PR just makes `SubscriptionConnection` a stream of unwrapped tuples. This has the added benefit of allowing the user of the API to actually access the data / errors before serializing. Alternatively, it might make sense to create a new type for this, e.g. an `ExecutionResult` type.

This is something I came across while working on #709 that I figured could go in its own PR.