### PR TITLE
Actix subscriptions tests

### DIFF
--- a/examples/actix_subscriptions/Cargo.toml
+++ b/examples/actix_subscriptions/Cargo.toml
@@ -13,7 +13,7 @@ actix-cors = "0.2.0"
 futures = "0.3.5"
 tokio = { version = "0.2", features = ["rt-core", "macros"] }
 env_logger = "0.7.1"
-serde = "1.0.114"
+serde = "1.0.115"
 serde_json = "1.0.57"
 rand = "0.7.3"
 

--- a/examples/actix_subscriptions/Cargo.toml
+++ b/examples/actix_subscriptions/Cargo.toml
@@ -17,6 +17,6 @@ serde = "1.0.115"
 serde_json = "1.0.57"
 rand = "0.7.3"
 
-juniper = { path = "../../juniper", features = ["expose-test-schema", "serde_json"] }
+juniper = { path = "../../juniper", features = ["expose-test-schema"] }
 juniper_actix = { path = "../../juniper_actix", features = ["subscriptions"] }
 juniper_graphql_ws = { path = "../../juniper_graphql_ws" }

--- a/examples/actix_subscriptions/src/main.rs
+++ b/examples/actix_subscriptions/src/main.rs
@@ -2,7 +2,6 @@ use std::{env, pin::Pin, time::Duration};
 
 use actix_cors::Cors;
 use actix_web::{middleware, web, App, Error, HttpRequest, HttpResponse, HttpServer};
-use futures::Stream;
 
 use juniper::{
     tests::fixtures::starwars::{model::Database, schema::Query},
@@ -49,14 +48,15 @@ impl RandomHuman {
     }
 }
 
+type RandomHumanStream =
+    Pin<Box<dyn futures::Stream<Item = Result<RandomHuman, FieldError>> + Send>>;
+
 #[juniper::graphql_subscription(Context = Database)]
 impl Subscription {
     #[graphql(
         description = "A random humanoid creature in the Star Wars universe every 3 seconds. Second result will be an error."
     )]
-    async fn random_human(
-        context: &Database,
-    ) -> Pin<Box<dyn Stream<Item = Result<RandomHuman, FieldError>> + Send>> {
+    async fn random_human(context: &Database) -> RandomHumanStream {
         let mut counter = 0;
 
         let context = (*context).clone();

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -54,7 +54,6 @@ uuid = { version = "0.8", optional = true }
 graphql-parser = {version = "0.3.0", optional = true }
 
 [dev-dependencies]
-anyhow = { version = "1.0.32" }
 bencher = "0.1.2"
 serde_json = { version = "1.0.2" }
 tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -54,6 +54,7 @@ uuid = { version = "0.8", optional = true }
 graphql-parser = {version = "0.3.0", optional = true }
 
 [dev-dependencies]
+anyhow = { version = "1.0.32" }
 bencher = "0.1.2"
 serde_json = { version = "1.0.2" }
 tokio = { version = "0.2", features = ["macros", "rt-core", "time"] }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 path = "benches/bench.rs"
 
 [features]
-expose-test-schema = ["serde_json"]
+expose-test-schema = ["anyhow", "async-trait", "serde_json"]
 schema-language = ["graphql-parser-integration"]
 graphql-parser-integration = ["graphql-parser"]
 default = [
@@ -39,6 +39,8 @@ scalar-naivetime = []
 [dependencies]
 juniper_codegen = { version = "0.14.2", path = "../juniper_codegen"  }
 
+anyhow = { version = "1.0.32", optional = true }
+async-trait = { version = "0.1.36", optional = true }
 bson = { version = "1.0.0", optional = true }
 chrono = { version = "0.4.0", optional = true }
 fnv = "1.0.3"

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -24,7 +24,7 @@ harness = false
 path = "benches/bench.rs"
 
 [features]
-expose-test-schema = ["anyhow", "async-trait", "serde_json"]
+expose-test-schema = ["anyhow", "serde_json"]
 schema-language = ["graphql-parser-integration"]
 graphql-parser-integration = ["graphql-parser"]
 default = [
@@ -40,7 +40,6 @@ scalar-naivetime = []
 juniper_codegen = { version = "0.14.2", path = "../juniper_codegen"  }
 
 anyhow = { version = "1.0.32", optional = true }
-async-trait = { version = "0.1.36", optional = true }
 bson = { version = "1.0.0", optional = true }
 chrono = { version = "0.4.0", optional = true }
 fnv = "1.0.3"

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -353,7 +353,7 @@ where
     }
 }
 
-#[cfg(any(test, feature = "expose-test-schema"))]
+#[cfg(feature = "expose-test-schema")]
 #[allow(missing_docs)]
 pub mod tests {
     use crate::LocalBoxFuture;

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -589,7 +589,8 @@ pub mod tests {
     pub trait WsIntegration {
         /// Runs a test with the given messages
         fn run(
-            &self, messages: Vec<WsIntegrationMessage>
+            &self,
+            messages: Vec<WsIntegrationMessage>,
         ) -> LocalBoxFuture<Result<(), anyhow::Error>>;
     }
 

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -356,7 +356,7 @@ where
 #[cfg(any(test, feature = "expose-test-schema"))]
 #[allow(missing_docs)]
 pub mod tests {
-    use async_trait::async_trait;
+    use crate::LocalBoxFuture;
     use serde_json::{self, Value as Json};
 
     /// Normalized response content we expect to get back from
@@ -586,10 +586,11 @@ pub mod tests {
     }
 
     /// Normalized way to make requests to the WebSocket framework integration we are testing.
-    #[async_trait(?Send)]
     pub trait WsIntegration {
         /// Runs a test with the given messages
-        async fn run(&self, messages: Vec<WsIntegrationMessage>) -> Result<(), anyhow::Error>;
+        fn run(
+            &self, messages: Vec<WsIntegrationMessage>
+        ) -> LocalBoxFuture<Result<(), anyhow::Error>>;
     }
 
     /// WebSocket framework integration message

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -122,7 +122,7 @@ extern crate bson;
 pub use {futures, static_assertions as sa};
 
 #[doc(inline)]
-pub use futures::future::BoxFuture;
+pub use futures::future::{BoxFuture, LocalBoxFuture};
 
 // Depend on juniper_codegen and re-export everything in it.
 // This allows users to just depend on juniper and get the derive

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -36,4 +36,4 @@ env_logger = "0.7.1"
 log = "0.4.11"
 tokio = { version = "0.2", features = ["time"] }
 
-juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }
+juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -19,7 +19,7 @@ actix-web-actors = "2.0.0"
 
 futures = { version = "0.3.5", features = ["compat"] }
 tokio = { version = "0.2", features = ["time"] }
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 anyhow = "1.0"
 thiserror = "1.0"
@@ -31,9 +31,10 @@ juniper_graphql_ws = { path = "../juniper_graphql_ws", optional = true }
 actix-cors = "0.2.0"
 actix-identity = "0.2.1"
 
+async-trait = "0.1.36"
 bytes = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.11"
-tokio = { version = "0.2", features = ["rt-core", "macros", "blocking"] }
+tokio = { version = "0.2", features = ["time"] }
 
 juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -31,7 +31,6 @@ juniper_graphql_ws = { path = "../juniper_graphql_ws", optional = true }
 actix-cors = "0.2.0"
 actix-identity = "0.2.1"
 
-async-trait = "0.1.36"
 bytes = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.11"

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -34,6 +34,5 @@ actix-identity = "0.2.1"
 bytes = "0.5.6"
 env_logger = "0.7.1"
 log = "0.4.11"
-tokio = { version = "0.2", features = ["time"] }
 
 juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { version = "0.10", features = ["blocking", "rustls-tls"] }
 
 [dev-dependencies.juniper]
 version = "0.14.2"
-features = ["expose-test-schema", "serde_json"]
+features = ["expose-test-schema"]
 path = "../juniper"
 
 [dev-dependencies.tokio]

--- a/juniper_iron/Cargo.toml
+++ b/juniper_iron/Cargo.toml
@@ -29,5 +29,5 @@ percent-encoding = "2"
 
 [dev-dependencies.juniper]
 version = "0.14.2"
-features = ["expose-test-schema", "serde_json"]
+features = ["expose-test-schema"]
 path = "../juniper"

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -18,5 +18,5 @@ rocket = { version = "0.4.2", default-features = false }
 
 [dev-dependencies.juniper]
 version = "0.14.2"
-features = ["expose-test-schema", "serde_json"]
+features = ["expose-test-schema"]
 path = "../juniper"

--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -20,5 +20,5 @@ tokio = { version = "0.2", features = ["rt-core", "macros"] }
 
 [dev-dependencies.juniper]
 version = "0.14.2"
-features = ["expose-test-schema", "serde_json"]
+features = ["expose-test-schema"]
 path = "../juniper"

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -25,7 +25,7 @@ warp = "0.2"
 
 [dev-dependencies]
 env_logger = "0.7.1"
-juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema", "serde_json"] }
+juniper = { version = "0.14.2", path = "../juniper", features = ["expose-test-schema"] }
 log = "0.4.3"
 percent-encoding = "2"
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-core"] }


### PR DESCRIPTION
A tiny subscriptions tests framework. 

An array of messages (to be sent or to be expected) is created and then given to the runner. This should work nicely with any web server. An example can be found below.

```rust
async fn test_ws_simple_subscription<T: WsIntegration>(integration: &T) {
    let messages = vec![
        WsIntegrationMessage::Send(
            r#"{
                "type":"connection_init",
                "payload":{}
            }"#
            .to_owned(),
        ),
        WsIntegrationMessage::Expect(
            r#"{
                "type":"connection_ack"
            }"#
            .to_owned(),
            WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
        ),
        WsIntegrationMessage::Expect(
            r#"{
                "type":"ka"
            }"#
            .to_owned(),
            WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
        ),
        WsIntegrationMessage::Send(
            r#"{
                "id":"1",
                "type":"start",
                "payload":{
                    "variables":{},
                    "extensions":{},
                    "operationName":null,
                    "query":"subscription { asyncHuman { id, name, homePlanet } }"
                }
            }"#
            .to_owned(),
        ),
        WsIntegrationMessage::Expect(
            r#"{
                "type":"data",
                "id":"1",
                "payload":{
                    "data":{
                        "asyncHuman":{
                            "id":"stream id",
                            "name":"stream name",
                            "homePlanet":"stream home planet"
                        }
                    }
                }
            }"#
            .to_owned(),
            WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
        ),
    ];

    integration.run(messages).await.unwrap();
}
```