### PR TITLE
Make parsing publicly accessible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "examples/warp_async",
   "examples/warp_subscriptions",
   "examples/actix_subscriptions",
+  "examples/simple",
   "integration_tests/juniper_tests",
   "integration_tests/async_await",
   "integration_tests/codegen_fail",

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "simple"
+version = "0.1.0"
+authors = ["Miroslav Zoricak <miroslav.zoricak@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+juniper = { git = "https://github.com/graphql-rust/juniper" }
+juniper_warp = { git = "https://github.com/graphql-rust/juniper" }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,0 +1,59 @@
+use juniper::http::{GraphQLRequest, GraphQLResponse};
+use juniper::Document;
+use juniper::{
+    graphql_object, DefaultScalarValue, EmptyMutation, EmptySubscription, ParseError, RootNode,
+    Spanning,
+};
+
+#[derive(Clone, Copy, Debug)]
+struct Context;
+impl juniper::Context for Context {}
+
+#[derive(Clone, Debug)]
+struct User {
+    name: String,
+}
+
+#[graphql_object(Context = Context)]
+impl User {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Query;
+
+#[graphql_object(Context = Context)]
+impl Query {
+    fn users() -> Vec<User> {
+        vec![User {
+            name: "user1".into(),
+        }]
+    }
+}
+
+type Schema = RootNode<'static, Query, EmptyMutation<Context>, EmptySubscription<Context>>;
+
+fn main() {
+    let schema = Schema::new(
+        Query,
+        EmptyMutation::<Context>::new(),
+        EmptySubscription::<Context>::new(),
+    );
+    let ctx = Context {};
+    let query = r#" query { users { name } } "#;
+    let req = GraphQLRequest::<DefaultScalarValue>::new(query.to_owned(), None, None);
+
+    {
+        // Just parse the request query
+        let doc: Result<Document<DefaultScalarValue>, Spanning<ParseError>> = req.parse(&schema);
+        println!("{:#?}", &doc);
+    }
+
+    {
+        // Execute the query synchronously
+        let res: GraphQLResponse = req.execute_sync(&schema, &ctx);
+        println!("{:#?}", &res);
+    }
+}

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -142,6 +142,10 @@ pub enum Definition<'a, S> {
     Fragment(Spanning<Fragment<'a, S>>),
 }
 
+/// Parsed GraphQL request.
+///
+/// `S` is an instance of [ScalarValue]
+/// By default [DefaultScalarValue]
 pub type Document<'a, S> = Vec<Definition<'a, S>>;
 
 /// Parse an unstructured input value into a Rust data type.

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -163,12 +163,12 @@ pub use crate::util::to_camel_case;
 use crate::{
     executor::{execute_validated_query, get_operation},
     introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS},
-    parser::{parse_document_source, ParseError, Spanning},
+    parser::parse_document_source,
     validation::{validate_input_values, visit_all_rules, ValidatorContext},
 };
 
 pub use crate::{
-    ast::{FromInputValue, InputValue, Selection, ToInputValue, Type},
+    ast::{Document, FromInputValue, InputValue, Selection, ToInputValue, Type},
     executor::{
         Applies, Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
         FromContext, IntoFieldError, IntoResolvable, LookAheadArgument, LookAheadMethods,
@@ -176,6 +176,7 @@ pub use crate::{
     },
     introspection::IntrospectionFormat,
     macros::subscription_helpers::{ExtractTypeFromStream, IntoFieldResult},
+    parser::{ParseError, Spanning},
     schema::{
         meta,
         model::{RootNode, SchemaType},


### PR DESCRIPTION
Partial fix for #726 
Reference #773 

I've added `parse` as a public method on the `GraphQLRequest` type. I've documented and exposed `Document`, `Spanning` and `ParseError` to allow working with the resulting type.