### PR TITLE
Add descriptive value validation errors

### DIFF
--- a/juniper/src/executor_tests/enums.rs
+++ b/juniper/src/executor_tests/enums.rs
@@ -99,7 +99,7 @@ async fn does_not_accept_string_literals() {
     assert_eq!(
         error,
         ValidationError(vec![RuleError::new(
-            r#"Invalid value for argument "color", expected type "Color!""#,
+            r#"Error for argument "color": Invalid value ""RED"" for enum "Color""#,
             &[SourcePosition::new(18, 0, 18)],
         )])
     );

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1038,7 +1038,7 @@ async fn does_not_allow_missing_required_field() {
     assert_eq!(
         error,
         ValidationError(vec![RuleError::new(
-            r#"Invalid value for argument "arg", expected type "ExampleInputObject!""#,
+            r#"Error for argument "arg": "ExampleInputObject" is missing fields: "b""#,
             &[SourcePosition::new(20, 0, 20)],
         )])
     );
@@ -1062,7 +1062,7 @@ async fn does_not_allow_null_in_required_field() {
     assert_eq!(
         error,
         ValidationError(vec![RuleError::new(
-            r#"Invalid value for argument "arg", expected type "ExampleInputObject!""#,
+            r#"Error for argument "arg": Error on "ExampleInputObject" field "b": Type "Int!" is not nullable"#,
             &[SourcePosition::new(20, 0, 20)],
         )])
     );

--- a/juniper/src/types/utilities.rs
+++ b/juniper/src/types/utilities.rs
@@ -1,34 +1,132 @@
 use crate::{
     ast::InputValue,
     schema::{
-        meta::{EnumMeta, InputObjectMeta, MetaType},
+        meta::{Argument, EnumMeta, InputObjectMeta, MetaType},
         model::{SchemaType, TypeType},
     },
     value::ScalarValue,
 };
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Display, iter::Iterator};
 
-pub fn is_valid_literal_value<S>(
+pub fn non_null_error_message<T>(arg_type: T) -> String
+where
+    T: Display,
+{
+    format!("Type \"{}\" is not nullable", arg_type)
+}
+
+pub fn enum_error_message<T, U>(arg_value: T, arg_type: U) -> String
+where
+    T: Display,
+    U: Display,
+{
+    format!("Invalid value \"{}\" for enum \"{}\"", arg_value, arg_type)
+}
+
+pub fn type_error_message<T, U>(arg_value: T, arg_type: U) -> String
+where
+    T: Display,
+    U: Display,
+{
+    format!("Invalid value \"{}\" for type \"{}\"", arg_value, arg_type)
+}
+
+pub fn parser_error_message<T>(arg_type: T) -> String
+where
+    T: Display,
+{
+    format!("Parser error for \"{}\"", arg_type)
+}
+
+pub fn input_object_error_message<T>(arg_type: T) -> String
+where
+    T: Display,
+{
+    format!("\"{}\" is not an input object", arg_type)
+}
+
+pub fn field_error_message<T, U>(arg_type: T, field_name: U, error_message: &str) -> String
+where
+    T: Display,
+    U: Display,
+{
+    format!(
+        "Error on \"{}\" field \"{}\": {}",
+        arg_type, field_name, error_message
+    )
+}
+
+pub fn missing_field_error_message<T, U>(arg_type: T, missing_fields: U) -> String
+where
+    T: Display,
+    U: Display,
+{
+    format!("\"{}\" is missing fields: {}", arg_type, missing_fields)
+}
+
+pub fn unknown_field_error_message<T, U>(arg_type: T, field_name: U) -> String
+where
+    T: Display,
+    U: Display,
+{
+    format!(
+        "Field \"{}\" does not exist on type \"{}\"",
+        field_name, arg_type
+    )
+}
+
+/// Returns an error string if the field is invalid
+fn validate_object_field<S>(
+    schema: &SchemaType<S>,
+    object_type: &TypeType<S>,
+    object_fields: &Vec<Argument<S>>,
+    field_value: &InputValue<S>,
+    field_key: &str,
+) -> Option<String>
+where
+    S: ScalarValue,
+{
+    let field_type = object_fields
+        .iter()
+        .filter(|f| f.name == field_key)
+        .map(|f| schema.make_type(&f.arg_type))
+        .next();
+
+    if let Some(field_arg_type) = field_type {
+        let error_message = validate_literal_value(schema, &field_arg_type, field_value);
+
+        if let Some(error_message) = error_message {
+            Some(field_error_message(object_type, field_key, &error_message))
+        } else {
+            None
+        }
+    } else {
+        Some(unknown_field_error_message(object_type, field_key))
+    }
+}
+
+/// Returns an error string if the value is invalid
+pub fn validate_literal_value<S>(
     schema: &SchemaType<S>,
     arg_type: &TypeType<S>,
     arg_value: &InputValue<S>,
-) -> bool
+) -> Option<String>
 where
     S: ScalarValue,
 {
     match *arg_type {
         TypeType::NonNull(ref inner) => {
             if arg_value.is_null() {
-                false
+                Some(non_null_error_message(arg_type))
             } else {
-                is_valid_literal_value(schema, inner, arg_value)
+                validate_literal_value(schema, inner, arg_value)
             }
         }
         TypeType::List(ref inner) => match *arg_value {
             InputValue::List(ref items) => items
                 .iter()
-                .all(|i| is_valid_literal_value(schema, inner, &i.item)),
-            ref v => is_valid_literal_value(schema, inner, v),
+                .find_map(|i| validate_literal_value(schema, inner, &i.item)),
+            ref v => validate_literal_value(schema, inner, v),
         },
         TypeType::Concrete(t) => {
             // Even though InputValue::String can be parsed into an enum, they
@@ -36,19 +134,23 @@ where
             if let (&InputValue::Scalar(_), Some(&MetaType::Enum(EnumMeta { .. }))) =
                 (arg_value, arg_type.to_concrete())
             {
-                return false;
+                return Some(enum_error_message(arg_value, arg_type));
             }
 
             match *arg_value {
-                InputValue::Null | InputValue::Variable(_) => true,
+                InputValue::Null | InputValue::Variable(_) => None,
                 ref v @ InputValue::Scalar(_) | ref v @ InputValue::Enum(_) => {
                     if let Some(parse_fn) = t.input_value_parse_fn() {
-                        parse_fn(v)
+                        if parse_fn(v) {
+                            None
+                        } else {
+                            Some(type_error_message(arg_value, arg_type))
+                        }
                     } else {
-                        false
+                        Some(parser_error_message(arg_type))
                     }
                 }
-                InputValue::List(_) => false,
+                InputValue::List(_) => Some("Input lists are not literals".to_owned()),
                 InputValue::Object(ref obj) => {
                     if let MetaType::InputObject(InputObjectMeta {
                         ref input_fields, ..
@@ -65,23 +167,33 @@ where
                             })
                             .collect::<HashSet<_>>();
 
-                        let all_types_ok = obj.iter().all(|&(ref key, ref value)| {
+                        let error_message = obj.iter().find_map(|&(ref key, ref value)| {
                             remaining_required_fields.remove(&key.item);
-                            if let Some(ref arg_type) = input_fields
-                                .iter()
-                                .filter(|f| f.name == key.item)
-                                .map(|f| schema.make_type(&f.arg_type))
-                                .next()
-                            {
-                                is_valid_literal_value(schema, arg_type, &value.item)
-                            } else {
-                                false
-                            }
+                            validate_object_field(
+                                schema,
+                                arg_type,
+                                input_fields,
+                                &value.item,
+                                &key.item,
+                            )
                         });
 
-                        all_types_ok && remaining_required_fields.is_empty()
+                        if error_message.is_some() {
+                            return error_message;
+                        }
+
+                        if remaining_required_fields.is_empty() {
+                            None
+                        } else {
+                            let missing_fields = remaining_required_fields
+                                .into_iter()
+                                .map(|s| format!("\"{}\"", &**s))
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            Some(missing_field_error_message(arg_type, missing_fields))
+                        }
                     } else {
-                        false
+                        Some(input_object_error_message(arg_type))
                     }
                 }
             }

--- a/juniper/src/validation/rules/default_values_of_correct_type.rs
+++ b/juniper/src/validation/rules/default_values_of_correct_type.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::VariableDefinition,
     parser::Spanning,
-    types::utilities::is_valid_literal_value,
+    types::utilities::validate_literal_value,
     validation::{ValidatorContext, Visitor},
     value::ScalarValue,
 };
@@ -35,9 +35,15 @@ where
             } else {
                 let meta_type = ctx.schema.make_type(&var_def.var_type.item);
 
-                if !is_valid_literal_value(ctx.schema, &meta_type, var_value) {
+                if let Some(error_message) =
+                    validate_literal_value(ctx.schema, &meta_type, var_value)
+                {
                     ctx.report_error(
-                        &type_error_message(var_name.item, &format!("{}", var_def.var_type.item)),
+                        &type_error_message(
+                            var_name.item,
+                            &format!("{}", var_def.var_type.item),
+                            &error_message,
+                        ),
                         &[*start],
                     );
                 }
@@ -46,16 +52,16 @@ where
     }
 }
 
-fn type_error_message(arg_name: &str, type_name: &str) -> String {
+fn type_error_message(arg_name: &str, type_name: &str, reason: &str) -> String {
     format!(
-        "Invalid default value for argument \"{}\", expected type \"{}\"",
-        arg_name, type_name
+        "Invalid default value for argument \"{}\", expected type \"{}\".  Reason: {}",
+        arg_name, type_name, reason
     )
 }
 
 fn non_null_error_message(arg_name: &str, type_name: &str) -> String {
     format!(
-        "Argument \"{}\" has type \"{}\" and is not nullable, so it't can't have a default value",
+        "Argument \"{}\" has type \"{}\" and is not nullable, so it can't have a default value",
         arg_name, type_name
     )
 }
@@ -66,6 +72,7 @@ mod tests {
 
     use crate::{
         parser::SourcePosition,
+        types::utilities,
         validation::{expect_fails_rule, expect_passes_rule, RuleError},
         value::DefaultScalarValue,
     };
@@ -147,15 +154,27 @@ mod tests {
         "#,
             &[
                 RuleError::new(
-                    &type_error_message("a", "Int"),
+                    &type_error_message(
+                        "a",
+                        "Int",
+                        &utilities::type_error_message("\"one\"", "Int"),
+                    ),
                     &[SourcePosition::new(61, 2, 22)],
                 ),
                 RuleError::new(
-                    &type_error_message("b", "String"),
+                    &type_error_message(
+                        "b",
+                        "String",
+                        &utilities::type_error_message("4", "String"),
+                    ),
                     &[SourcePosition::new(93, 3, 25)],
                 ),
                 RuleError::new(
-                    &type_error_message("c", "ComplexInput"),
+                    &type_error_message(
+                        "c",
+                        "ComplexInput",
+                        &utilities::type_error_message("\"notverycomplex\"", "ComplexInput"),
+                    ),
                     &[SourcePosition::new(127, 4, 31)],
                 ),
             ],
@@ -172,7 +191,11 @@ mod tests {
           }
         "#,
             &[RuleError::new(
-                &type_error_message("a", "ComplexInput"),
+                &type_error_message(
+                    "a",
+                    "ComplexInput",
+                    &utilities::missing_field_error_message("ComplexInput", "\"requiredField\""),
+                ),
                 &[SourcePosition::new(57, 1, 56)],
             )],
         );
@@ -188,7 +211,11 @@ mod tests {
           }
         "#,
             &[RuleError::new(
-                &type_error_message("a", "[String]"),
+                &type_error_message(
+                    "a",
+                    "[String]",
+                    &utilities::type_error_message("2", "String"),
+                ),
                 &[SourcePosition::new(44, 1, 43)],
             )],
         );


### PR DESCRIPTION
Fixes: #693 

This pull request adds descriptive errors when validating argument and default values.

For example, an input object missing a field would show `Error for argument "arg": "ExampleInputObject" is missing fields: "b"`.

If there's a different approach you'd like to take for this, I'd be happy to implement that as well.