### PR TITLE
Mark `Arc` with `IsInputType` & `IsOutputType`.

### DIFF
--- a/integration_tests/juniper_tests/src/arc_fields.rs
+++ b/integration_tests/juniper_tests/src/arc_fields.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+struct Query;
+
+#[juniper::graphql_object]
+impl Query {
+    fn ping() -> Arc<bool> {
+        Arc::new(false)
+    }
+}
+
+#[derive(juniper::GraphQLInputObject)]
+struct Ping {
+    expect_result: Arc<bool>,
+}

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod api;
 #[cfg(test)]
+mod arc_fields;
+#[cfg(test)]
 mod codegen;
 #[cfg(test)]
 mod custom_scalar;

--- a/juniper/src/types/marker.rs
+++ b/juniper/src/types/marker.rs
@@ -168,5 +168,18 @@ where
 {
 }
 
+impl<S, T> IsInputType<S> for std::sync::Arc<T>
+where
+    T: IsInputType<S> + ?Sized,
+    S: ScalarValue,
+{
+}
+impl<S, T> IsOutputType<S> for std::sync::Arc<T>
+where
+    T: IsOutputType<S> + ?Sized,
+    S: ScalarValue,
+{
+}
+
 impl<'a, S> IsInputType<S> for str where S: ScalarValue {}
 impl<'a, S> IsOutputType<S> for str where S: ScalarValue {}

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -283,6 +283,19 @@ where
     }
 }
 
+impl<T, S> FromInputValue<S> for Arc<T>
+where
+    S: ScalarValue,
+    T: FromInputValue<S>,
+{
+    fn from_input_value(v: &InputValue<S>) -> Option<Arc<T>> {
+        match <T as FromInputValue<S>>::from_input_value(v) {
+            Some(v) => Some(Arc::new(v)),
+            None => None,
+        }
+    }
+}
+
 impl<T, S> ToInputValue<S> for Arc<T>
 where
     S: fmt::Debug,


### PR DESCRIPTION
We've just updated a service we work with to the latest release of
juniper (it's been on a fairly old master commit for some time).  In
this service we have some fields that are contained within `Arc`s, which
I added support for in #479.

Since then it seems the new marker traits of `IsInputType` &
`IsOutputType` have been added, but they do not support `Arc`, leading
to:

```
error[E0277]: the trait bound `Arc<menu::Menu>: IsOutputType<__S>` is not satisfied
  --> src/graphql.rs:36:1
   |
36 | #[juniper::graphql_object(Context=Context)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `Arc<menu::Menu>`
   |
   = note: required by `juniper::marker::IsOutputType::mark`
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

This commit adds impls for `Arc`, mirroring the impls for `Box`.

I'm not sure if there's a good place to add a test for this
functionality so that regressions can be avoided in the future?