### PR TITLE
Allow raw identifier for field arguments

### DIFF
--- a/integration_tests/juniper_tests/src/codegen/impl_object.rs
+++ b/integration_tests/juniper_tests/src/codegen/impl_object.rs
@@ -94,3 +94,17 @@ mod fallible {
         }
     }
 }
+
+mod raw_arguments {
+    use juniper::graphql_object;
+
+    struct Obj;
+
+    #[graphql_object]
+    impl Obj {
+        #[graphql(arguments(r#arg(description = "The only argument")))]
+        fn test(&self, arg: String) -> String {
+            arg
+        }
+    }
+}

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -58,11 +58,24 @@ impl Root {
         arg
     }
 
+    #[graphql(arguments(r#arg(description = "The arg")))]
+    fn single_arg_descr_raw_idents(arg: i32) -> i32 {
+        arg
+    }
+
     #[graphql(arguments(
         arg1(description = "The first arg",),
         arg2(description = "The second arg")
     ))]
     fn multi_args_descr(arg1: i32, arg2: i32) -> i32 {
+        arg1 + arg2
+    }
+
+    #[graphql(arguments(
+        r#arg1(description = "The first arg",),
+        r#arg2(description = "The second arg")
+    ))]
+    fn multi_args_descr_raw_idents(arg1: i32, arg2: i32) -> i32 {
         arg1 + arg2
     }
 
@@ -106,6 +119,11 @@ impl Root {
         arg
     }
 
+    #[graphql(arguments(r#arg(default = 123, description = "The arg")))]
+    fn arg_with_default_descr_raw_ident(arg: i32) -> i32 {
+        arg
+    }
+
     #[graphql(arguments(
         arg1(default = 123, description = "The first arg"),
         arg2(default = 456, description = "The second arg")
@@ -115,10 +133,26 @@ impl Root {
     }
 
     #[graphql(arguments(
+        r#arg1(default = 123, description = "The first arg"),
+        r#arg2(default = 456, description = "The second arg")
+    ))]
+    fn multi_args_with_default_descr_raw_ident(arg1: i32, arg2: i32) -> i32 {
+        arg1 + arg2
+    }
+
+    #[graphql(arguments(
         arg1(default = 123, description = "The first arg",),
         arg2(default = 456, description = "The second arg",)
     ))]
     fn multi_args_with_default_trailing_comma_descr(arg1: i32, arg2: i32) -> i32 {
+        arg1 + arg2
+    }
+
+    #[graphql(arguments(
+        r#arg1(default = 123, description = "The first arg",),
+        r#arg2(default = 456, description = "The second arg",)
+    ))]
+    fn multi_args_with_default_trailing_comma_descr_raw_ident(arg1: i32, arg2: i32) -> i32 {
         arg1 + arg2
     }
 
@@ -461,8 +495,102 @@ async fn introspect_field_single_arg_descr() {
 }
 
 #[tokio::test]
+async fn introspect_field_single_arg_descr_raw_idents() {
+    run_args_info_query("singleArgDescrRawIdents", |args| {
+        assert_eq!(args.len(), 1);
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg")),
+                ("description", Value::scalar("The arg")),
+                ("defaultValue", Value::null()),
+                (
+                    "type",
+                    Value::object(
+                        vec![
+                            ("name", Value::null()),
+                            (
+                                "ofType",
+                                Value::object(
+                                    vec![("name", Value::scalar("Int"))].into_iter().collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn introspect_field_multi_args_descr() {
     run_args_info_query("multiArgsDescr", |args| {
+        assert_eq!(args.len(), 2);
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg1")),
+                ("description", Value::scalar("The first arg")),
+                ("defaultValue", Value::null()),
+                (
+                    "type",
+                    Value::object(
+                        vec![
+                            ("name", Value::null()),
+                            (
+                                "ofType",
+                                Value::object(
+                                    vec![("name", Value::scalar("Int"))].into_iter().collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg2")),
+                ("description", Value::scalar("The second arg")),
+                ("defaultValue", Value::null()),
+                (
+                    "type",
+                    Value::object(
+                        vec![
+                            ("name", Value::null()),
+                            (
+                                "ofType",
+                                Value::object(
+                                    vec![("name", Value::scalar("Int"))].into_iter().collect(),
+                                ),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn introspect_field_multi_args_descr_raw_idents() {
+    run_args_info_query("multiArgsDescrRawIdents", |args| {
         assert_eq!(args.len(), 2);
 
         assert!(args.contains(&Value::object(
@@ -787,6 +915,32 @@ async fn introspect_field_arg_with_default_descr() {
 }
 
 #[tokio::test]
+async fn introspect_field_arg_with_default_descr_raw_ident() {
+    run_args_info_query("argWithDefaultDescrRawIdent", |args| {
+        assert_eq!(args.len(), 1);
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg")),
+                ("description", Value::scalar("The arg")),
+                ("defaultValue", Value::scalar("123")),
+                (
+                    "type",
+                    Value::object(
+                        vec![("name", Value::scalar("Int")), ("ofType", Value::null())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn introspect_field_multi_args_with_default_descr() {
     run_args_info_query("multiArgsWithDefaultDescr", |args| {
         assert_eq!(args.len(), 2);
@@ -831,8 +985,96 @@ async fn introspect_field_multi_args_with_default_descr() {
 }
 
 #[tokio::test]
+async fn introspect_field_multi_args_with_default_descr_raw_ident() {
+    run_args_info_query("multiArgsWithDefaultDescrRawIdent", |args| {
+        assert_eq!(args.len(), 2);
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg1")),
+                ("description", Value::scalar("The first arg")),
+                ("defaultValue", Value::scalar("123")),
+                (
+                    "type",
+                    Value::object(
+                        vec![("name", Value::scalar("Int")), ("ofType", Value::null())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg2")),
+                ("description", Value::scalar("The second arg")),
+                ("defaultValue", Value::scalar("456")),
+                (
+                    "type",
+                    Value::object(
+                        vec![("name", Value::scalar("Int")), ("ofType", Value::null())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn introspect_field_multi_args_with_default_trailing_comma_descr() {
     run_args_info_query("multiArgsWithDefaultTrailingCommaDescr", |args| {
+        assert_eq!(args.len(), 2);
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg1")),
+                ("description", Value::scalar("The first arg")),
+                ("defaultValue", Value::scalar("123")),
+                (
+                    "type",
+                    Value::object(
+                        vec![("name", Value::scalar("Int")), ("ofType", Value::null())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+
+        assert!(args.contains(&Value::object(
+            vec![
+                ("name", Value::scalar("arg2")),
+                ("description", Value::scalar("The second arg")),
+                ("defaultValue", Value::scalar("456")),
+                (
+                    "type",
+                    Value::object(
+                        vec![("name", Value::scalar("Int")), ("ofType", Value::null())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        )));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn introspect_field_multi_args_with_default_trailing_comma_descr_raw_ident() {
+    run_args_info_query("multiArgsWithDefaultTrailingCommaDescrRawIdent", |args| {
         assert_eq!(args.len(), 2);
 
         assert!(args.contains(&Value::object(

--- a/juniper/src/macros/tests/args.rs
+++ b/juniper/src/macros/tests/args.rs
@@ -81,7 +81,7 @@ impl Root {
 
     #[graphql(arguments(
         arg1(description = "The first arg",),
-        arg2(description = "The second arg")
+        arg2(description = "The second arg",)
     ))]
     fn multi_args_descr_trailing_comma(arg1: i32, arg2: i32) -> i32 {
         arg1 + arg2

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -11,11 +11,12 @@ use proc_macro_error::abort;
 use quote::quote;
 use span_container::SpanContainer;
 use syn::{
+    ext::IdentExt,
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
     spanned::Spanned,
-    token, Attribute, Lit, Meta, MetaList, MetaNameValue, NestedMeta,
+    token, Attribute, Ident, Lit, Meta, MetaList, MetaNameValue, NestedMeta,
 };
 
 use crate::common::parse::ParseBufferExt as _;
@@ -450,7 +451,7 @@ pub struct FieldAttributeArgument {
 
 impl Parse for FieldAttributeArgument {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let name = input.parse()?;
+        let name = input.parse::<Ident>()?.unraw();
 
         let mut arg = Self {
             name,

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -11,7 +11,7 @@ use proc_macro_error::abort;
 use quote::quote;
 use span_container::SpanContainer;
 use syn::{
-    ext::IdentExt,
+    ext::IdentExt as _,
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,


### PR DESCRIPTION
Fixes #786.

This pull request allows raw identifiers to be used for field arguments, and updates `multi_args_descr_trailing_comma` to include a trailing comma.