### PR TITLE
GraphQL-WS crate and Warp subscriptions update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "juniper_rocket",
   "juniper_rocket_async",
   "juniper_subscriptions",
+  "juniper_graphql_ws",
   "juniper_warp",
   "juniper_actix",
 ]

--- a/examples/warp_subscriptions/Cargo.toml
+++ b/examples/warp_subscriptions/Cargo.toml
@@ -13,6 +13,6 @@ serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 warp = "0.2.1"
 
-juniper = { git = "https://github.com/graphql-rust/juniper" }
-juniper_subscriptions = { git = "https://github.com/graphql-rust/juniper" }
-juniper_warp = { git = "https://github.com/graphql-rust/juniper", features = ["subscriptions"] }
+juniper = { path = "../../juniper" }
+juniper_graphql_ws = { path = "../../juniper_graphql_ws" }
+juniper_warp = { path = "../../juniper_warp", features = ["subscriptions"] }

--- a/juniper/release.toml
+++ b/juniper/release.toml
@@ -30,6 +30,8 @@ pre-release-replacements = [
   {file="../juniper_warp/Cargo.toml", search="\\[dev-dependencies\\.juniper\\]\nversion = \"[^\"]+\"", replace="[dev-dependencies.juniper]\nversion = \"{{version}}\""},
   # Subscriptions
   {file="../juniper_subscriptions/Cargo.toml", search="juniper = \\{ version = \"[^\"]+\"", replace="juniper = { version = \"{{version}}\""},
+  # GraphQL-WS
+  {file="../juniper_graphql_ws/Cargo.toml", search="juniper = \\{ version = \"[^\"]+\"", replace="juniper = { version = \"{{version}}\""},
   # Actix-Web
   {file="../juniper_actix/Cargo.toml", search="juniper = \\{ version = \"[^\"]+\"", replace="juniper = { version = \"{{version}}\""},
   {file="../juniper_actix/Cargo.toml", search="\\[dev-dependencies\\.juniper\\]\nversion = \"[^\"]+\"", replace="[dev-dependencies.juniper]\nversion = \"{{version}}\""},

--- a/juniper_graphql_ws/CHANGELOG.md
+++ b/juniper_graphql_ws/CHANGELOG.md
@@ -1,0 +1,3 @@
+# master
+
+- Initial Release

--- a/juniper_graphql_ws/Cargo.toml
+++ b/juniper_graphql_ws/Cargo.toml
@@ -6,7 +6,7 @@ license = "BSD-2-Clause"
 description = "Graphql-ws protocol implementation for Juniper"
 documentation = "https://docs.rs/juniper_graphql_ws"
 repository = "https://github.com/graphql-rust/juniper"
-keywords = ["graphql-ws"]
+keywords = ["graphql-ws", "juniper", "graphql", "apollo"]
 edition = "2018"
 
 [dependencies]

--- a/juniper_graphql_ws/Cargo.toml
+++ b/juniper_graphql_ws/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "juniper_graphql_ws"
+version = "0.1.0"
+authors = ["Christopher Brown <ccbrown112@gmail.com>"]
+license = "BSD-2-Clause"
+description = "Graphql-ws protocol implementation for Juniper"
+documentation = "https://docs.rs/juniper_graphql_ws"
+repository = "https://github.com/graphql-rust/juniper"
+keywords = ["graphql-ws"]
+edition = "2018"
+
+[dependencies]
+juniper = { version = "0.14.2", path = "../juniper", default-features = false }
+juniper_subscriptions = { path = "../juniper_subscriptions" }
+serde = { version = "1.0.8", features = ["derive"] }
+tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }
+
+[dev-dependencies]
+serde_json = { version = "1.0.2" }

--- a/juniper_graphql_ws/Makefile.toml
+++ b/juniper_graphql_ws/Makefile.toml
@@ -1,0 +1,20 @@
+[env]
+CARGO_MAKE_CARGO_ALL_FEATURES = ""
+
+[tasks.build-verbose]
+condition = { rust_version = { min = "1.29.0" } }
+
+[tasks.build-verbose.windows]
+condition = { rust_version = { min = "1.29.0" }, env = { "TARGET" = "x86_64-pc-windows-msvc" } }
+
+[tasks.test-verbose]
+condition = { rust_version = { min = "1.29.0" } }
+
+[tasks.test-verbose.windows]
+condition = { rust_version = { min = "1.29.0" }, env = { "TARGET" = "x86_64-pc-windows-msvc" } }
+
+[tasks.ci-coverage-flow]
+condition = { rust_version = { min = "1.29.0" } }
+
+[tasks.ci-coverage-flow.windows]
+disabled = true

--- a/juniper_graphql_ws/release.toml
+++ b/juniper_graphql_ws/release.toml
@@ -1,0 +1,8 @@
+no-dev-version = true
+pre-release-commit-message = "Release {{crate_name}} {{version}}"
+pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
+tag-message = "Release {{crate_name}} {{version}}"
+upload-doc = false
+pre-release-replacements = [
+  {file="src/lib.rs", search="docs.rs/juniper_graphql_ws/[a-z0-9\\.-]+", replace="docs.rs/juniper_graphql_ws/{{version}}"},
+]

--- a/juniper_graphql_ws/src/client_message.rs
+++ b/juniper_graphql_ws/src/client_message.rs
@@ -1,12 +1,19 @@
 use juniper::{ScalarValue, Variables};
 
+/// The payload for a client's "start" message. This triggers execution of a query, mutation, or
+/// subscription.
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(bound(deserialize = "S: ScalarValue"))]
 #[serde(rename_all = "camelCase")]
 pub struct StartPayload<S: ScalarValue> {
+    /// The document body.
     pub query: String,
+
+    /// The optional variables.
     #[serde(default)]
     pub variables: Variables<S>,
+
+    /// The optional operation name (required if the document contains multiple operations).
     pub operation_name: Option<String>,
 }
 
@@ -18,16 +25,25 @@ pub struct StartPayload<S: ScalarValue> {
 pub enum ClientMessage<S: ScalarValue> {
     /// ConnectionInit is sent by the client upon connecting.
     ConnectionInit {
+        /// Optional parameters of any type sent from the client. These are often used for
+        /// authentication.
         #[serde(default)]
         payload: Variables<S>,
     },
     /// Start messages are used to execute a GraphQL operation.
     Start {
+        /// The id of the operation. This can be anything, but must be unique. If there are other
+        /// in-flight operations with the same id, the message will be ignored or cause an error.
         id: String,
+
+        /// The query, variables, and operation name.
         payload: StartPayload<S>,
     },
     /// Stop messages are used to unsubscribe from a subscription.
-    Stop { id: String },
+    Stop {
+        /// The id of the operation to stop.
+        id: String,
+    },
     /// ConnectionTerminate is used to terminate the connection.
     ConnectionTerminate,
 }

--- a/juniper_graphql_ws/src/client_message.rs
+++ b/juniper_graphql_ws/src/client_message.rs
@@ -1,0 +1,115 @@
+use juniper::{ScalarValue, Variables};
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(bound(deserialize = "S: ScalarValue"))]
+#[serde(rename_all = "camelCase")]
+pub struct StartPayload<S: ScalarValue> {
+    pub query: String,
+    #[serde(default)]
+    pub variables: Variables<S>,
+    pub operation_name: Option<String>,
+}
+
+/// ClientMessage defines the message types that clients can send.
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(bound(deserialize = "S: ScalarValue"))]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum ClientMessage<S: ScalarValue> {
+    /// ConnectionInit is sent by the client upon connecting.
+    ConnectionInit {
+        #[serde(default)]
+        payload: Variables<S>,
+    },
+    /// Start messages are used to execute a GraphQL operation.
+    Start {
+        id: String,
+        payload: StartPayload<S>,
+    },
+    /// Stop messages are used to unsubscribe from a subscription.
+    Stop { id: String },
+    /// ConnectionTerminate is used to terminate the connection.
+    ConnectionTerminate,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use juniper::{DefaultScalarValue, InputValue};
+
+    #[test]
+    fn test_deserialization() {
+        type ClientMessage = super::ClientMessage<DefaultScalarValue>;
+
+        assert_eq!(
+            ClientMessage::ConnectionInit {
+                payload: [("foo".to_string(), InputValue::scalar("bar"))]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            },
+            serde_json::from_str(r##"{"type": "connection_init", "payload": {"foo": "bar"}}"##)
+                .unwrap(),
+        );
+
+        assert_eq!(
+            ClientMessage::ConnectionInit {
+                payload: Variables::default(),
+            },
+            serde_json::from_str(r##"{"type": "connection_init"}"##).unwrap(),
+        );
+
+        assert_eq!(
+            ClientMessage::Start {
+                id: "foo".to_string(),
+                payload: StartPayload {
+                    query: "query MyQuery { __typename }".to_string(),
+                    variables: [("foo".to_string(), InputValue::scalar("bar"))]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                    operation_name: Some("MyQuery".to_string()),
+                },
+            },
+            serde_json::from_str(
+                r##"{"type": "start", "id": "foo", "payload": {
+                "query": "query MyQuery { __typename }",
+                "variables": {
+                    "foo": "bar"
+                },
+                "operationName": "MyQuery"
+            }}"##
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            ClientMessage::Start {
+                id: "foo".to_string(),
+                payload: StartPayload {
+                    query: "query MyQuery { __typename }".to_string(),
+                    variables: Variables::default(),
+                    operation_name: None,
+                },
+            },
+            serde_json::from_str(
+                r##"{"type": "start", "id": "foo", "payload": {
+                "query": "query MyQuery { __typename }"
+            }}"##
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            ClientMessage::Stop {
+                id: "foo".to_string()
+            },
+            serde_json::from_str(r##"{"type": "stop", "id": "foo"}"##).unwrap(),
+        );
+
+        assert_eq!(
+            ClientMessage::ConnectionTerminate,
+            serde_json::from_str(r##"{"type": "connection_terminate"}"##).unwrap(),
+        );
+    }
+}

--- a/juniper_graphql_ws/src/lib.rs
+++ b/juniper_graphql_ws/src/lib.rs
@@ -467,10 +467,13 @@ impl<S: Schema> Stream for SubscriptionStart<S> {
                     ref id,
                     ref mut stream,
                 } => match Pin::new(stream).poll_next(cx) {
-                    Poll::Ready(Some((data, errors))) => {
+                    Poll::Ready(Some(output)) => {
                         return Poll::Ready(Some(Reaction::ServerMessage(ServerMessage::Data {
                             id: id.clone(),
-                            payload: DataPayload { data, errors },
+                            payload: DataPayload {
+                                data: output.data,
+                                errors: output.errors,
+                            },
                         })));
                     }
                     Poll::Ready(None) => {

--- a/juniper_graphql_ws/src/lib.rs
+++ b/juniper_graphql_ws/src/lib.rs
@@ -2,7 +2,7 @@
 
 # juniper_graphql_ws
 
-This crate contains an implementation of the graphql-ws protocol, as used by Apollo.
+This crate contains an implementation of the [graphql-ws protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/263844b5c1a850c1e29814564eb62cb587e5eaaf/PROTOCOL.md), as used by Apollo.
 
 */
 
@@ -329,9 +329,10 @@ impl<S: Schema, I: Init<S::ScalarValue, S::Context>> ConnectionState<S, I> {
             Err(e) => {
                 return Reaction::ServerMessage(ServerMessage::Error {
                     id: id.clone(),
+                    // e only references data owned by params. The new ErrorPayload will continue to keep that data alive.
                     payload: unsafe { ErrorPayload::new_unchecked(Box::new(params.clone()), e) },
                 })
-                .to_stream()
+                .to_stream();
             }
         }
 
@@ -454,6 +455,7 @@ impl<S: Schema> Stream for SubscriptionStart<S> {
                             return Poll::Ready(Some(Reaction::ServerMessage(
                                 ServerMessage::Error {
                                     id: id.clone(),
+                                    // e only references data owned by params. The new ErrorPayload will continue to keep that data alive.
                                     payload: unsafe {
                                         ErrorPayload::new_unchecked(Box::new(params.clone()), e)
                                     },

--- a/juniper_graphql_ws/src/lib.rs
+++ b/juniper_graphql_ws/src/lib.rs
@@ -1,0 +1,785 @@
+#[macro_use]
+extern crate serde;
+
+mod client_message;
+pub use client_message::*;
+
+mod server_message;
+pub use server_message::*;
+
+use juniper::{
+    futures::{
+        channel::oneshot,
+        future::{self, BoxFuture, Either, Future, FutureExt, TryFutureExt},
+        stream::{self, BoxStream, SelectAll, StreamExt},
+        task::{Context, Poll},
+        Stream,
+    },
+    GraphQLError, GraphQLSubscriptionType, GraphQLTypeAsync, RootNode, RuleError, ScalarValue,
+    Variables,
+};
+use std::{
+    collections::HashMap, convert::{Infallible, TryInto}, error::Error, marker::PhantomPinned,
+    pin::Pin, sync::Arc, time::Duration,
+};
+
+struct ExecutionParams<S: Schema> {
+    start_payload: StartPayload<S::ScalarValue>,
+    config: Arc<ConnectionConfig<S::Context>>,
+    schema: S,
+}
+
+/// Schema defines the requirements for schemas that can be used for operations. Typically this is
+/// just an Arc<RootNode>.
+pub trait Schema: Unpin + Clone + Send + Sync + 'static {
+    type Context: Unpin + Send + Sync;
+    type ScalarValue: ScalarValue + Send + Sync;
+    type QueryTypeInfo: Send + Sync;
+    type Query: GraphQLTypeAsync<Self::ScalarValue, Context = Self::Context, TypeInfo = Self::QueryTypeInfo>
+        + Send;
+    type MutationTypeInfo: Send + Sync;
+    type Mutation: GraphQLTypeAsync<
+            Self::ScalarValue,
+            Context = Self::Context,
+            TypeInfo = Self::MutationTypeInfo,
+        > + Send;
+    type SubscriptionTypeInfo: Send + Sync;
+    type Subscription: GraphQLSubscriptionType<
+            Self::ScalarValue,
+            Context = Self::Context,
+            TypeInfo = Self::SubscriptionTypeInfo,
+        > + Send;
+
+    fn root_node(
+        &self,
+    ) -> &RootNode<'static, Self::Query, Self::Mutation, Self::Subscription, Self::ScalarValue>;
+}
+
+impl<QueryT, MutationT, SubscriptionT, CtxT, S> Schema
+    for Arc<RootNode<'static, QueryT, MutationT, SubscriptionT, S>>
+where
+    QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    QueryT::TypeInfo: Send + Sync,
+    MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    MutationT::TypeInfo: Send + Sync,
+    SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+    SubscriptionT::TypeInfo: Send + Sync,
+    CtxT: Unpin + Send + Sync,
+    S: ScalarValue + Send + Sync + 'static,
+{
+    type Context = CtxT;
+    type ScalarValue = S;
+    type QueryTypeInfo = QueryT::TypeInfo;
+    type Query = QueryT;
+    type MutationTypeInfo = MutationT::TypeInfo;
+    type Mutation = MutationT;
+    type SubscriptionTypeInfo = SubscriptionT::TypeInfo;
+    type Subscription = SubscriptionT;
+
+    fn root_node(&self) -> &RootNode<'static, QueryT, MutationT, SubscriptionT, S> {
+        self
+    }
+}
+
+/// ConnectionConfig is used to configure the connection once the client sends the ConnectionInit
+/// message.
+pub struct ConnectionConfig<CtxT> {
+    context: CtxT,
+    max_in_flight_operations: usize,
+    keep_alive_interval: Duration,
+}
+
+impl<CtxT> ConnectionConfig<CtxT> {
+    /// Constructs the configuration required for a connection to be accepted.
+    pub fn new(context: CtxT) -> Self {
+        Self {
+            context,
+            max_in_flight_operations: 0,
+            keep_alive_interval: Duration::from_secs(30),
+        }
+    }
+
+    /// Specifies the maximum number of in-flight operations that a connection can have. If this
+    /// number is exceeded, attempting to start more will result in an error. By default, there is
+    /// no limit to in-flight operations.
+    pub fn with_max_in_flight_operations(mut self, max: usize) -> Self {
+        self.max_in_flight_operations = max;
+        self
+    }
+
+    /// Specifies the interval at which to send keep-alives. Specifying a zero duration will
+    /// disable keep-alives. By default, keep-alives are sent every
+    /// 30 seconds.
+    pub fn with_keep_alive_interval(mut self, interval: Duration) -> Self {
+        self.keep_alive_interval = interval;
+        self
+    }
+}
+
+impl<S: Schema> Init<S> for ConnectionConfig<S::Context> {
+    type Error = Infallible;
+    type Future = future::Ready<Result<Self, Self::Error>>;
+
+    fn init(self, _params: Variables<S::ScalarValue>) -> Self::Future {
+        future::ready(Ok(self))
+    }
+}
+
+enum Reaction<S: Schema> {
+    ServerMessage(ServerMessage<S::ScalarValue>),
+    Activate {
+        config: ConnectionConfig<S::Context>,
+        schema: S,
+    },
+    EndStream,
+}
+
+impl<S: Schema> Reaction<S> {
+    /// Converts the reaction into a one-item stream.
+    fn to_stream(self) -> BoxStream<'static, Self> {
+        stream::once(future::ready(self)).boxed()
+    }
+}
+
+/// Init defines the requirements for types that can provide connection configurations when
+/// ConnectionInit messages are received. It is automatically implemented for closures that meet
+/// the requirements.
+pub trait Init<S: Schema>: Unpin + 'static {
+    type Error: Error;
+    type Future: Future<Output = Result<ConnectionConfig<S::Context>, Self::Error>> + Send + 'static;
+
+    fn init(self, params: Variables<S::ScalarValue>) -> Self::Future;
+}
+
+impl<F, S, Fut, E> Init<S> for F
+where
+    S: Schema,
+    F: FnOnce(Variables<S::ScalarValue>) -> Fut + Unpin + 'static,
+    Fut: Future<Output = Result<ConnectionConfig<S::Context>, E>> + Send + 'static,
+    E: Error,
+{
+    type Error = E;
+    type Future = Fut;
+
+    fn init(self, params: Variables<S::ScalarValue>) -> Fut {
+        self(params)
+    }
+}
+
+enum ConnectionState<S: Schema, I: Init<S>> {
+    /// PreInit is the state before a ConnectionInit message has been accepted.
+    PreInit { init: I, schema: S },
+    /// Initializing is the state after a ConnectionInit message has been received, but before the
+    /// init future has resolved.
+    Initializing,
+    /// Active is the state after a ConnectionInit message has been accepted.
+    Active {
+        config: Arc<ConnectionConfig<S::Context>>,
+        stoppers: HashMap<String, oneshot::Sender<()>>,
+        schema: S,
+    },
+}
+
+impl<S: Schema, I: Init<S>> ConnectionState<S, I> {
+    // Each message we receive results in a stream of zero or more reactions. For example, a
+    // ConnectionTerminate message results in a one-item stream with the EndStream reaction.
+    fn handle_message(
+        &mut self,
+        msg: ClientMessage<S::ScalarValue>,
+    ) -> BoxStream<'static, Reaction<S>> {
+        if let ClientMessage::ConnectionTerminate = msg {
+            return Reaction::EndStream.to_stream();
+        }
+
+        match self {
+            Self::PreInit { .. } => match msg {
+                ClientMessage::ConnectionInit { payload } => {
+                    match std::mem::replace(self, Self::Initializing) {
+                        Self::PreInit { init, schema } => init
+                            .init(payload)
+                            .map(|r| match r {
+                                Ok(config) => {
+                                    let keep_alive_interval = config.keep_alive_interval;
+
+                                    let mut s = stream::iter(vec![
+                                        Reaction::Activate { config, schema },
+                                        Reaction::ServerMessage(ServerMessage::ConnectionAck),
+                                    ])
+                                    .boxed();
+
+                                    if keep_alive_interval > Duration::from_secs(0) {
+                                        s = s
+                                            .chain(
+                                                Reaction::ServerMessage(
+                                                    ServerMessage::ConnectionKeepAlive,
+                                                )
+                                                .to_stream(),
+                                            )
+                                            .boxed();
+                                        s = s
+                                            .chain(stream::unfold((), move |_| async move {
+                                                tokio::time::delay_for(keep_alive_interval).await;
+                                                Some((
+                                                    Reaction::ServerMessage(
+                                                        ServerMessage::ConnectionKeepAlive,
+                                                    ),
+                                                    (),
+                                                ))
+                                            }))
+                                            .boxed();
+                                    }
+
+                                    s
+                                }
+                                Err(e) => stream::iter(vec![
+                                    Reaction::ServerMessage(ServerMessage::ConnectionError {
+                                        payload: ConnectionErrorPayload {
+                                            message: e.to_string(),
+                                        },
+                                    }),
+                                    Reaction::EndStream,
+                                ])
+                                .boxed(),
+                            })
+                            .into_stream()
+                            .flatten()
+                            .boxed(),
+                        _ => unreachable!(),
+                    }
+                }
+                _ => stream::empty().boxed(),
+            },
+            Self::Initializing => stream::empty().boxed(),
+            Self::Active {
+                config,
+                stoppers,
+                schema,
+            } => {
+                match msg {
+                    ClientMessage::Start { id, payload } => {
+                        if stoppers.contains_key(&id) {
+                            // We already have an operation with this id, so we can't start a new
+                            // one.
+                            return stream::empty().boxed();
+                        }
+
+                        // Go ahead and prune canceled stoppers before adding a new one.
+                        stoppers.retain(|_, tx| !tx.is_canceled());
+
+                        if config.max_in_flight_operations > 0
+                            && stoppers.len() >= config.max_in_flight_operations
+                        {
+                            // Too many in-flight operations. Just send back a validation error.
+                            return stream::iter(vec![
+                                Reaction::ServerMessage(ServerMessage::Error {
+                                    id: id.clone(),
+                                    payload: GraphQLError::ValidationError(vec![RuleError::new(
+                                        "Too many in-flight operations.",
+                                        &[],
+                                    )])
+                                    .into(),
+                                }),
+                                Reaction::ServerMessage(ServerMessage::Complete { id }),
+                            ])
+                            .boxed();
+                        }
+
+                        // Create a channel that we can use to cancel the operation.
+                        let (tx, rx) = oneshot::channel::<()>();
+                        stoppers.insert(id.clone(), tx);
+
+                        // Create the operation stream. This stream will emit Data and Error
+                        // messages, but will not emit Complete – that part is up to us.
+                        let s = Self::start(
+                            id.clone(),
+                            ExecutionParams {
+                                start_payload: payload,
+                                config: config.clone(),
+                                schema: schema.clone(),
+                            },
+                        )
+                        .into_stream()
+                        .flatten();
+
+                        // Combine this with our oneshot channel so that the stream ends if the
+                        // oneshot is ever fired.
+                        let s = stream::unfold((rx, s.boxed()), |(rx, mut s)| async move {
+                            let next = match future::select(rx, s.next()).await {
+                                Either::Left(_) => None,
+                                Either::Right((r, rx)) => r.map(|r| (r, rx)),
+                            };
+                            next.map(|(r, rx)| (r, (rx, s)))
+                        });
+
+                        // Once the stream ends, send the Complete message.
+                        let s = s.chain(
+                            Reaction::ServerMessage(ServerMessage::Complete { id }).to_stream(),
+                        );
+
+                        s.boxed()
+                    }
+                    ClientMessage::Stop { id } => {
+                        stoppers.remove(&id);
+                        stream::empty().boxed()
+                    }
+                    _ => stream::empty().boxed(),
+                }
+            }
+        }
+    }
+
+    async fn start(id: String, params: ExecutionParams<S>) -> BoxStream<'static, Reaction<S>> {
+        // TODO: This could be made more efficient if juniper exposed functionality to allow us to
+        // parse and validate the query, determine whether it's a subscription, and then execute
+        // it. For now, the query gets parsed and validated twice.
+
+        let params = Arc::new(params);
+
+        // Try to execute this as a query or mutation.
+        match juniper::execute(
+            &params.start_payload.query,
+            params
+                .start_payload
+                .operation_name
+                .as_ref()
+                .map(|s| s.as_str()),
+            params.schema.root_node(),
+            &params.start_payload.variables,
+            &params.config.context,
+        )
+        .await
+        {
+            Ok((data, errors)) => {
+                return Reaction::ServerMessage(ServerMessage::Data {
+                    id: id.clone(),
+                    payload: DataPayload { data, errors },
+                })
+                .to_stream();
+            }
+            Err(GraphQLError::IsSubscription) => {}
+            Err(e) => {
+                return Reaction::ServerMessage(ServerMessage::Error {
+                    id: id.clone(),
+                    payload: unsafe { ErrorPayload::new_unchecked(Box::new(params.clone()), e) },
+                })
+                .to_stream()
+            }
+        }
+
+        // Try to execute as a subscription.
+        SubscriptionStart::new(id, params.clone()).boxed()
+    }
+}
+
+struct InterruptableStream<S> {
+    stream: S,
+    rx: oneshot::Receiver<()>,
+}
+
+impl<S: Stream + Unpin> Stream for InterruptableStream<S> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        match Pin::new(&mut self.rx).poll(cx) {
+            Poll::Ready(_) => return Poll::Ready(None),
+            Poll::Pending => {}
+        }
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}
+
+/// SubscriptionStartState is the state for a subscription operation.
+enum SubscriptionStartState<S: Schema> {
+    /// Init is the start before being polled for the first time.
+    Init { id: String },
+    /// ResolvingIntoStream is the state after being polled for the first time. In this state,
+    /// we're parsing, validating, and getting the actual event stream.
+    ResolvingIntoStream {
+        id: String,
+        future: BoxFuture<
+            'static,
+            Result<
+                juniper_subscriptions::Connection<'static, S::ScalarValue>,
+                GraphQLError<'static>,
+            >,
+        >,
+    },
+    /// Streaming is the state after we've successfully obtained the event stream for the
+    /// subscription. In this state, we're just forwarding events back to the client.
+    Streaming {
+        id: String,
+        stream: juniper_subscriptions::Connection<'static, S::ScalarValue>,
+    },
+    /// Terminated is the state once we're all done.
+    Terminated,
+}
+
+/// SubscriptionStart is the stream for a subscription operation.
+struct SubscriptionStart<S: Schema> {
+    params: Arc<ExecutionParams<S>>,
+    state: SubscriptionStartState<S>,
+    _marker: PhantomPinned,
+}
+
+impl<S: Schema> SubscriptionStart<S> {
+    fn new(id: String, params: Arc<ExecutionParams<S>>) -> Pin<Box<Self>> {
+        Box::pin(Self {
+            params,
+            state: SubscriptionStartState::Init { id },
+            _marker: PhantomPinned,
+        })
+    }
+}
+
+impl<S: Schema> Stream for SubscriptionStart<S> {
+    type Item = Reaction<S>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let (params, state) = unsafe {
+            // XXX: The execution parameters are referenced by state and must not be modified.
+            // Modifying state is fine though.
+            let inner = self.get_unchecked_mut();
+            (&inner.params, &mut inner.state)
+        };
+
+        loop {
+            match state {
+                SubscriptionStartState::Init { id } => {
+                    // XXX: resolve_into_stream returns a Future that references the execution
+                    // parameters, and the returned stream also references them. We can guarantee
+                    // that everything has the same lifetime in this self-referential struct.
+                    let params = Arc::as_ptr(params);
+                    *state = SubscriptionStartState::ResolvingIntoStream {
+                        id: id.clone(),
+                        future: unsafe {
+                            juniper::resolve_into_stream(
+                                &(*params).start_payload.query,
+                                (*params)
+                                    .start_payload
+                                    .operation_name
+                                    .as_ref()
+                                    .map(|s| s.as_str()),
+                                (*params).schema.root_node(),
+                                &(*params).start_payload.variables,
+                                &(*params).config.context,
+                            )
+                        }
+                        .map_ok(|(stream, errors)| {
+                            juniper_subscriptions::Connection::from_stream(stream, errors)
+                        })
+                        .boxed(),
+                    };
+                }
+                SubscriptionStartState::ResolvingIntoStream {
+                    ref id,
+                    ref mut future,
+                } => match future.as_mut().poll(cx) {
+                    Poll::Ready(r) => match r {
+                        Ok(stream) => {
+                            *state = SubscriptionStartState::Streaming {
+                                id: id.clone(),
+                                stream,
+                            }
+                        }
+                        Err(e) => {
+                            return Poll::Ready(Some(Reaction::ServerMessage(
+                                ServerMessage::Error {
+                                    id: id.clone(),
+                                    payload: unsafe {
+                                        ErrorPayload::new_unchecked(Box::new(params.clone()), e)
+                                    },
+                                },
+                            )));
+                        }
+                    },
+                    Poll::Pending => return Poll::Pending,
+                },
+                SubscriptionStartState::Streaming {
+                    ref id,
+                    ref mut stream,
+                } => match Pin::new(stream).poll_next(cx) {
+                    Poll::Ready(Some((data, errors))) => {
+                        return Poll::Ready(Some(Reaction::ServerMessage(ServerMessage::Data {
+                            id: id.clone(),
+                            payload: DataPayload { data, errors },
+                        })));
+                    }
+                    Poll::Ready(None) => {
+                        *state = SubscriptionStartState::Terminated;
+                        return Poll::Ready(None);
+                    }
+                    Poll::Pending => return Poll::Pending,
+                },
+                SubscriptionStartState::Terminated => return Poll::Ready(None),
+            }
+        }
+    }
+}
+
+pub fn serve<St, StT, StE, S, I>(stream: St, schema: S, init: I) -> Serve<St, S, I>
+where
+    St: Stream<Item = StT> + Unpin,
+    StT: TryInto<ClientMessage<S::ScalarValue>, Error = StE>,
+    StE: Error,
+    S: Schema,
+    I: Init<S>,
+{
+    Serve {
+        stream,
+        reactions: SelectAll::new(),
+        state: ConnectionState::PreInit { init, schema },
+    }
+}
+
+/// Stream for the serve function.
+pub struct Serve<St, S: Schema, I: Init<S>> {
+    stream: St,
+    reactions: SelectAll<BoxStream<'static, Reaction<S>>>,
+    state: ConnectionState<S, I>,
+}
+
+impl<St, StT, StE, S, I> Stream for Serve<St, S, I>
+where
+    St: Stream<Item = StT> + Unpin,
+    StT: TryInto<ClientMessage<S::ScalarValue>, Error = StE>,
+    StE: Error,
+    S: Schema,
+    I: Init<S>,
+{
+    type Item = ServerMessage<S::ScalarValue>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        // Poll the connection for new incoming messages.
+        loop {
+            match Pin::new(&mut self.stream).poll_next(cx) {
+                Poll::Ready(Some(msg)) => {
+                    // We have a new message. Try to parse it and add the reaction stream.
+                    let reactions = match msg.try_into() {
+                        Ok(msg) => self.state.handle_message(msg),
+                        Err(e) => {
+                            // If we weren't able to parse the message, just send back an error and
+                            // carry on.
+                            Reaction::ServerMessage(ServerMessage::ConnectionError {
+                                payload: ConnectionErrorPayload {
+                                    message: e.to_string(),
+                                },
+                            })
+                            .to_stream()
+                        }
+                    };
+                    self.reactions.push(reactions);
+                }
+                Poll::Ready(None) => {
+                    // The connection stream has ended, so we should end too.
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => break,
+            }
+        }
+
+        // Poll the reactions for new outgoing messages.
+        loop {
+            if !self.reactions.is_empty() {
+                match Pin::new(&mut self.reactions).poll_next(cx) {
+                    Poll::Ready(Some(reaction)) => match reaction {
+                        Reaction::ServerMessage(msg) => return Poll::Ready(Some(msg)),
+                        Reaction::Activate { config, schema } => {
+                            self.state = ConnectionState::Active {
+                                config: Arc::new(config),
+                                stoppers: HashMap::new(),
+                                schema,
+                            }
+                        }
+                        Reaction::EndStream => return Poll::Ready(None),
+                    },
+                    Poll::Ready(None) => {
+                        // In rare cases, the reaction stream may terminate. For example, this will
+                        // happen if the first message we receive does not require any reaction. Just
+                        // recreate it in that case.
+                        self.reactions = SelectAll::new();
+                        return Poll::Pending;
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            } else {
+                return Poll::Pending;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::Infallible;
+    use super::*;
+    use juniper::{
+        futures::channel::mpsc, DefaultScalarValue, EmptyMutation, FieldResult, InputValue,
+        RootNode, Value,
+    };
+
+    struct Context(i32);
+
+    struct Query;
+
+    #[juniper::graphql_object(Context=Context)]
+    impl Query {
+        /// context just resolves to the current context.
+        async fn context(context: &Context) -> i32 {
+            context.0
+        }
+    }
+
+    struct Subscription;
+
+    #[juniper::graphql_subscription(Context=Context)]
+    impl Subscription {
+        /// context emits the current context once, then never emits anything else.
+        async fn context(context: &Context) -> BoxStream<'static, FieldResult<i32>> {
+            stream::once(future::ready(Ok(context.0)))
+                .chain(
+                    tokio::time::delay_for(Duration::from_secs(10000))
+                        .map(|_| unreachable!())
+                        .into_stream(),
+                )
+                .boxed()
+        }
+    }
+
+    type ClientMessage = super::ClientMessage<DefaultScalarValue>;
+    type ServerMessage = super::ServerMessage<DefaultScalarValue>;
+
+    fn new_test_schema() -> Arc<RootNode<'static, Query, EmptyMutation<Context>, Subscription>> {
+        Arc::new(RootNode::new(Query, EmptyMutation::new(), Subscription))
+    }
+
+    #[tokio::test]
+    async fn test_query() {
+        let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+        let mut rx = serve(
+            rx,
+            new_test_schema(),
+            ConnectionConfig::new(Context(1)).with_keep_alive_interval(Duration::from_secs(0)),
+        );
+
+        tx.unbounded_send(ClientMessage::ConnectionInit {
+            payload: Variables::default(),
+        })
+        .unwrap();
+
+        assert_eq!(ServerMessage::ConnectionAck, rx.next().await.unwrap());
+
+        tx.unbounded_send(ClientMessage::Start {
+            id: "foo".to_string(),
+            payload: StartPayload {
+                query: "{context}".to_string(),
+                variables: Variables::default(),
+                operation_name: None,
+            },
+        })
+        .unwrap();
+
+        assert_eq!(
+            ServerMessage::Data {
+                id: "foo".to_string(),
+                payload: DataPayload {
+                    data: Value::Object(
+                        [("context", Value::Scalar(DefaultScalarValue::Int(1)))]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    ),
+                    errors: vec![],
+                },
+            },
+            rx.next().await.unwrap()
+        );
+
+        assert_eq!(
+            ServerMessage::Complete {
+                id: "foo".to_string(),
+            },
+            rx.next().await.unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscription() {
+        let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+        let mut rx = serve(
+            rx,
+            new_test_schema(),
+            ConnectionConfig::new(Context(1)).with_keep_alive_interval(Duration::from_secs(0)),
+        );
+
+        tx.unbounded_send(ClientMessage::ConnectionInit {
+            payload: Variables::default(),
+        })
+        .unwrap();
+
+        assert_eq!(ServerMessage::ConnectionAck, rx.next().await.unwrap());
+
+        tx.unbounded_send(ClientMessage::Start {
+            id: "foo".to_string(),
+            payload: StartPayload {
+                query: "subscription Foo {context}".to_string(),
+                variables: Variables::default(),
+                operation_name: None,
+            },
+        })
+        .unwrap();
+
+        assert_eq!(
+            ServerMessage::Data {
+                id: "foo".to_string(),
+                payload: DataPayload {
+                    data: Value::Object(
+                        [("context", Value::scalar(1))]
+                            .iter()
+                            .cloned()
+                            .collect()
+                    ),
+                    errors: vec![],
+                },
+            },
+            rx.next().await.unwrap()
+        );
+
+        tx.unbounded_send(ClientMessage::Stop {
+            id: "foo".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            ServerMessage::Complete {
+                id: "foo".to_string(),
+            },
+            rx.next().await.unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_params_ok() {
+        let (tx, rx) = mpsc::unbounded::<ClientMessage>();
+        let mut rx = serve(
+            rx,
+            new_test_schema(),
+            |params: Variables<DefaultScalarValue>| async move {
+                assert_eq!(params.get("foo"), Some(&InputValue::scalar("bar")));
+                Ok(ConnectionConfig::new(Context(1))) as Result<_, Infallible>
+            },
+        );
+
+        tx.unbounded_send(ClientMessage::ConnectionInit {
+            payload: [(
+                "foo".to_string(),
+                InputValue::scalar("bar".to_string())
+            )]
+            .iter()
+            .cloned()
+            .collect(),
+        })
+        .unwrap();
+
+        assert_eq!(ServerMessage::ConnectionAck, rx.next().await.unwrap());
+    }
+}

--- a/juniper_graphql_ws/src/schema.rs
+++ b/juniper_graphql_ws/src/schema.rs
@@ -1,0 +1,131 @@
+use juniper::{GraphQLSubscriptionType, GraphQLTypeAsync, RootNode, ScalarValue};
+use std::sync::Arc;
+
+/// Schema defines the requirements for schemas that can be used for operations. Typically this is
+/// just an `Arc<RootNode<...>>` and you should not have to implement it yourself.
+pub trait Schema: Unpin + Clone + Send + Sync + 'static {
+    /// The context type.
+    type Context: Unpin + Send + Sync;
+
+    /// The scalar value type.
+    type ScalarValue: ScalarValue + Send + Sync;
+
+    /// The query type info.
+    type QueryTypeInfo: Send + Sync;
+
+    /// The query type.
+    type Query: GraphQLTypeAsync<Self::ScalarValue, Context = Self::Context, TypeInfo = Self::QueryTypeInfo>
+        + Send;
+
+    /// The mutation type info.
+    type MutationTypeInfo: Send + Sync;
+
+    /// The mutation type.
+    type Mutation: GraphQLTypeAsync<
+            Self::ScalarValue,
+            Context = Self::Context,
+            TypeInfo = Self::MutationTypeInfo,
+        > + Send;
+
+    /// The subscription type info.
+    type SubscriptionTypeInfo: Send + Sync;
+
+    /// The subscription type.
+    type Subscription: GraphQLSubscriptionType<
+            Self::ScalarValue,
+            Context = Self::Context,
+            TypeInfo = Self::SubscriptionTypeInfo,
+        > + Send;
+
+    /// Returns the root node for the schema.
+    fn root_node(
+        &self,
+    ) -> &RootNode<'static, Self::Query, Self::Mutation, Self::Subscription, Self::ScalarValue>;
+}
+
+/// This exists as a work-around for this issue: https://github.com/rust-lang/rust/issues/64552
+///
+/// It can be used in generators where using Arc directly would result in an error.
+// TODO: Remove this once that issue is resolved.
+#[doc(hidden)]
+pub struct ArcSchema<QueryT, MutationT, SubscriptionT, CtxT, S>(
+    pub Arc<RootNode<'static, QueryT, MutationT, SubscriptionT, S>>,
+)
+where
+    QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    QueryT::TypeInfo: Send + Sync,
+    MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    MutationT::TypeInfo: Send + Sync,
+    SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+    SubscriptionT::TypeInfo: Send + Sync,
+    CtxT: Unpin + Send + Sync,
+    S: ScalarValue + Send + Sync + 'static;
+
+impl<QueryT, MutationT, SubscriptionT, CtxT, S> Clone
+    for ArcSchema<QueryT, MutationT, SubscriptionT, CtxT, S>
+where
+    QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    QueryT::TypeInfo: Send + Sync,
+    MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    MutationT::TypeInfo: Send + Sync,
+    SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+    SubscriptionT::TypeInfo: Send + Sync,
+    CtxT: Unpin + Send + Sync,
+    S: ScalarValue + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<QueryT, MutationT, SubscriptionT, CtxT, S> Schema
+    for ArcSchema<QueryT, MutationT, SubscriptionT, CtxT, S>
+where
+    QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    QueryT::TypeInfo: Send + Sync,
+    MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    MutationT::TypeInfo: Send + Sync,
+    SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+    SubscriptionT::TypeInfo: Send + Sync,
+    CtxT: Unpin + Send + Sync + 'static,
+    S: ScalarValue + Send + Sync + 'static,
+{
+    type Context = CtxT;
+    type ScalarValue = S;
+    type QueryTypeInfo = QueryT::TypeInfo;
+    type Query = QueryT;
+    type MutationTypeInfo = MutationT::TypeInfo;
+    type Mutation = MutationT;
+    type SubscriptionTypeInfo = SubscriptionT::TypeInfo;
+    type Subscription = SubscriptionT;
+
+    fn root_node(&self) -> &RootNode<'static, QueryT, MutationT, SubscriptionT, S> {
+        &self.0
+    }
+}
+
+impl<QueryT, MutationT, SubscriptionT, CtxT, S> Schema
+    for Arc<RootNode<'static, QueryT, MutationT, SubscriptionT, S>>
+where
+    QueryT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    QueryT::TypeInfo: Send + Sync,
+    MutationT: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+    MutationT::TypeInfo: Send + Sync,
+    SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+    SubscriptionT::TypeInfo: Send + Sync,
+    CtxT: Unpin + Send + Sync,
+    S: ScalarValue + Send + Sync + 'static,
+{
+    type Context = CtxT;
+    type ScalarValue = S;
+    type QueryTypeInfo = QueryT::TypeInfo;
+    type Query = QueryT;
+    type MutationTypeInfo = MutationT::TypeInfo;
+    type Mutation = MutationT;
+    type SubscriptionTypeInfo = SubscriptionT::TypeInfo;
+    type Subscription = SubscriptionT;
+
+    fn root_node(&self) -> &RootNode<'static, QueryT, MutationT, SubscriptionT, S> {
+        self
+    }
+}

--- a/juniper_graphql_ws/src/server_message.rs
+++ b/juniper_graphql_ws/src/server_message.rs
@@ -1,0 +1,155 @@
+use juniper::{ExecutionError, GraphQLError, ScalarValue, Value};
+use serde::{Serialize, Serializer};
+use std::{any::Any, fmt, marker::PhantomPinned};
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionErrorPayload {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(bound(serialize = "S: ScalarValue"))]
+#[serde(rename_all = "camelCase")]
+pub struct DataPayload<S> {
+    pub data: Value<S>,
+    pub errors: Vec<ExecutionError<S>>,
+}
+
+// XXX: Think carefully before deriving traits. This is self-referential (error references
+// _execution_params).
+pub struct ErrorPayload {
+    _execution_params: Option<Box<dyn Any + Send>>,
+    error: GraphQLError<'static>,
+    _marker: PhantomPinned,
+}
+
+impl ErrorPayload {
+    /// For this to be okay, the caller must guarantee that the error can only reference data from
+    /// execution_params and that execution_params has not been modified or moved.
+    pub(crate) unsafe fn new_unchecked<'a>(
+        execution_params: Box<dyn Any + Send>,
+        error: GraphQLError<'a>,
+    ) -> Self {
+        Self {
+            _execution_params: Some(execution_params),
+            error: std::mem::transmute(error),
+            _marker: PhantomPinned,
+        }
+    }
+}
+
+impl fmt::Debug for ErrorPayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl PartialEq for ErrorPayload {
+    fn eq(&self, other: &Self) -> bool {
+        self.error.eq(&other.error)
+    }
+}
+
+impl Serialize for ErrorPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.error.serialize(serializer)
+    }
+}
+
+impl From<GraphQLError<'static>> for ErrorPayload {
+    fn from(error: GraphQLError<'static>) -> Self {
+        Self {
+            _execution_params: None,
+            error,
+            _marker: PhantomPinned,
+        }
+    }
+}
+
+/// ServerMessage defines the message types that servers can send.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(bound(serialize = "S: ScalarValue"))]
+#[serde(rename_all = "snake_case")]
+#[serde(tag = "type")]
+pub enum ServerMessage<S: ScalarValue> {
+    /// ConnectionError is used when the server rejects a connection based on the client's ConnectionInit
+    /// message or when the server encounters a protocol error such as not being able to parse a
+    /// client's message.
+    ConnectionError { payload: ConnectionErrorPayload },
+    /// ConnectionAck is sent in response to a client's ConnectionInit message if the server accepted a
+    /// connection.
+    ConnectionAck,
+    /// Data contains the result of a query, mutation, or subscription event.
+    Data { id: String, payload: DataPayload<S> },
+    /// Error contains an error that occurs before execution, such as validation errors.
+    Error { id: String, payload: ErrorPayload },
+    /// Complete indicates that no more data will be sent for the given operation.
+    Complete { id: String },
+    /// ConnectionKeepAlive is sent periodically after accepting a connection.
+    #[serde(rename = "ka")]
+    ConnectionKeepAlive,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use juniper::DefaultScalarValue;
+
+    #[test]
+    fn test_serialization() {
+        type ServerMessage = super::ServerMessage<DefaultScalarValue>;
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ConnectionError {
+                payload: ConnectionErrorPayload {
+                    message: "foo".to_string(),
+                },
+            })
+            .unwrap(),
+            r##"{"type":"connection_error","payload":{"message":"foo"}}"##,
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ConnectionAck).unwrap(),
+            r##"{"type":"connection_ack"}"##,
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::Data {
+                id: "foo".to_string(),
+                payload: DataPayload {
+                    data: Value::null(),
+                    errors: vec![],
+                },
+            })
+            .unwrap(),
+            r##"{"type":"data","id":"foo","payload":{"data":null,"errors":[]}}"##,
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::Error {
+                id: "foo".to_string(),
+                payload: GraphQLError::UnknownOperationName.into(),
+            })
+            .unwrap(),
+            r##"{"type":"error","id":"foo","payload":[{"message":"Unknown operation"}]}"##,
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::Complete {
+                id: "foo".to_string(),
+            })
+            .unwrap(),
+            r##"{"type":"complete","id":"foo"}"##,
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ConnectionKeepAlive).unwrap(),
+            r##"{"type":"ka"}"##,
+        );
+    }
+}

--- a/juniper_subscriptions/src/lib.rs
+++ b/juniper_subscriptions/src/lib.rs
@@ -222,19 +222,25 @@ where
                 }
 
                 if filled_count == obj_len {
+                    let mut errors = vec![];
                     filled_count = 0;
                     let new_vec = (0..obj_len).map(|_| None).collect::<Vec<_>>();
                     let ready_vec = std::mem::replace(&mut ready_vec, new_vec);
                     let ready_vec_iterator = ready_vec.into_iter().map(|el| {
                         let (name, val) = el.unwrap();
-                        if let Ok(value) = val {
-                            (name, value)
-                        } else {
-                            (name, Value::Null)
+                        match val {
+                            Ok(value) => (name, value),
+                            Err(e) => {
+                                errors.push(e);
+                                (name, Value::Null)
+                            }
                         }
                     });
                     let obj = Object::from_iter(ready_vec_iterator);
-                    Poll::Ready(Some(ExecutionOutput::from_data(Value::Object(obj))))
+                    Poll::Ready(Some(ExecutionOutput {
+                        data: Value::Object(obj),
+                        errors,
+                    }))
                 } else {
                     Poll::Pending
                 }

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/graphql-rust/juniper"
 edition = "2018"
 
 [features]
-subscriptions = ["juniper_subscriptions"]
+subscriptions = ["juniper_graphql_ws"]
 
 [dependencies]
 bytes = "0.5"
@@ -17,7 +17,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 futures = "0.3.1"
 juniper = { version = "0.14.2", path = "../juniper", default-features = false  }
-juniper_subscriptions = { path = "../juniper_subscriptions", optional = true }
+juniper_graphql_ws = { path = "../juniper_graphql_ws", optional = true }
 serde = { version = "1.0.75", features = ["derive"] }
 serde_json = "1.0.24"
 tokio = { version = "0.2", features = ["blocking", "rt-core"] }

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -469,7 +469,7 @@ pub mod subscriptions {
         Subscription::TypeInfo: Send + Sync,
         CtxT: Unpin + Send + Sync + 'static,
         S: ScalarValue + Send + Sync + 'static,
-        I: Init<S, CtxT>,
+        I: Init<S, CtxT> + Send,
     {
         let (ws_tx, ws_rx) = websocket.split();
         let (s_tx, s_rx) = Connection::new(ArcSchema(root_node), init).split();

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -393,237 +393,103 @@ fn playground_response(
 /// [1]: https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
 #[cfg(feature = "subscriptions")]
 pub mod subscriptions {
-    use std::{
-        collections::HashMap,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
-        },
-    };
-
-    use anyhow::anyhow;
-    use futures::{channel::mpsc, Future, StreamExt as _, TryFutureExt as _, TryStreamExt as _};
     use juniper::{
-        http::GraphQLRequest, ExecutionError, InputValue, ScalarValue,
-        SubscriptionCoordinator as _, Value,
+        futures::{
+            future::{self, Either},
+            sink::SinkExt,
+            stream::StreamExt,
+        },
+        GraphQLSubscriptionType, GraphQLTypeAsync, RootNode, ScalarValue,
     };
-    use juniper_subscriptions::Coordinator;
-    use serde::{Deserialize, Serialize};
-    use warp::ws::Message;
+    use juniper_graphql_ws::{ArcSchema, ClientMessage, Connection, Init};
+    use std::{convert::Infallible, fmt, sync::Arc};
 
-    #[derive(Serialize)]
-    struct DataPayload<'a, S: ScalarValue> {
-        data: &'a Value<S>,
-        errors: &'a Vec<ExecutionError<S>>,
-    }
+    struct Message(warp::ws::Message);
 
-    /// Listen to incoming messages and do one of the following:
-    ///  - execute subscription and return values from stream
-    ///  - stop stream and close ws connection
-    #[allow(dead_code)]
-    pub fn graphql_subscriptions<Query, Mutation, Subscription, CtxT, S>(
-        websocket: warp::ws::WebSocket,
-        coordinator: Arc<Coordinator<'static, Query, Mutation, Subscription, CtxT, S>>,
-        context: CtxT,
-    ) -> impl Future<Output = Result<(), anyhow::Error>> + Send
-    where
-        Query: juniper::GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
-        Query::TypeInfo: Send + Sync,
-        Mutation: juniper::GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
-        Mutation::TypeInfo: Send + Sync,
-        Subscription: juniper::GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
-        Subscription::TypeInfo: Send + Sync,
-        CtxT: Send + Sync + 'static,
-        S: ScalarValue + Send + Sync + 'static,
-    {
-        let (sink_tx, sink_rx) = websocket.split();
-        let (ws_tx, ws_rx) = mpsc::unbounded();
-        tokio::task::spawn(
-            ws_rx
-                .take_while(|v: &Option<_>| futures::future::ready(v.is_some()))
-                .map(|x| x.unwrap())
-                .forward(sink_tx),
-        );
+    impl<S: ScalarValue> std::convert::TryFrom<Message> for ClientMessage<S> {
+        type Error = serde_json::Error;
 
-        let context = Arc::new(context);
-        let got_close_signal = Arc::new(AtomicBool::new(false));
-        let got_close_signal2 = got_close_signal.clone();
-
-        struct SubscriptionState {
-            should_stop: AtomicBool,
+        fn try_from(msg: Message) -> serde_json::Result<Self> {
+            serde_json::from_slice(msg.0.as_bytes())
         }
-        let subscription_states = HashMap::<String, Arc<SubscriptionState>>::new();
-
-        sink_rx
-            .map_err(move |e| {
-                got_close_signal2.store(true, Ordering::Relaxed);
-                anyhow!("Websocket error: {}", e)
-            })
-            .try_fold(subscription_states, move |mut subscription_states, msg| {
-                let coordinator = coordinator.clone();
-                let context = context.clone();
-                let got_close_signal = got_close_signal.clone();
-                let ws_tx = ws_tx.clone();
-
-                async move {
-                    if msg.is_close() {
-                        return Ok(subscription_states);
-                    }
-
-                    let msg = msg
-                        .to_str()
-                        .map_err(|_| anyhow!("Non-text messages are not accepted"))?;
-                    let request: WsPayload<S> = serde_json::from_str(msg)
-                        .map_err(|e| anyhow!("Invalid WsPayload: {}", e))?;
-
-                    match request.type_name.as_str() {
-                        "connection_init" => {}
-                        "start" => {
-                            if got_close_signal.load(Ordering::Relaxed) {
-                                return Ok(subscription_states);
-                            }
-
-                            let request_id = request.id.clone().unwrap_or("1".to_owned());
-
-                            if let Some(existing) = subscription_states.get(&request_id) {
-                                existing.should_stop.store(true, Ordering::Relaxed);
-                            }
-                            let state = Arc::new(SubscriptionState {
-                                should_stop: AtomicBool::new(false),
-                            });
-                            subscription_states.insert(request_id.clone(), state.clone());
-
-                            let ws_tx = ws_tx.clone();
-
-                            if let Some(ref payload) = request.payload {
-                                if payload.query.is_none() {
-                                    return Err(anyhow!("Query not found"));
-                                }
-                            } else {
-                                return Err(anyhow!("Payload not found"));
-                            }
-
-                            tokio::task::spawn(async move {
-                                let payload = request.payload.unwrap();
-
-                                let graphql_request = GraphQLRequest::<S>::new(
-                                    payload.query.unwrap(),
-                                    None,
-                                    payload.variables,
-                                );
-
-                                let values_stream = match coordinator
-                                    .subscribe(&graphql_request, &context)
-                                    .await
-                                {
-                                    Ok(s) => s,
-                                    Err(err) => {
-                                        let _ =
-                                            ws_tx.unbounded_send(Some(Ok(Message::text(format!(
-                                                r#"{{"type":"error","id":"{}","payload":{}}}"#,
-                                                request_id,
-                                                serde_json::ser::to_string(&err).unwrap_or(
-                                                    "Error deserializing GraphQLError".to_owned()
-                                                )
-                                            )))));
-
-                                        let close_message = format!(
-                                            r#"{{"type":"complete","id":"{}","payload":null}}"#,
-                                            request_id
-                                        );
-                                        let _ = ws_tx
-                                            .unbounded_send(Some(Ok(Message::text(close_message))));
-                                        // close channel
-                                        let _ = ws_tx.unbounded_send(None);
-                                        return;
-                                    }
-                                };
-
-                                values_stream
-                                    .take_while(move |(data, errors)| {
-                                        let request_id = request_id.clone();
-                                        let should_stop = state.should_stop.load(Ordering::Relaxed)
-                                            || got_close_signal.load(Ordering::Relaxed);
-                                        if !should_stop {
-                                            let mut response_text =
-                                                serde_json::to_string(&DataPayload {
-                                                    data,
-                                                    errors,
-                                                })
-                                                .unwrap_or(
-                                                    "Error deserializing response".to_owned(),
-                                                );
-
-                                            response_text = format!(
-                                                r#"{{"type":"data","id":"{}","payload":{} }}"#,
-                                                request_id, response_text
-                                            );
-
-                                            let _ = ws_tx.unbounded_send(Some(Ok(Message::text(
-                                                response_text,
-                                            ))));
-                                        }
-
-                                        async move { !should_stop }
-                                    })
-                                    .for_each(|_| async {})
-                                    .await;
-                            });
-                        }
-                        "stop" => {
-                            let request_id = request.id.unwrap_or("1".to_owned());
-                            if let Some(existing) = subscription_states.get(&request_id) {
-                                existing.should_stop.store(true, Ordering::Relaxed);
-                                subscription_states.remove(&request_id);
-                            }
-
-                            let close_message = format!(
-                                r#"{{"type":"complete","id":"{}","payload":null}}"#,
-                                request_id
-                            );
-                            let _ = ws_tx.unbounded_send(Some(Ok(Message::text(close_message))));
-
-                            // close channel
-                            let _ = ws_tx.unbounded_send(None);
-                        }
-                        _ => {}
-                    }
-
-                    Ok(subscription_states)
-                }
-            })
-            .map_ok(|_| ())
     }
 
-    #[derive(Deserialize)]
-    #[serde(bound = "GraphQLPayload<S>: Deserialize<'de>")]
-    struct WsPayload<S>
+    /// Errors that can happen while serving a connection.
+    #[derive(Debug)]
+    pub enum Error {
+        /// Errors that can happen in Warp while serving a connection.
+        Warp(warp::Error),
+
+        /// Errors that can happen while serializing outgoing messages. Note that errors that occur
+        /// while deserializing internal messages are handled internally by the protocol.
+        Serde(serde_json::Error),
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Warp(e) => write!(f, "warp error: {}", e),
+                Self::Serde(e) => write!(f, "serde error: {}", e),
+            }
+        }
+    }
+
+    impl std::error::Error for Error {}
+
+    impl From<warp::Error> for Error {
+        fn from(err: warp::Error) -> Self {
+            Self::Warp(err)
+        }
+    }
+
+    impl From<Infallible> for Error {
+        fn from(_err: Infallible) -> Self {
+            unreachable!()
+        }
+    }
+
+    /// Serves the graphql-ws protocol over a WebSocket connection.
+    ///
+    /// The `init` argument is used to provide the context and additional configuration for
+    /// connections. This can be a `juniper_graphql_ws::ConnectionConfig` if the context and
+    /// configuration are already known, or it can be a closure that gets executed asynchronously
+    /// when the client sends the ConnectionInit message. Using a closure allows you to perform
+    /// authentication based on the parameters provided by the client.
+    pub async fn serve_graphql_ws<Query, Mutation, Subscription, CtxT, S, I>(
+        websocket: warp::ws::WebSocket,
+        root_node: Arc<RootNode<'static, Query, Mutation, Subscription, S>>,
+        init: I,
+    ) -> Result<(), Error>
     where
-        S: ScalarValue + Send + Sync,
+        Query: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+        Query::TypeInfo: Send + Sync,
+        Mutation: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
+        Mutation::TypeInfo: Send + Sync,
+        Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
+        Subscription::TypeInfo: Send + Sync,
+        CtxT: Unpin + Send + Sync + 'static,
+        S: ScalarValue + Send + Sync + 'static,
+        I: Init<S, CtxT>,
     {
-        id: Option<String>,
-        #[serde(rename(deserialize = "type"))]
-        type_name: String,
-        payload: Option<GraphQLPayload<S>>,
-    }
+        let (ws_tx, ws_rx) = websocket.split();
+        let (s_tx, s_rx) = Connection::new(ArcSchema(root_node), init).split();
 
-    #[derive(Debug, Deserialize)]
-    #[serde(bound = "InputValue<S>: Deserialize<'de>")]
-    struct GraphQLPayload<S>
-    where
-        S: ScalarValue + Send + Sync,
-    {
-        variables: Option<InputValue<S>>,
-        extensions: Option<HashMap<String, String>>,
-        #[serde(rename(deserialize = "operationName"))]
-        operaton_name: Option<String>,
-        query: Option<String>,
-    }
+        let ws_rx = ws_rx.map(|r| r.map(|msg| Message(msg)));
+        let s_rx = s_rx.map(|msg| {
+            serde_json::to_string(&msg)
+                .map(|t| warp::ws::Message::text(t))
+                .map_err(|e| Error::Serde(e))
+        });
 
-    #[derive(Serialize)]
-    struct Output {
-        data: String,
-        variables: String,
+        match future::select(
+            ws_rx.forward(s_tx.sink_err_into()),
+            s_rx.forward(ws_tx.sink_err_into()),
+        )
+        .await
+        {
+            Either::Left((r, _)) => r.map_err(|e| e.into()),
+            Either::Right((r, _)) => r,
+        }
     }
 }
 


### PR DESCRIPTION
This add a new crate: `juniper_graphql_ws`. This crate implements the [Apollo graphql-ws protocol](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md).

This is a replacement for the implementation that was previously in `juniper_warp`. A few of the differences:

* ~Simplifies `SubscriptionConnection`. There is a dedicated PR for this here: https://github.com/graphql-rust/juniper/pull/719. This can be reviewed separately, or that PR can be closed and everything can just be reviewed at once.~ (Edit: This was merged separately.)
* Errors are now correctly emitted for field resolution errors within subscription event streams. Previously they were just being silently dropped inside of `juniper_subscriptions::whole_responses_stream`. This and the first bullet are the only changes outside of the new crate, `juniper_warp::subscriptions` mod, and the `warp_subscriptions` example.
* Types for all graphql-ws message types have been added. This makes a host of things much easier than before, and makes serialization and deserialization much safer and more robust. For example, previously, if a client sent a "}" in a message id, we would do bad things because the implementation was crafting responses using `format!`.
* The server now responds to "connection_init" with the appropriate "ack" + "keep-alive".
* The server now sends keep-alives. These default to a 30 second interval, but are configurable.
* Queries and mutations can now be executed over the same WebSocket connection.
* Stopping a subscription now has well-defined timing. All work is immediately dropped and the "complete" message is not sent until we can guarantee that no other events will be sent.
* We now have more reasonable behavior for "weird things" such as clients using the same id for multiple subscriptions, not sending "init" packets, etc. Clients *must* send an "init" packet before anything else happens, and multiple subscriptions with the same id do not start multiple unstoppable background streams.
* We now correctly send "error" messages for pre-execution errors and "data" packets for errors that happen during execution.
* We now correctly send "connection_error" messages for issues not associated with operations such as malformed client messages.
* There is now a configurable maximum number of operations a single connection can have at any time.
* Parameters from the client's "connection_init" message are now parsed and can be used as parameters for context creation. Because we actually require the "connection_init" message now, no context is required until this point. This enables support for authentication via this message.
* Serialization and deserialization are defined outside of the crate, so users can serialize in the way that's most optimal for them. You don't even have to use JSON.
* There are now unit tests, and lots of them. Because the entire implementation is contained by a single `Sink + Stream` and there are proper message types, writing unit tests is a breeze.

I suspect there are more. The previous implementation was really rough. But on to the usage.

## Usage

I'm just going to copy a unit test:

```rust
#[tokio::test]
async fn test_query() {
    let mut conn = Connection::new(
        new_test_schema(),
        ConnectionConfig::new(Context(1)).with_keep_alive_interval(Duration::from_secs(0)),
    );

    conn.send(ClientMessage::ConnectionInit {
        payload: Variables::default(),
    })
    .await
    .unwrap();

    assert_eq!(ServerMessage::ConnectionAck, conn.next().await.unwrap());

    conn.send(ClientMessage::Start {
        id: "foo".to_string(),
        payload: StartPayload {
            query: "{context}".to_string(),
            variables: Variables::default(),
            operation_name: None,
        },
    })
    .await
    .unwrap();

    assert_eq!(
        ServerMessage::Data {
            id: "foo".to_string(),
            payload: DataPayload {
                data: Value::Object(
                    [("context", Value::Scalar(DefaultScalarValue::Int(1)))]
                        .iter()
                        .cloned()
                        .collect()
                ),
                errors: vec![],
            },
        },
        conn.next().await.unwrap()
    );

    assert_eq!(
        ServerMessage::Complete {
            id: "foo".to_string(),
        },
        conn.next().await.unwrap()
    );
}
```

It couldn't really be any easier.

The second argument to `Connection::new` is generic. Instead of `ConnectionConfig`, you can provide a closure:

```rust
let mut conn = Connection::new(new_test_schema(), |params: Variables| async move {
    Ok(ConnectionConfig::new(Context(1))) as Result<_, Infallible>
});
```

This allows you to defer the configuration until you receive the "connection_init" parameters. Any error returned by this closure is sent back the client.

The entire `juniper_warp::subscriptions` module is now just a few lines to compose the sinks and streams:

```rust
/// Serves the graphql-ws protocol over a WebSocket connection.
///
/// The `init` argument is used to provide the context and additional configuration for
/// connections. This can be a `juniper_graphql_ws::ConnectionConfig` if the context and
/// configuration are already known, or it can be a closure that gets executed asynchronously
/// when the client sends the ConnectionInit message. Using a closure allows you to perform
/// authentication based on the parameters provided by the client.
pub async fn serve_graphql_ws<Query, Mutation, Subscription, CtxT, S, I>(
    websocket: warp::ws::WebSocket,
    root_node: Arc<RootNode<'static, Query, Mutation, Subscription, S>>,
    init: I,
) -> Result<(), Error>
where
    Query: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
    Query::TypeInfo: Send + Sync,
    Mutation: GraphQLTypeAsync<S, Context = CtxT> + Send + 'static,
    Mutation::TypeInfo: Send + Sync,
    Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
    Subscription::TypeInfo: Send + Sync,
    CtxT: Unpin + Send + Sync + 'static,
    S: ScalarValue + Send + Sync + 'static,
    I: Init<S, CtxT> + Send,
{
    let (ws_tx, ws_rx) = websocket.split();
    let (s_tx, s_rx) = Connection::new(ArcSchema(root_node), init).split();

    let ws_rx = ws_rx.map(|r| r.map(|msg| Message(msg)));
    let s_rx = s_rx.map(|msg| {
        serde_json::to_string(&msg)
            .map(|t| warp::ws::Message::text(t))
            .map_err(|e| Error::Serde(e))
    });

    match future::select(
        ws_rx.forward(s_tx.sink_err_into()),
        s_rx.forward(ws_tx.sink_err_into()),
    )
    .await
    {
        Either::Left((r, _)) => r.map_err(|e| e.into()),
        Either::Right((r, _)) => r,
    }
}
```

So adding support for the other frameworks should be pretty trivial now and they can all share one implementation.

## Related Issues

* Depends on / includes https://github.com/graphql-rust/juniper/pull/719
* Obsoletes https://github.com/graphql-rust/juniper/pull/717
* Obsoletes https://github.com/graphql-rust/juniper/pull/617
* Obsoletes https://github.com/graphql-rust/juniper/pull/597
* Simplifies https://github.com/graphql-rust/juniper/pull/716
* Simplifies https://github.com/graphql-rust/juniper/issues/649

* Closes #709