### PR TITLE
juniper_rocket_async: fix tokio dependency

### DIFF
--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -287,7 +287,7 @@ where
     type Error = String;
 
     async fn from_data(req: &Request<'_>, data: Data) -> data::Outcome<Self, Self::Error> {
-        use tokio::io::AsyncReadExt as _;
+        use rocket::tokio::io::AsyncReadExt as _;
 
         let content_type = req
             .content_type()


### PR DESCRIPTION
rocket async has recently bumped its tokio dependency
to 1.0.1 which breaks juniper_rocket_async. This can
be trivially fixed by using rocket's tokio re-export.