### PR TITLE
Support subscriptions for GraphiQL and Playground.

### DIFF
--- a/juniper_rocket_async/examples/rocket_server.rs
+++ b/juniper_rocket_async/examples/rocket_server.rs
@@ -8,7 +8,7 @@ type Schema = RootNode<'static, Query, EmptyMutation<Database>, EmptySubscriptio
 
 #[rocket::get("/")]
 fn graphiql() -> content::Html<String> {
-    juniper_rocket_async::graphiql_source("/graphql")
+    juniper_rocket_async::graphiql_source("/graphql", None)
 }
 
 #[rocket::get("/graphql?<request>")]

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -69,18 +69,24 @@ where
 pub struct GraphQLResponse(pub Status, pub String);
 
 /// Generate an HTML page containing GraphiQL
-pub fn graphiql_source(graphql_endpoint_url: &str) -> content::Html<String> {
+pub fn graphiql_source(
+    graphql_endpoint_url: &str,
+    subscriptions_endpoint_url: Option<&str>,
+) -> content::Html<String> {
     content::Html(juniper::http::graphiql::graphiql_source(
         graphql_endpoint_url,
-        None,
+        subscriptions_endpoint_url,
     ))
 }
 
 /// Generate an HTML page containing GraphQL Playground
-pub fn playground_source(graphql_endpoint_url: &str) -> content::Html<String> {
+pub fn playground_source(
+    graphql_endpoint_url: &str,
+    subscriptions_endpoint_url: Option<&str>,
+) -> content::Html<String> {
     content::Html(juniper::http::playground::playground_source(
         graphql_endpoint_url,
-        None,
+        subscriptions_endpoint_url,
     ))
 }
 


### PR DESCRIPTION
Add support for subscriptions for GraphiQL and Playground in `juniper_rocket_async`.

Note this changes the function signatures. Since the crate hasn't been release I'm not sure about backwards compatibility concerns. At least the signatures are consistent now.