### PR TITLE
Use the standard subscription keep-alive message

### DIFF
--- a/juniper_graphql_ws/src/server_message.rs
+++ b/juniper_graphql_ws/src/server_message.rs
@@ -126,7 +126,6 @@ pub enum ServerMessage<S: ScalarValue> {
         id: String,
     },
     /// ConnectionKeepAlive is sent periodically after accepting a connection.
-    #[serde(rename = "ka")]
     ConnectionKeepAlive,
 }
 
@@ -185,7 +184,7 @@ mod test {
 
         assert_eq!(
             serde_json::to_string(&ServerMessage::ConnectionKeepAlive).unwrap(),
-            r##"{"type":"ka"}"##,
+            r##"{"type":"connection_keep_alive"}"##,
         );
     }
 }


### PR DESCRIPTION
Use the [standard subscription keep-alive message](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_connection_keep_alive) so that the clients can handle it automatically.