### PR TITLE
Allow disabling case convertion

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/derive_enum.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_enum.rs
@@ -16,6 +16,13 @@ enum SomeEnum {
     Full,
 }
 
+#[derive(juniper::GraphQLEnum, Debug, PartialEq)]
+#[graphql(rename = "none")]
+enum NoRenameEnum {
+    OneVariant,
+    AnotherVariant,
+}
+
 /// Enum doc.
 #[derive(juniper::GraphQLEnum)]
 enum DocEnum {
@@ -63,6 +70,12 @@ fn test_derived_enum() {
 
     assert_eq!(meta.name(), Some("Some"));
     assert_eq!(meta.description(), Some(&"enum descr".to_string()));
+
+    // Test no rename variant.
+    assert_eq!(
+        <_ as ToInputValue>::to_input_value(&NoRenameEnum::AnotherVariant),
+        InputValue::scalar("AnotherVariant")
+    );
 
     // Test Regular variant.
     assert_eq!(

--- a/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/derive_input_object.rs
@@ -20,6 +20,12 @@ struct Input {
     other: Option<bool>,
 }
 
+#[derive(GraphQLInputObject, Debug, PartialEq)]
+#[graphql(rename = "none")]
+struct NoRenameInput {
+    regular_field: String,
+}
+
 /// Object comment.
 #[derive(GraphQLInputObject, Debug, PartialEq)]
 struct DocComment {
@@ -145,6 +151,21 @@ fn test_derived_input_object() {
             regular_field: "a".into(),
             c: 55,
             other: Some(true),
+        }
+    );
+
+    // Test disable renaming
+
+    let input: InputValue = ::serde_json::from_value(serde_json::json!({
+        "regular_field": "hello",
+    }))
+    .unwrap();
+
+    let output: NoRenameInput = FromInputValue::from_input_value(&input).unwrap();
+    assert_eq!(
+        output,
+        NoRenameInput {
+            regular_field: "hello".into(),
         }
     );
 }

--- a/juniper_codegen/src/derive_enum.rs
+++ b/juniper_codegen/src/derive_enum.rs
@@ -4,7 +4,7 @@ use syn::{ext::IdentExt, spanned::Spanned, Data, Fields};
 
 use crate::{
     result::{GraphQLScope, UnsupportedAttribute},
-    util::{self, span_container::SpanContainer},
+    util::{self, span_container::SpanContainer, RenameRule},
 };
 
 pub fn impl_enum(ast: syn::DeriveInput, error: GraphQLScope) -> syn::Result<TokenStream> {
@@ -48,7 +48,12 @@ pub fn impl_enum(ast: syn::DeriveInput, error: GraphQLScope) -> syn::Result<Toke
                 .name
                 .clone()
                 .map(SpanContainer::into_inner)
-                .unwrap_or_else(|| util::to_upper_snake_case(&field_name.unraw().to_string()));
+                .unwrap_or_else(|| {
+                    attrs
+                        .rename
+                        .unwrap_or(RenameRule::ScreamingSnakeCase)
+                        .apply(&field_name.unraw().to_string())
+                });
 
             let resolver_code = quote!( #ident::#field_name );
 

--- a/juniper_codegen/src/derive_input_object.rs
+++ b/juniper_codegen/src/derive_input_object.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::match_wild_err_arm)]
 use crate::{
     result::{GraphQLScope, UnsupportedAttribute},
-    util::{self, span_container::SpanContainer},
+    util::{self, span_container::SpanContainer, RenameRule},
 };
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -50,7 +50,10 @@ pub fn impl_input_object(ast: syn::DeriveInput, error: GraphQLScope) -> syn::Res
             let field_ident = field.ident.as_ref().unwrap();
             let name = match field_attrs.name {
                 Some(ref name) => name.to_string(),
-                None => crate::util::to_camel_case(&field_ident.unraw().to_string()),
+                None => attrs
+                    .rename
+                    .unwrap_or(RenameRule::CamelCase)
+                    .apply(&field_ident.unraw().to_string()),
             };
 
             if let Some(span) = field_attrs.skip {

--- a/juniper_codegen/src/derive_object.rs
+++ b/juniper_codegen/src/derive_object.rs
@@ -1,6 +1,6 @@
 use crate::{
     result::{GraphQLScope, UnsupportedAttribute},
-    util::{self, span_container::SpanContainer},
+    util::{self, span_container::SpanContainer, RenameRule},
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -50,7 +50,12 @@ pub fn build_derive_object(ast: syn::DeriveInput, error: GraphQLScope) -> syn::R
                 .name
                 .clone()
                 .map(SpanContainer::into_inner)
-                .unwrap_or_else(|| util::to_camel_case(&field_name.unraw().to_string()));
+                .unwrap_or_else(|| {
+                    attrs
+                        .rename
+                        .unwrap_or(RenameRule::CamelCase)
+                        .apply(&field_name.unraw().to_string())
+                });
 
             if name.starts_with("__") {
                 error.no_double_underscore(if let Some(name) = field_attrs.name {

--- a/juniper_codegen/src/impl_object.rs
+++ b/juniper_codegen/src/impl_object.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     result::{GraphQLScope, UnsupportedAttribute},
-    util::{self, span_container::SpanContainer},
+    util::{self, span_container::SpanContainer, RenameRule},
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -44,6 +44,8 @@ fn create(
         .map(SpanContainer::into_inner)
         .unwrap_or_else(|| _impl.type_ident.unraw().to_string());
 
+    let top_attrs = &_impl.attrs;
+
     let fields = _impl
         .methods
         .iter()
@@ -78,7 +80,12 @@ fn create(
                     let final_name = attrs
                         .argument(&arg_name)
                         .and_then(|attrs| attrs.rename.clone().map(|ident| ident.value()))
-                        .unwrap_or_else(|| util::to_camel_case(&arg_name));
+                        .unwrap_or_else(|| {
+                            top_attrs
+                                .rename
+                                .unwrap_or(RenameRule::CamelCase)
+                                .apply(&arg_name)
+                        });
 
                     let expect_text = format!(
                         "Internal error: missing argument {} - validation must have failed",
@@ -137,7 +144,12 @@ fn create(
                 .name
                 .clone()
                 .map(SpanContainer::into_inner)
-                .unwrap_or_else(|| util::to_camel_case(&ident.unraw().to_string()));
+                .unwrap_or_else(|| {
+                    top_attrs
+                        .rename
+                        .unwrap_or(RenameRule::CamelCase)
+                        .apply(&ident.unraw().to_string())
+                });
 
             if name.starts_with("__") {
                 error.no_double_underscore(if let Some(name) = attrs.name {


### PR DESCRIPTION
Add a new attribute `rename` which could be "none", "camelCase", "SCREAMING_SNAKE_CASE".
By default (when this attribute is not specified) the exiting rules apply: camelCase to structs, SCREAMING_SNAKE_CASE to enums.

Inspired by Serde & Structopts.

This does not change interfaces because I haven't figured how to do them yet.

Re https://github.com/graphql-rust/juniper/issues/201.