### PR TITLE
Reduce warp_subscriptions example to 15 seconds so that GQL clients don't disconnect

### DIFF
--- a/juniper_graphql_ws/src/lib.rs
+++ b/juniper_graphql_ws/src/lib.rs
@@ -63,7 +63,7 @@ impl<CtxT> ConnectionConfig<CtxT> {
         Self {
             context,
             max_in_flight_operations: 0,
-            keep_alive_interval: Duration::from_secs(30),
+            keep_alive_interval: Duration::from_secs(15),
         }
     }
 


### PR DESCRIPTION
Closes #754 