### PR TITLE
Fix release replacements.

### DIFF
--- a/_build/release.toml
+++ b/_build/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="CHANGELOG.md", search="# master", replace="# master\n\n- Compatibility with the latest `juniper`.\n\n# [[{{version}}] {{date}}](https://github.com/graphql-rust/juniper/releases/tag/{{crate_name}}-{{version}})"},
 ]

--- a/juniper/release.toml
+++ b/juniper/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   # Juniper's changelog
   {file="CHANGELOG.md", search="# master", replace="# master\n\n- No changes yet\n\n# [[{{version}}] {{date}}](https://github.com/graphql-rust/juniper/releases/tag/{{crate_name}}-{{version}})"},

--- a/juniper_codegen/release.toml
+++ b/juniper_codegen/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="../juniper/Cargo.toml", search="juniper_codegen = \\{ version = \"[^\"]+\"", replace="juniper_codegen = { version = \"{{version}}\""},
   {file="src/lib.rs", search="docs.rs/juniper_codegen/[a-z0-9\\.-]+", replace="docs.rs/juniper_codegen/{{version}}"},

--- a/juniper_graphql_ws/Makefile.toml
+++ b/juniper_graphql_ws/Makefile.toml
@@ -1,3 +1,15 @@
+# This is needed as the release config is at a different path than the top-level
+# release config.
+
+[tasks.release-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
+
+[tasks.release-dry-run-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
+
+[tasks.release-local-test-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]
+
 [env]
 CARGO_MAKE_CARGO_ALL_FEATURES = ""
 

--- a/juniper_graphql_ws/release.toml
+++ b/juniper_graphql_ws/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_graphql_ws/[a-z0-9\\.-]+", replace="docs.rs/juniper_graphql_ws/{{version}}"},
 {file="../juniper_warp/Cargo.toml", search="juniper_graphql_ws = \\{ version = \"[^\"]+\"", replace="juniper_graphql_ws = { version = \"{{version}}\""},

--- a/juniper_hyper/release.toml
+++ b/juniper_hyper/release.toml
@@ -1,7 +1,0 @@
-no-dev-version = true
-pre-release-commit-message = "Release {{crate_name}} {{version}}"
-pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
-tag-message = "Release {{crate_name}} {{version}}"
-pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_hyper/[a-z0-9\\.-]+", replace="docs.rs/juniper_hyper/{{version}}"},
-]

--- a/juniper_hyper/release.toml
+++ b/juniper_hyper/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_hyper/[a-z0-9\\.-]+", replace="docs.rs/juniper_hyper/{{version}}"},
 ]

--- a/juniper_iron/release.toml
+++ b/juniper_iron/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_iron/[a-z0-9\\.-]+", replace="docs.rs/juniper_iron/{{version}}"},
 ]

--- a/juniper_iron/release.toml
+++ b/juniper_iron/release.toml
@@ -1,7 +1,0 @@
-no-dev-version = true
-pre-release-commit-message = "Release {{crate_name}} {{version}}"
-pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
-tag-message = "Release {{crate_name}} {{version}}"
-pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_iron/[a-z0-9\\.-]+", replace="docs.rs/juniper_iron/{{version}}"},
-]

--- a/juniper_rocket/release.toml
+++ b/juniper_rocket/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_rocket/[a-z0-9\\.-]+", replace="docs.rs/juniper_rocket/{{version}}"},
 ]

--- a/juniper_rocket/release.toml
+++ b/juniper_rocket/release.toml
@@ -1,7 +1,0 @@
-no-dev-version = true
-pre-release-commit-message = "Release {{crate_name}} {{version}}"
-pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
-tag-message = "Release {{crate_name}} {{version}}"
-pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_rocket/[a-z0-9\\.-]+", replace="docs.rs/juniper_rocket/{{version}}"},
-]

--- a/juniper_rocket_async/release.toml
+++ b/juniper_rocket_async/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_rocket/[a-z0-9\\.-]+", replace="docs.rs/juniper_rocket/{{version}}"},
 ]

--- a/juniper_rocket_async/release.toml
+++ b/juniper_rocket_async/release.toml
@@ -1,7 +1,0 @@
-no-dev-version = true
-pre-release-commit-message = "Release {{crate_name}} {{version}}"
-pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
-tag-message = "Release {{crate_name}} {{version}}"
-pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_rocket/[a-z0-9\\.-]+", replace="docs.rs/juniper_rocket/{{version}}"},
-]

--- a/juniper_subscriptions/Makefile.toml
+++ b/juniper_subscriptions/Makefile.toml
@@ -1,4 +1,16 @@
 
+# This is needed as the release config is at a different path than the top-level
+# release config.
+
+[tasks.release-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
+
+[tasks.release-dry-run-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
+
+[tasks.release-local-test-INTERNAL]
+args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]
+
 [env]
 CARGO_MAKE_CARGO_ALL_FEATURES = ""
 

--- a/juniper_subscriptions/release.toml
+++ b/juniper_subscriptions/release.toml
@@ -2,8 +2,7 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_subscriptions/[a-z0-9\\.-]+", replace="docs.rs/juniper_subscriptions/{{version}}"},
   {file="../juniper_graphql_ws/Cargo.toml", search="juniper_subscriptions = \\{ version = \"[^\"]+\"", replace="juniper_subscriptions = { version = \"{{version}}\""},
+  {file="src/lib.rs", search="docs.rs/juniper_subscriptions/[a-z0-9\\.-]+", replace="docs.rs/juniper_subscriptions/{{version}}"},
 ]

--- a/juniper_warp/release.toml
+++ b/juniper_warp/release.toml
@@ -1,7 +1,0 @@
-no-dev-version = true
-pre-release-commit-message = "Release {{crate_name}} {{version}}"
-pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
-tag-message = "Release {{crate_name}} {{version}}"
-pre-release-replacements = [
-  {file="src/lib.rs", search="docs.rs/juniper_warp/[a-z0-9\\.-]+", replace="docs.rs/juniper_warp/{{version}}"},
-]

--- a/juniper_warp/release.toml
+++ b/juniper_warp/release.toml
@@ -2,7 +2,6 @@ no-dev-version = true
 pre-release-commit-message = "Release {{crate_name}} {{version}}"
 pro-release-commit-message = "Bump {{crate_name}} version to {{next_version}}"
 tag-message = "Release {{crate_name}} {{version}}"
-upload-doc = false
 pre-release-replacements = [
   {file="src/lib.rs", search="docs.rs/juniper_warp/[a-z0-9\\.-]+", replace="docs.rs/juniper_warp/{{version}}"},
 ]


### PR DESCRIPTION
Some crates need to rewrite values when they are released in other crates. It turns out, by default we use a general config `_build/release.toml`. So it turns out these local-to-the-crate `release.toml`s were not being used unless explicitly chosen in the local-to-the-crate `Makefile.toml`. This removes the dead `release.toml`s and overrides the ones that need to edit other crates on release.