### PR TITLE
Make the executor and validation APIs public to enable split parsing and execution

### DIFF
--- a/integration_tests/juniper_tests/Cargo.toml
+++ b/integration_tests/juniper_tests/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 derive_more = "0.99"
 futures = "0.3"
 juniper = { path = "../../juniper" }
+juniper_subscriptions = { path = "../../juniper_subscriptions" }
 
 [dev-dependencies]
 async-trait = "0.1.39"

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -16,3 +16,5 @@ mod issue_371;
 mod issue_398;
 #[cfg(test)]
 mod issue_500;
+#[cfg(test)]
+mod pre_parse;

--- a/integration_tests/juniper_tests/src/pre_parse.rs
+++ b/integration_tests/juniper_tests/src/pre_parse.rs
@@ -1,0 +1,102 @@
+use futures::{Stream, StreamExt, TryFutureExt};
+use juniper::{
+    executor::{execute_validated_query_async, get_operation, resolve_validated_subscription},
+    graphql_object, graphql_subscription,
+    parser::parse_document_source,
+    validation::{validate_input_values, visit_all_rules, ValidatorContext},
+    EmptyMutation, FieldError, OperationType, RootNode, Variables,
+};
+use std::pin::Pin;
+
+pub struct Context;
+
+impl juniper::Context for Context {}
+
+pub type UserStream = Pin<Box<dyn Stream<Item = Result<User, FieldError>> + Send>>;
+
+pub struct Query;
+
+#[graphql_object(context = Context)]
+impl Query {
+    fn users() -> Vec<User> {
+        vec![User]
+    }
+}
+
+pub struct Subscription;
+
+#[graphql_subscription(context = Context)]
+impl Subscription {
+    async fn users() -> UserStream {
+        Box::pin(futures::stream::iter(vec![Ok(User)]))
+    }
+}
+
+#[derive(Clone)]
+pub struct User;
+
+#[graphql_object(context = Context)]
+impl User {
+    fn id() -> i32 {
+        1
+    }
+}
+
+type Schema = RootNode<'static, Query, EmptyMutation<Context>, Subscription>;
+
+#[tokio::test]
+async fn query_document_can_be_pre_parsed() {
+    let root_node = &Schema::new(Query, EmptyMutation::<Context>::new(), Subscription);
+
+    let document_source = r#"query { users { id } }"#;
+    let document = parse_document_source(document_source, &root_node.schema).unwrap();
+
+    {
+        let mut ctx = ValidatorContext::new(&root_node.schema, &document);
+        visit_all_rules(&mut ctx, &document);
+        let errors = ctx.into_errors();
+        assert!(errors.is_empty());
+    }
+
+    let operation = get_operation(&document, None).unwrap();
+    assert!(operation.item.operation_type == OperationType::Query);
+
+    let errors = validate_input_values(&juniper::Variables::new(), operation, &root_node.schema);
+    assert!(errors.is_empty());
+
+    let (_, errors) = execute_validated_query_async(
+        &document,
+        operation,
+        root_node,
+        &Variables::new(),
+        &Context {},
+    )
+    .await
+    .unwrap();
+
+    assert!(errors.len() == 0);
+}
+
+#[tokio::test]
+async fn subscription_document_can_be_pre_parsed() {
+    let root_node = &Schema::new(Query, EmptyMutation::<Context>::new(), Subscription);
+
+    let document_source = r#"subscription { users { id } }"#;
+    let document = parse_document_source(document_source, &root_node.schema).unwrap();
+
+    let operation = get_operation(&document, None).unwrap();
+    assert!(operation.item.operation_type == OperationType::Subscription);
+
+    let mut stream = resolve_validated_subscription(
+        &document,
+        &operation,
+        &root_node,
+        &Variables::new(),
+        &Context {},
+    )
+    .map_ok(|(stream, errors)| juniper_subscriptions::Connection::from_stream(stream, errors))
+    .await
+    .unwrap();
+
+    let _ = stream.next().await.unwrap();
+}

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -137,6 +137,7 @@ pub struct Fragment<'a, S> {
     pub selection_set: Vec<Selection<'a, S>>,
 }
 
+#[doc(hidden)]
 #[derive(Clone, PartialEq, Debug)]
 pub enum Definition<'a, S> {
     Operation(Spanning<Operation<'a, S>>),

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -119,6 +119,7 @@ pub enum OperationType {
     Subscription,
 }
 
+#[allow(missing_docs)]
 #[derive(Clone, PartialEq, Debug)]
 pub struct Operation<'a, S> {
     pub operation_type: OperationType,
@@ -142,6 +143,7 @@ pub enum Definition<'a, S> {
     Fragment(Spanning<Fragment<'a, S>>),
 }
 
+#[doc(hidden)]
 pub type Document<'a, S> = Vec<Definition<'a, S>>;
 
 /// Parse an unstructured input value into a Rust data type.

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -112,6 +112,7 @@ pub struct Directive<'a, S> {
     pub arguments: Option<Spanning<Arguments<'a, S>>>,
 }
 
+#[allow(missing_docs)]
 #[derive(Clone, PartialEq, Debug)]
 pub enum OperationType {
     Query,

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -96,6 +96,7 @@ where
     }
 }
 
+#[doc(hidden)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChildSelection<'a, S: 'a> {
     pub(super) inner: LookAheadSelection<'a, S>,

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -1,3 +1,5 @@
+//! Resolve the document to values
+
 use std::{
     borrow::Cow,
     cmp::Ordering,
@@ -54,6 +56,7 @@ pub struct Registry<'r, S = DefaultScalarValue> {
     pub types: FnvHashMap<Name, MetaType<'r, S>>,
 }
 
+#[allow(missing_docs)]
 #[derive(Clone)]
 pub enum FieldPath<'a> {
     Root(SourcePosition),
@@ -979,6 +982,7 @@ where
     Ok((value, errors))
 }
 
+#[doc(hidden)]
 pub fn get_operation<'b, 'd, 'e, S>(
     document: &'b Document<'d, S>,
     operation_name: Option<&str>,

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -119,13 +119,13 @@ mod value;
 #[macro_use]
 mod macros;
 mod ast;
-mod executor;
+pub mod executor;
 mod introspection;
 pub mod parser;
 pub(crate) mod schema;
 mod types;
 mod util;
-mod validation;
+pub mod validation;
 // This needs to be public until docs have support for private modules:
 // https://github.com/rust-lang/cargo/issues/1520
 pub mod http;
@@ -145,12 +145,12 @@ pub use crate::util::to_camel_case;
 use crate::{
     executor::{execute_validated_query, get_operation},
     introspection::{INTROSPECTION_QUERY, INTROSPECTION_QUERY_WITHOUT_DESCRIPTIONS},
-    parser::{parse_document_source, ParseError, Spanning},
+    parser::parse_document_source,
     validation::{validate_input_values, visit_all_rules, ValidatorContext},
 };
 
 pub use crate::{
-    ast::{FromInputValue, InputValue, Selection, ToInputValue, Type},
+    ast::{Document, FromInputValue, InputValue, Operation, Selection, ToInputValue, Type},
     executor::{
         Applies, Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
         FromContext, IntoFieldError, IntoResolvable, LookAheadArgument, LookAheadMethods,
@@ -161,6 +161,7 @@ pub use crate::{
         subscription::{ExtractTypeFromStream, IntoFieldResult},
         AsDynGraphQLValue,
     },
+    parser::{ParseError, Spanning},
     schema::{
         meta,
         model::{RootNode, SchemaType},

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -150,7 +150,9 @@ use crate::{
 };
 
 pub use crate::{
-    ast::{Document, FromInputValue, InputValue, Operation, Selection, ToInputValue, Type},
+    ast::{
+        Definition, Document, FromInputValue, InputValue, Operation, Selection, ToInputValue, Type,
+    },
     executor::{
         Applies, Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,
         FromContext, IntoFieldError, IntoResolvable, LookAheadArgument, LookAheadMethods,

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -151,7 +151,8 @@ use crate::{
 
 pub use crate::{
     ast::{
-        Definition, Document, FromInputValue, InputValue, Operation, Selection, ToInputValue, Type,
+        Definition, Document, FromInputValue, InputValue, Operation, OperationType, Selection,
+        ToInputValue, Type,
     },
     executor::{
         Applies, Context, ExecutionError, ExecutionResult, Executor, FieldError, FieldResult,

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -348,7 +348,10 @@ impl<'a, S> MetaType<'a, S> {
     ///
     /// Objects, interfaces, and unions are composite.
     pub fn is_composite(&self) -> bool {
-        matches!(*self, MetaType::Object(_) | MetaType::Interface(_) | MetaType::Union(_))
+        matches!(
+            *self,
+            MetaType::Object(_) | MetaType::Interface(_) | MetaType::Union(_)
+        )
     }
 
     /// Returns true if the type can occur in leaf positions in queries
@@ -369,7 +372,10 @@ impl<'a, S> MetaType<'a, S> {
     ///
     /// Only scalars, enums, and input objects are input types.
     pub fn is_input(&self) -> bool {
-        matches!(*self, MetaType::Scalar(_) | MetaType::Enum(_) | MetaType::InputObject(_))
+        matches!(
+            *self,
+            MetaType::Scalar(_) | MetaType::Enum(_) | MetaType::InputObject(_)
+        )
     }
 
     /// Returns true if the type is built-in to GraphQL.

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -19,6 +19,7 @@ enum Path<'a> {
     ObjectField(&'a str, &'a Path<'a>),
 }
 
+#[doc(hidden)]
 pub fn validate_input_values<S>(
     values: &Variables<S>,
     operation: &Spanning<Operation<S>>,

--- a/juniper/src/validation/mod.rs
+++ b/juniper/src/validation/mod.rs
@@ -10,7 +10,7 @@ mod visitor;
 #[cfg(test)]
 pub(crate) mod test_harness;
 
-pub(crate) use self::rules::visit_all_rules;
+pub use self::rules::visit_all_rules;
 pub use self::{
     context::{RuleError, ValidatorContext},
     input_value::validate_input_values,

--- a/juniper/src/validation/mod.rs
+++ b/juniper/src/validation/mod.rs
@@ -10,11 +10,11 @@ mod visitor;
 #[cfg(test)]
 pub(crate) mod test_harness;
 
-pub use self::rules::visit_all_rules;
 pub use self::{
     context::{RuleError, ValidatorContext},
     input_value::validate_input_values,
     multi_visitor::MultiVisitorNil,
+    rules::visit_all_rules,
     traits::Visitor,
     visitor::visit,
 };

--- a/juniper/src/validation/multi_visitor.rs
+++ b/juniper/src/validation/multi_visitor.rs
@@ -11,6 +11,7 @@ use crate::{
 #[doc(hidden)]
 pub struct MultiVisitorNil;
 
+#[doc(hidden)]
 impl MultiVisitorNil {
     pub fn with<V>(self, visitor: V) -> MultiVisitorCons<V, Self> {
         MultiVisitorCons(visitor, self)

--- a/juniper/src/validation/rules/mod.rs
+++ b/juniper/src/validation/rules/mod.rs
@@ -30,7 +30,8 @@ use crate::{
 };
 use std::fmt::Debug;
 
-pub(crate) fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)
+#[doc(hidden)]
+pub fn visit_all_rules<'a, S: Debug>(ctx: &mut ValidatorContext<'a, S>, doc: &'a Document<S>)
 where
     S: ScalarValue,
 {


### PR DESCRIPTION
Making these APIs public is based on my understanding of https://github.com/graphql-rust/juniper/pull/773#issuecomment-703783048 and https://github.com/graphql-rust/juniper/pull/773#issuecomment-704009918

This PR is related to #776, #726, and enables features similar to #843 to be implemented in user land code. In my project I'm currently doing this (pseudo code) in the first step:
``` rust
fn compile() {
  let document = parse_document_source(document_source, &root_node.schema)?;
  visit_all_rules(&mut ctx, &document);
  let operation = get_operation(&document, operation_name)?;
  Ok((document.clone(), operation.clone()))
}
```
so I can make use of the `operation` and `document` and then in the second step I'm using the [now public] `validation::validate_input_values` and `executor::execute_validated_query_async` or `resolve_validated_subscription` as needed.

Thoughts on these changes?