### PR TITLE
Use working GraphQL Playground version

### DIFF
--- a/juniper/src/http/playground.rs
+++ b/juniper/src/http/playground.rs
@@ -21,9 +21,9 @@ pub fn playground_source(
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/static/js/middleware.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/js/middleware.js"></script>
 
 </head>
 

--- a/juniper/src/http/playground.rs
+++ b/juniper/src/http/playground.rs
@@ -23,7 +23,7 @@ pub fn playground_source(
   <title>GraphQL Playground</title>
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
   <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.27/build/static/js/middleware.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/static/js/middleware.js"></script>
 
 </head>
 

--- a/juniper/src/http/playground.rs
+++ b/juniper/src/http/playground.rs
@@ -21,8 +21,8 @@ pub fn playground_source(
   <meta charset=utf-8 />
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/favicon.png" />
   <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.20/build/static/js/middleware.js"></script>
 
 </head>


### PR DESCRIPTION
the linked file on jsDelivr doesn't work, as I detailed in this issue on the GraphQL Playground repo (https://github.com/graphql/graphql-playground/issues/1310). Going back to version 1.7.26 ensures the playground loads for now until they can publish a new version with a working middleware.js file.

(not working) link to the currently used 1.7.27 file:
https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.27/build/static/js/middleware.js

fixed link to the 1.7.26 file:
https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/js/middleware.js
