### PR TITLE
Update juniper_codegen for syn 1.0.60

### DIFF
--- a/examples/basic_subscriptions/Cargo.toml
+++ b/examples/basic_subscriptions/Cargo.toml
@@ -13,5 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "macros", "stream"] }
 
-juniper = { git = "https://github.com/graphql-rust/juniper" }
-juniper_subscriptions = { git = "https://github.com/graphql-rust/juniper" }
+juniper = { path = "../../juniper" }
+juniper_subscriptions = { path = "../../juniper_subscriptions" }

--- a/examples/warp_async/Cargo.toml
+++ b/examples/warp_async/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 authors = ["Christoph Herzog <chris@theduke.at>"]
 
 [dependencies]
-juniper = { git = "https://github.com/graphql-rust/juniper" }
-juniper_warp = { git = "https://github.com/graphql-rust/juniper" }
+juniper = { path = "../../juniper" }
+juniper_warp = { path = "../../juniper_warp" }
 
 env_logger = "0.8.1"
 futures = "0.3.1"

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 proc-macro-error = "1.0.2"
 proc-macro2 = "1.0.1"
 quote = "1.0.3"
-syn = { version = "1.0.3", features = ["extra-traits", "full", "parsing"], default-features = false }
+syn = { version = "1.0.60", features = ["extra-traits", "full", "parsing"], default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99.7"

--- a/juniper_codegen/src/common/parse/mod.rs
+++ b/juniper_codegen/src/common/parse/mod.rs
@@ -191,12 +191,15 @@ impl TypeExt for syn::Type {
             }
 
             // These types unlikely will be used as GraphQL types.
-            T::BareFn(_)
-            | T::Infer(_)
-            | T::Macro(_)
-            | T::Never(_)
-            | T::Verbatim(_)
-            | T::__Nonexhaustive => {}
+            T::BareFn(_) | T::Infer(_) | T::Macro(_) | T::Never(_) | T::Verbatim(_) => {}
+
+            // Following the syn idiom for exhaustive matching on Type
+            // https://github.com/dtolnay/syn/blob/master/src/ty.rs#L66-L88
+            #[cfg(test)]
+            T::__TestExhaustive(_) => unimplemented!(),
+
+            #[cfg(not(test))]
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
syn 1.0.60 has updated it's `Type::__Nonexhaustive` to
`Type::TestExhaustive`, breaking juniper.  This updates juniper to use
the recommended idiom for doing exhaustive matching on `Type`, which
fixes this.

Not entirely clear if this needs exhaustive matching or if we could
just use a fallback, but this fixes the build at least.

I imagine this will break for users who are still on an old syn though.

Fixes #858