### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Build and run tests
         env:
-          RUSTFLAGS: "-C link-dead-code"
           CARGO_MAKE_RUN_CODECOV: true
         run: |
           cargo make workspace-ci-flow --no-workspace

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -348,7 +348,10 @@ impl<'a, S> MetaType<'a, S> {
     ///
     /// Objects, interfaces, and unions are composite.
     pub fn is_composite(&self) -> bool {
-        matches!(*self, MetaType::Object(_) | MetaType::Interface(_) | MetaType::Union(_))
+        matches!(
+            *self,
+            MetaType::Object(_) | MetaType::Interface(_) | MetaType::Union(_)
+        )
     }
 
     /// Returns true if the type can occur in leaf positions in queries
@@ -369,7 +372,10 @@ impl<'a, S> MetaType<'a, S> {
     ///
     /// Only scalars, enums, and input objects are input types.
     pub fn is_input(&self) -> bool {
-        matches!(*self, MetaType::Scalar(_) | MetaType::Enum(_) | MetaType::InputObject(_))
+        matches!(
+            *self,
+            MetaType::Scalar(_) | MetaType::Enum(_) | MetaType::InputObject(_)
+        )
     }
 
     /// Returns true if the type is built-in to GraphQL.

--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -231,11 +231,11 @@ where
                 }
 
                 let meta_field = meta_type.field_by_name(f.name.item).unwrap_or_else(|| {
-                    panic!(format!(
+                    panic!(
                         "Field {} not found on type {:?}",
                         f.name.item,
                         meta_type.name()
-                    ))
+                    )
                 });
 
                 let exec_vars = executor.variables();

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -449,11 +449,11 @@ where
                 }
 
                 let meta_field = meta_type.field_by_name(f.name.item).unwrap_or_else(|| {
-                    panic!(format!(
+                    panic!(
                         "Field {} not found on type {:?}",
                         f.name.item,
                         meta_type.name()
-                    ))
+                    )
                 });
 
                 let exec_vars = executor.variables();


### PR DESCRIPTION
This adjusts a few tiny things that have changed in Rust nightly, and removes `-C link-dead-code` that was causing problems for the Windows GitHub Actions runners.

(I'm not quite sure where the `-C link-dead-code` part came from, but it does not appear to be present in the Azure script, so this should just bring us to parity and let the GHA runners succeed.)

This passes GHA on my branch: https://github.com/trevyn/juniper/actions/runs/598443306

(Is there anything preventing us from switching completely from Azure to GHA? This would make testing PRs in forks much easier.)