### PR TITLE
Implement `IntoFieldError` for `Infallible`

### DIFF
--- a/integration_tests/juniper_tests/src/infallible_as_field_error.rs
+++ b/integration_tests/juniper_tests/src/infallible_as_field_error.rs
@@ -1,0 +1,8 @@
+struct Query;
+
+#[juniper::graphql_object]
+impl Query {
+    fn ping() -> Result<bool, std::convert::Infallible> {
+        Ok(false)
+    }
+}

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -7,6 +7,8 @@ mod custom_scalar;
 #[cfg(test)]
 mod explicit_null;
 #[cfg(test)]
+mod infallible_as_field_error;
+#[cfg(test)]
 mod issue_371;
 #[cfg(test)]
 mod issue_398;

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -37,6 +37,9 @@
 
 - Added support for distinguishing between between implicit and explicit null. ([#795](https://github.com/graphql-rust/juniper/pull/795))
   
+
+- Implement `IntoFieldError` for `std::convert::Infallible`. ([#796](https://github.com/graphql-rust/juniper/pull/796))
+
 ## Fixes
 
 - Massively improved the `#[graphql_union]` proc macro. ([#666](https://github.com/graphql-rust/juniper/pull/666)):

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -246,6 +246,12 @@ impl<S> IntoFieldError<S> for FieldError<S> {
     }
 }
 
+impl<S> IntoFieldError<S> for std::convert::Infallible {
+    fn into_field_error(self) -> FieldError<S> {
+        match self {}
+    }
+}
+
 #[doc(hidden)]
 pub trait IntoResolvable<'a, S, T, C>
 where


### PR DESCRIPTION
Makes it possible to use `Result<T, Infallible>` as your return type from resolvers, which can be handy sometimes.