### PR TITLE
Support !Sync (and maybe !Send) Context

### DIFF
--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -238,7 +238,7 @@ pub type ExecutionResult<S = DefaultScalarValue> = Result<Value<S>, FieldError<S
 
 /// Boxed `Stream` yielding `Result<Value<S>, ExecutionError<S>>`
 pub type ValuesStream<'a, S = DefaultScalarValue> =
-    std::pin::Pin<Box<dyn Stream<Item = Result<Value<S>, ExecutionError<S>>> + Send + 'a>>;
+    std::pin::Pin<Box<dyn Stream<Item = Result<Value<S>, ExecutionError<S>>> + 'a>>;
 
 /// The map of variables used for substitution during query execution
 pub type Variables<S = DefaultScalarValue> = HashMap<String, InputValue<S>>;
@@ -412,7 +412,6 @@ where
         'a: 'res,
         T: GraphQLSubscriptionValue<S, Context = CtxT> + ?Sized,
         T::TypeInfo: Sync,
-        CtxT: Sync,
         S: Send + Sync,
     {
         self.subscribe(info, value).await.unwrap_or_else(|e| {
@@ -433,7 +432,6 @@ where
         'a: 'res,
         T: GraphQLSubscriptionValue<S, Context = CtxT> + ?Sized,
         T::TypeInfo: Sync,
-        CtxT: Sync,
         S: Send + Sync,
     {
         value.resolve_into_stream(info, self).await
@@ -462,7 +460,6 @@ where
     where
         T: GraphQLValueAsync<S, Context = CtxT> + ?Sized,
         T::TypeInfo: Sync,
-        CtxT: Sync,
         S: Send + Sync,
     {
         value
@@ -479,7 +476,7 @@ where
     where
         T: GraphQLValueAsync<S, Context = NewCtxT> + ?Sized,
         T::TypeInfo: Sync,
-        NewCtxT: FromContext<CtxT> + Sync,
+        NewCtxT: FromContext<CtxT>,
         S: Send + Sync,
     {
         let e = self.replaced_context(<NewCtxT as FromContext<CtxT>>::from(self.context));
@@ -506,7 +503,6 @@ where
     where
         T: GraphQLValueAsync<S, Context = CtxT> + ?Sized,
         T::TypeInfo: Sync,
-        CtxT: Sync,
         S: Send + Sync,
     {
         self.resolve_async(info, value).await.unwrap_or_else(|e| {
@@ -887,7 +883,6 @@ pub async fn execute_validated_query_async<'a, 'b, QueryT, MutationT, Subscripti
 where
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLType<S, Context = QueryT::Context> + Sync,
@@ -1033,7 +1028,7 @@ where
     'op: 'd,
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync + 'r,
+    QueryT::Context: 'r,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = QueryT::Context>,

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -107,7 +107,6 @@ where
     where
         QueryT: GraphQLTypeAsync<S>,
         QueryT::TypeInfo: Sync,
-        QueryT::Context: Sync,
         MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
         MutationT::TypeInfo: Sync,
         SubscriptionT: GraphQLType<S, Context = QueryT::Context> + Sync,
@@ -136,7 +135,6 @@ where
     'ctx: 'a,
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = QueryT::Context>,
@@ -291,7 +289,6 @@ where
     where
         QueryT: GraphQLTypeAsync<S>,
         QueryT::TypeInfo: Sync,
-        QueryT::Context: Sync,
         MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
         MutationT::TypeInfo: Sync,
         SubscriptionT: GraphQLSubscriptionType<S, Context = QueryT::Context>,

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -264,7 +264,6 @@ pub async fn execute<'a, S, QueryT, MutationT, SubscriptionT>(
 where
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLType<S, Context = QueryT::Context> + Sync,
@@ -308,7 +307,6 @@ pub async fn resolve_into_stream<'a, S, QueryT, MutationT, SubscriptionT>(
 where
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = QueryT::Context>,

--- a/juniper/src/macros/tests/util.rs
+++ b/juniper/src/macros/tests/util.rs
@@ -3,7 +3,7 @@ use crate::{DefaultScalarValue, GraphQLType, GraphQLTypeAsync, RootNode, Value, 
 pub async fn run_query<Query, Mutation, Subscription>(query: &str) -> Value
 where
     Query: GraphQLTypeAsync<DefaultScalarValue, TypeInfo = ()> + Default,
-    Query::Context: Default + Sync,
+    Query::Context: Default,
     Mutation:
         GraphQLTypeAsync<DefaultScalarValue, TypeInfo = (), Context = Query::Context> + Default,
     Subscription:
@@ -31,7 +31,7 @@ where
 pub async fn run_info_query<Query, Mutation, Subscription>(type_name: &str) -> Value
 where
     Query: GraphQLTypeAsync<DefaultScalarValue, TypeInfo = ()> + Default,
-    Query::Context: Default + Sync,
+    Query::Context: Default,
     Mutation:
         GraphQLTypeAsync<DefaultScalarValue, TypeInfo = (), Context = Query::Context> + Default,
     Subscription:

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -102,7 +102,7 @@ impl<'a, S, QueryT, MutationT, SubscriptionT> GraphQLValueAsync<S>
 where
     QueryT: GraphQLTypeAsync<S>,
     QueryT::TypeInfo: Sync,
-    QueryT::Context: Sync + 'a,
+    QueryT::Context: 'a,
     MutationT: GraphQLTypeAsync<S, Context = QueryT::Context>,
     MutationT::TypeInfo: Sync,
     SubscriptionT: GraphQLType<S, Context = QueryT::Context> + Sync,
@@ -115,7 +115,7 @@ where
         field_name: &'b str,
         arguments: &'b Arguments<S>,
         executor: &'b Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'b, ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'b, ExecutionResult<S>> {
         use futures::future::ready;
         match field_name {
             "__schema" | "__type" => {

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -55,7 +55,6 @@ impl<S, T> GraphQLValueAsync<S> for Option<T>
 where
     T: GraphQLValueAsync<S>,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -63,7 +62,7 @@ where
         info: &'a Self::TypeInfo,
         _: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'a, ExecutionResult<S>> {
         let f = async move {
             let value = match self {
                 Some(obj) => executor.resolve_into_value_async(info, obj).await,
@@ -144,7 +143,6 @@ impl<S, T> GraphQLValueAsync<S> for Vec<T>
 where
     T: GraphQLValueAsync<S>,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -152,7 +150,7 @@ where
         info: &'a Self::TypeInfo,
         _: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'a, ExecutionResult<S>> {
         let f = resolve_into_list_async(executor, info, self.iter());
         Box::pin(f)
     }
@@ -233,7 +231,6 @@ impl<S, T> GraphQLValueAsync<S> for [T]
 where
     T: GraphQLValueAsync<S>,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -241,7 +238,7 @@ where
         info: &'a Self::TypeInfo,
         _: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'a, ExecutionResult<S>> {
         let f = resolve_into_list_async(executor, info, self.iter());
         Box::pin(f)
     }
@@ -295,7 +292,6 @@ where
     I: Iterator<Item = &'t T> + ExactSizeIterator,
     T: GraphQLValueAsync<S> + ?Sized + 't,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     use futures::stream::{FuturesOrdered, StreamExt as _};

--- a/juniper/src/types/nullable.rs
+++ b/juniper/src/types/nullable.rs
@@ -258,7 +258,6 @@ impl<S, T> GraphQLValueAsync<S> for Nullable<T>
 where
     T: GraphQLValueAsync<S>,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -266,7 +265,7 @@ where
         info: &'a Self::TypeInfo,
         _: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'a, ExecutionResult<S>> {
         let f = async move {
             let value = match self {
                 Self::Some(obj) => executor.resolve_into_value_async(info, obj).await,

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -9,7 +9,7 @@ use crate::{
         base::{Arguments, GraphQLType, GraphQLValue},
     },
     value::ScalarValue,
-    BoxFuture,
+    LocalBoxFuture,
 };
 
 impl<S, T> GraphQLType<S> for Box<T>
@@ -75,7 +75,6 @@ impl<S, T> GraphQLValueAsync<S> for Box<T>
 where
     T: GraphQLValueAsync<S> + ?Sized,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -83,7 +82,7 @@ where
         info: &'a Self::TypeInfo,
         selection_set: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> BoxFuture<'a, ExecutionResult<S>> {
+    ) -> LocalBoxFuture<'a, ExecutionResult<S>> {
         (**self).resolve_async(info, selection_set, executor)
     }
 }
@@ -174,7 +173,6 @@ impl<'e, S, T> GraphQLValueAsync<S> for &'e T
 where
     T: GraphQLValueAsync<S> + ?Sized,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_field_async<'b>(
@@ -183,7 +181,7 @@ where
         field_name: &'b str,
         arguments: &'b Arguments<S>,
         executor: &'b Executor<Self::Context, S>,
-    ) -> BoxFuture<'b, ExecutionResult<S>> {
+    ) -> LocalBoxFuture<'b, ExecutionResult<S>> {
         (**self).resolve_field_async(info, field_name, arguments, executor)
     }
 
@@ -192,7 +190,7 @@ where
         info: &'a Self::TypeInfo,
         selection_set: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> BoxFuture<'a, ExecutionResult<S>> {
+    ) -> LocalBoxFuture<'a, ExecutionResult<S>> {
         (**self).resolve_async(info, selection_set, executor)
     }
 }
@@ -270,7 +268,6 @@ impl<'e, S, T> GraphQLValueAsync<S> for Arc<T>
 where
     T: GraphQLValueAsync<S> + Send + ?Sized,
     T::TypeInfo: Sync,
-    T::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
     fn resolve_async<'a>(
@@ -278,7 +275,7 @@ where
         info: &'a Self::TypeInfo,
         selection_set: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> BoxFuture<'a, ExecutionResult<S>> {
+    ) -> LocalBoxFuture<'a, ExecutionResult<S>> {
         (**self).resolve_async(info, selection_set, executor)
     }
 }

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -251,7 +251,7 @@ where
         info: &'a Self::TypeInfo,
         selection_set: Option<&'a [Selection<S>]>,
         executor: &'a Executor<Self::Context, S>,
-    ) -> crate::BoxFuture<'a, crate::ExecutionResult<S>> {
+    ) -> crate::LocalBoxFuture<'a, crate::ExecutionResult<S>> {
         use futures::future;
         Box::pin(future::ready(self.resolve(info, selection_set, executor)))
     }
@@ -395,7 +395,6 @@ where
 impl<S, T> GraphQLValueAsync<S> for EmptyMutation<T>
 where
     Self::TypeInfo: Sync,
-    Self::Context: Sync,
     S: ScalarValue + Send + Sync,
 {
 }
@@ -455,7 +454,6 @@ where
 impl<T, S> GraphQLSubscriptionValue<S> for EmptySubscription<T>
 where
     Self::TypeInfo: Sync,
-    Self::Context: Sync,
     S: ScalarValue + Send + Sync + 'static,
 {
 }

--- a/juniper_actix/src/lib.rs
+++ b/juniper_actix/src/lib.rs
@@ -95,7 +95,6 @@ where
     Mutation::TypeInfo: Sync,
     Subscription: juniper::GraphQLSubscriptionType<S, Context = CtxT>,
     Subscription::TypeInfo: Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
     match *req.method() {
@@ -119,7 +118,6 @@ where
     Mutation::TypeInfo: Sync,
     Subscription: juniper::GraphQLSubscriptionType<S, Context = CtxT>,
     Subscription::TypeInfo: Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
     let get_req = web::Query::<GetGraphQLRequest>::from_query(req.query_string())?;
@@ -149,7 +147,6 @@ where
     Mutation::TypeInfo: Sync,
     Subscription: juniper::GraphQLSubscriptionType<S, Context = CtxT>,
     Subscription::TypeInfo: Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
     let content_type_header = req
@@ -262,7 +259,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Unpin + Send + Sync + 'static,
+        CtxT: Unpin + 'static,
         S: ScalarValue + Send + Sync + 'static,
         I: Init<S, CtxT> + Send,
     {
@@ -304,7 +301,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Unpin + Send + Sync + 'static,
+        CtxT: Unpin + 'static,
         S: ScalarValue + Send + Sync + 'static,
         I: Init<S, CtxT> + Send,
     {
@@ -323,7 +320,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Unpin + Send + Sync + 'static,
+        CtxT: Unpin + 'static,
         S: ScalarValue + Send + Sync + 'static,
         I: Init<S, CtxT> + Send,
     {
@@ -361,7 +358,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Unpin + Send + Sync + 'static,
+        CtxT: Unpin + 'static,
         S: ScalarValue + Send + Sync + 'static,
         I: Init<S, CtxT> + Send,
     {
@@ -399,7 +396,7 @@ pub mod subscriptions {
         Mutation::TypeInfo: Send + Sync,
         Subscription: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
         Subscription::TypeInfo: Send + Sync,
-        CtxT: Unpin + Send + Sync + 'static,
+        CtxT: Unpin + 'static,
         S: ScalarValue + Send + Sync + 'static,
         I: Init<S, CtxT> + Send,
     {

--- a/juniper_codegen/src/derive_scalar_value.rs
+++ b/juniper_codegen/src/derive_scalar_value.rs
@@ -123,7 +123,6 @@ fn impl_scalar_struct(
         where
             Self: Sync,
             Self::TypeInfo: Sync,
-            Self::Context: Sync,
             #scalar: ::juniper::ScalarValue + Send + Sync,
         {
             fn resolve_async<'a>(
@@ -131,7 +130,7 @@ fn impl_scalar_struct(
                 info: &'a Self::TypeInfo,
                 selection_set: Option<&'a [::juniper::Selection<#scalar>]>,
                 executor: &'a ::juniper::Executor<Self::Context, #scalar>,
-            ) -> ::juniper::BoxFuture<'a, ::juniper::ExecutionResult<#scalar>> {
+            ) -> ::juniper::LocalBoxFuture<'a, ::juniper::ExecutionResult<#scalar>> {
                 use ::juniper::futures::future;
                 let v = ::juniper::GraphQLValue::<#scalar>::resolve(self, info, selection_set, executor);
                 Box::pin(future::ready(v))

--- a/juniper_codegen/src/graphql_interface/mod.rs
+++ b/juniper_codegen/src/graphql_interface/mod.rs
@@ -978,7 +978,7 @@ impl Definition {
                     field: &'b str,
                     args: &'b ::juniper::Arguments<#scalar>,
                     executor: &'b ::juniper::Executor<Self::Context, #scalar>,
-                ) -> ::juniper::BoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
+                ) -> ::juniper::LocalBoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
                     match field {
                         #( #fields_resolvers )*
                         _ => #no_field_panic,
@@ -991,7 +991,7 @@ impl Definition {
                     type_name: &str,
                     _: Option<&'b [::juniper::Selection<'b, #scalar>]>,
                     executor: &'b ::juniper::Executor<'b, 'b, Self::Context, #scalar>
-                ) -> ::juniper::BoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
+                ) -> ::juniper::LocalBoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
                     #( #custom_downcasts )*
                     #regular_downcast
                 }

--- a/juniper_codegen/src/graphql_union/mod.rs
+++ b/juniper_codegen/src/graphql_union/mod.rs
@@ -545,7 +545,7 @@ impl ToTokens for UnionDefinition {
                     type_name: &str,
                     _: Option<&'b [::juniper::Selection<'b, #scalar>]>,
                     executor: &'b ::juniper::Executor<'b, 'b, Self::Context, #scalar>
-                ) -> ::juniper::BoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
+                ) -> ::juniper::LocalBoxFuture<'b, ::juniper::ExecutionResult<#scalar>> {
                     let context = executor.context();
                     #( #resolve_into_type_async )*
                     panic!(

--- a/juniper_codegen/src/impl_scalar.rs
+++ b/juniper_codegen/src/impl_scalar.rs
@@ -241,7 +241,6 @@ pub fn build_scalar(
         where
             Self: Sync,
             Self::TypeInfo: Sync,
-            Self::Context: Sync,
             #async_generic_type: ::juniper::ScalarValue + Send + Sync,
         {
             fn resolve_async<'a>(
@@ -249,7 +248,7 @@ pub fn build_scalar(
                 info: &'a Self::TypeInfo,
                 selection_set: Option<&'a [::juniper::Selection<#async_generic_type>]>,
                 executor: &'a ::juniper::Executor<Self::Context, #async_generic_type>,
-            ) -> ::juniper::BoxFuture<'a, ::juniper::ExecutionResult<#async_generic_type>> {
+            ) -> ::juniper::LocalBoxFuture<'a, ::juniper::ExecutionResult<#async_generic_type>> {
                 use ::juniper::futures::future;
                 let v = ::juniper::GraphQLValue::resolve(self, info, selection_set, executor);
                 Box::pin(future::ready(v))

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -936,7 +936,7 @@ impl GraphQLTypeDefiniton {
                                 }
                             };
                             use ::juniper::futures::future;
-                            future::FutureExt::boxed(f)
+                            future::FutureExt::boxed_local(f)
                         )
                     } else {
                         quote!(
@@ -1004,7 +1004,7 @@ impl GraphQLTypeDefiniton {
                         field: &'b str,
                         args: &'b ::juniper::Arguments<#scalar>,
                         executor: &'b ::juniper::Executor<Self::Context, #scalar>,
-                    ) -> ::juniper::BoxFuture<'b, ::juniper::ExecutionResult<#scalar>>
+                    ) -> ::juniper::LocalBoxFuture<'b, ::juniper::ExecutionResult<#scalar>>
                         where #scalar: Send + Sync,
                     {
                         use ::juniper::futures::future;
@@ -1271,7 +1271,7 @@ impl GraphQLTypeDefiniton {
                 };
                 quote!(
                     #name => {
-                        ::juniper::futures::FutureExt::boxed(async move {
+                        ::juniper::futures::FutureExt::boxed_local(async move {
                             let res #_type = { #code };
                             let res = ::juniper::IntoFieldResult::<_, #scalar>::into_result(res)?;
                             let executor= executor.as_owned_executor();
@@ -1404,7 +1404,7 @@ impl GraphQLTypeDefiniton {
                                 ::juniper::Value<::juniper::ValuesStream<'res, #scalar>>,
                                 ::juniper::FieldError<#scalar>
                             >
-                        > + Send + 'f
+                        > + 'f
                     >>
                     where
                         's: 'f,
@@ -1549,7 +1549,7 @@ impl GraphQLTypeDefiniton {
                     info: &'a Self::TypeInfo,
                     selection_set: Option<&'a [::juniper::Selection<#scalar>]>,
                     executor: &'a ::juniper::Executor<Self::Context, #scalar>,
-                ) -> ::juniper::BoxFuture<'a, ::juniper::ExecutionResult<#scalar>> {
+                ) -> ::juniper::LocalBoxFuture<'a, ::juniper::ExecutionResult<#scalar>> {
                     use ::juniper::futures::future;
                     let v = ::juniper::GraphQLValue::resolve(self, info, selection_set, executor);
                     Box::pin(future::ready(v))

--- a/juniper_graphql_ws/src/lib.rs
+++ b/juniper_graphql_ws/src/lib.rs
@@ -652,7 +652,7 @@ mod test {
     use std::{convert::Infallible, io};
 
     use juniper::{
-        futures::sink::SinkExt,
+        futures::{sink::SinkExt, stream::BoxStream},
         graphql_object, graphql_subscription,
         parser::{ParseError, Spanning, Token},
         DefaultScalarValue, EmptyMutation, FieldError, FieldResult, InputValue, RootNode, Value,

--- a/juniper_graphql_ws/src/schema.rs
+++ b/juniper_graphql_ws/src/schema.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 /// just an `Arc<RootNode<...>>` and you should not have to implement it yourself.
 pub trait Schema: Unpin + Clone + Send + Sync + 'static {
     /// The context type.
-    type Context: Unpin + Send + Sync;
+    type Context: Unpin;
 
     /// The scalar value type.
     type ScalarValue: ScalarValue + Send + Sync;
@@ -14,28 +14,31 @@ pub trait Schema: Unpin + Clone + Send + Sync + 'static {
     type QueryTypeInfo: Send + Sync;
 
     /// The query type.
-    type Query: GraphQLTypeAsync<Self::ScalarValue, Context = Self::Context, TypeInfo = Self::QueryTypeInfo>
-        + Send;
+    type Query: GraphQLTypeAsync<
+        Self::ScalarValue,
+        Context = Self::Context,
+        TypeInfo = Self::QueryTypeInfo,
+    > + Send;
 
     /// The mutation type info.
     type MutationTypeInfo: Send + Sync;
 
     /// The mutation type.
     type Mutation: GraphQLTypeAsync<
-            Self::ScalarValue,
-            Context = Self::Context,
-            TypeInfo = Self::MutationTypeInfo,
-        > + Send;
+        Self::ScalarValue,
+        Context = Self::Context,
+        TypeInfo = Self::MutationTypeInfo,
+    > + Send;
 
     /// The subscription type info.
     type SubscriptionTypeInfo: Send + Sync;
 
     /// The subscription type.
     type Subscription: GraphQLSubscriptionType<
-            Self::ScalarValue,
-            Context = Self::Context,
-            TypeInfo = Self::SubscriptionTypeInfo,
-        > + Send;
+        Self::ScalarValue,
+        Context = Self::Context,
+        TypeInfo = Self::SubscriptionTypeInfo,
+    > + Send;
 
     /// Returns the root node for the schema.
     fn root_node(
@@ -58,7 +61,7 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Unpin + Send + Sync,
+    CtxT: Unpin,
     S: ScalarValue + Send + Sync + 'static;
 
 impl<QueryT, MutationT, SubscriptionT, CtxT, S> Clone
@@ -70,7 +73,7 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Unpin + Send + Sync,
+    CtxT: Unpin,
     S: ScalarValue + Send + Sync + 'static,
 {
     fn clone(&self) -> Self {
@@ -87,7 +90,7 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Unpin + Send + Sync + 'static,
+    CtxT: Unpin + 'static,
     S: ScalarValue + Send + Sync + 'static,
 {
     type Context = CtxT;
@@ -113,7 +116,7 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send + 'static,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Unpin + Send + Sync,
+    CtxT: Unpin,
     S: ScalarValue + Send + Sync + 'static,
 {
     type Context = CtxT;

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -20,4 +20,4 @@ url = "2"
 juniper = { version = "0.15.1", path = "../juniper", features = ["expose-test-schema"] }
 pretty_env_logger = "0.4"
 reqwest = { version = "0.10", features = ["blocking", "rustls-tls"] }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "0.2", features = ["macros", "rt-util"] }

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -123,7 +123,6 @@ where
         MutationT::TypeInfo: Sync,
         SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT>,
         SubscriptionT::TypeInfo: Sync,
-        CtxT: Sync,
         S: Send + Sync,
     {
         let response = self.0.execute(root_node, context).await;

--- a/juniper_subscriptions/src/lib.rs
+++ b/juniper_subscriptions/src/lib.rs
@@ -35,7 +35,6 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
     root_node: juniper::RootNode<'a, QueryT, MutationT, SubscriptionT, S>,
@@ -50,7 +49,6 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
     /// Builds new [`Coordinator`] with specified `root_node`
@@ -68,7 +66,6 @@ where
     MutationT::TypeInfo: Send + Sync,
     SubscriptionT: GraphQLSubscriptionType<S, Context = CtxT> + Send,
     SubscriptionT::TypeInfo: Send + Sync,
-    CtxT: Sync,
     S: ScalarValue + Send + Sync + 'a,
 {
     type Connection = Connection<'a, S>;

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -20,7 +20,7 @@ juniper_graphql_ws = { version = "0.2.1", path = "../juniper_graphql_ws", option
 serde = { version = "1.0.75", features = ["derive"] }
 serde_json = "1.0.24"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["blocking", "rt-core"] }
+tokio = { version = "0.2", features = ["blocking", "rt-core", "rt-util"] }
 warp = "0.2"
 
 [dev-dependencies]
@@ -28,5 +28,5 @@ env_logger = "0.8"
 juniper = { version = "0.15.1", path = "../juniper", features = ["expose-test-schema"] }
 log = "0.4"
 percent-encoding = "2.1"
-tokio = { version = "0.2", features = ["blocking", "macros", "rt-core"] }
+tokio = { version = "0.2", features = ["blocking", "macros", "rt-core", "rt-util"] }
 url = "2"


### PR DESCRIPTION
When upgrading juniper from 0.9 to 0.15, I found that context types now require `Send + Sync`. Previously, before juniper was async, everything was synchronous and the context could contain `!Sync` types such as database connections (ex. SQLite). This PR experiments with removing the `Sync` requirement (and `Send`, since the context is only ever referenced not owned).

There are some roadblocks which I'm not sure can be resolved at this time. The juniper futures now are `!Send` since they hold a reference to the `!Sync` context. This is fine in the core juniper library and juniper_actix, but web services based on tokio/hyper have issues with spawning `!Send` futures. Tokio supports spawning `!Send` futures, but only when using a `LocalSet`, which is only really feasible when using the single-threaded runtime. There is a (recently closed, but in-discussion) issue which addresses spawning `!Send` futures on the multi-threaded runtime: https://github.com/tokio-rs/tokio/issues/2545. Due to this issue, Hyper only supports `!Send` futures when using the single-threaded runtime: https://github.com/hyperium/hyper/blob/8861f9a7867216c81ea14ac6224c11a1303e7761/examples/single_threaded.rs. Warp does not support `!Send` yet: https://github.com/seanmonstar/warp/issues/528. It's not clear how Rocket 0.5 will handle `!Send`, but since it's based on hyper it won't be any better than what they provide.

Theoretically the future that runs the graphql resolver could be `Send` because the `!Sync` context is owned by the future and passed into juniper by reference. However, because GATs (Generic Abstract Types) are not implemented, traits with async methods must box their futures. This causes juniper's future to hold `LocalBoxFuture`s, which are not `Send`. Due to this, the overall future is not `Send`... If GATs were implemented, it may be possible to avoid the tokio `!Send` futures issue by convincing Rust that the overall juniper resolve future is `Send` since the context is owned by the calling code (the web handler which calls juniper) which is part of the same future object.

The main changes include:
* Removing `Send` and `Sync` bounds on context types.
* Replacing `BoxFuture` with `LocalBoxFuture` (similar for streams), due to the removal of `Context: Sync`.
* Updating `juniper_hyper` examples and tests to use a single-threaded runtime due to the above issues.
* Updating `juniper_warp` in an attempt to support `!Send` futures, but this fails at runtime due to the lack of support in warp for `!Send` futures (see issue link above).
* Move the config out of `ExecutionParams` so that the context is not captured in the error type, which would require the context to be `Send`. This is safe because the error object only refers to data in the request and schema, not the context (see the lifetimes on `juniper::execute`).

I don't really expect this PR to be merged any time soon, if at all, but it's worth bringing up the issue and showing how the core juniper library can support `!Sync` (and even `!Send`) context. The issues lie in the web server integration libraries, mainly due to the lack of GATs and issues in tokio with spawning `!Send` futures.

Related juniper issues:
* https://github.com/graphql-rust/juniper/issues/329#issuecomment-493672618
* https://github.com/graphql-rust/juniper/issues/425