### PR TITLE
Make juniper_hyper functions return `Response<Body>` where applicable

### DIFF
--- a/juniper_hyper/examples/hyper_server.rs
+++ b/juniper_hyper/examples/hyper_server.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{convert::Infallible, sync::Arc};
 
 use hyper::{
     service::{make_service_fn, service_fn},
@@ -31,7 +31,7 @@ async fn main() {
                 let root_node = root_node.clone();
                 let ctx = ctx.clone();
                 async {
-                    match (req.method(), req.uri().path()) {
+                    Ok::<_, Infallible>(match (req.method(), req.uri().path()) {
                         (&Method::GET, "/") => juniper_hyper::graphiql("/graphql", None).await,
                         (&Method::GET, "/graphql") | (&Method::POST, "/graphql") => {
                             juniper_hyper::graphql(root_node, ctx, req).await
@@ -39,9 +39,9 @@ async fn main() {
                         _ => {
                             let mut response = Response::new(Body::empty());
                             *response.status_mut() = StatusCode::NOT_FOUND;
-                            Ok(response)
+                            response
                         }
-                    }
+                    })
                 }
             }))
         }

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -38,7 +38,7 @@ pub async fn graphql<CtxT, QueryT, MutationT, SubscriptionT, S>(
     root_node: Arc<RootNode<'static, QueryT, MutationT, SubscriptionT, S>>,
     context: Arc<CtxT>,
     req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error>
+) -> Response<Body>
 where
     QueryT: GraphQLTypeAsync<S, Context = CtxT>,
     QueryT::TypeInfo: Sync,
@@ -49,10 +49,10 @@ where
     CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
-    Ok(match parse_req(req).await {
+    match parse_req(req).await {
         Ok(req) => execute_request(root_node, context, req).await,
         Err(resp) => resp,
-    })
+    }
 }
 
 async fn parse_req<S: ScalarValue>(
@@ -121,26 +121,26 @@ async fn parse_post_graphql_req<S: ScalarValue>(
 pub async fn graphiql(
     graphql_endpoint: &str,
     subscriptions_endpoint: Option<&str>,
-) -> Result<Response<Body>, hyper::Error> {
+) -> Response<Body> {
     let mut resp = new_html_response(StatusCode::OK);
     // XXX: is the call to graphiql_source blocking?
     *resp.body_mut() = Body::from(juniper::http::graphiql::graphiql_source(
         graphql_endpoint,
         subscriptions_endpoint,
     ));
-    Ok(resp)
+    resp
 }
 
 pub async fn playground(
     graphql_endpoint: &str,
     subscriptions_endpoint: Option<&str>,
-) -> Result<Response<Body>, hyper::Error> {
+) -> Response<Body> {
     let mut resp = new_html_response(StatusCode::OK);
     *resp.body_mut() = Body::from(juniper::http::playground::playground_source(
         graphql_endpoint,
         subscriptions_endpoint,
     ));
-    Ok(resp)
+    resp
 }
 
 fn render_error(err: GraphQLRequestError) -> Response<Body> {

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -17,7 +17,7 @@ pub async fn graphql_sync<CtxT, QueryT, MutationT, SubscriptionT, S>(
     root_node: Arc<RootNode<'static, QueryT, MutationT, SubscriptionT, S>>,
     context: Arc<CtxT>,
     req: Request<Body>,
-) -> Result<Response<Body>, hyper::Error>
+) -> Response<Body>
 where
     QueryT: GraphQLType<S, Context = CtxT>,
     QueryT::TypeInfo: Sync,
@@ -28,10 +28,10 @@ where
     CtxT: Sync,
     S: ScalarValue + Send + Sync,
 {
-    Ok(match parse_req(req).await {
+    match parse_req(req).await {
         Ok(req) => execute_request_sync(root_node, context, req).await,
         Err(resp) => resp,
-    })
+    }
 }
 
 pub async fn graphql<CtxT, QueryT, MutationT, SubscriptionT, S>(

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
         EmptyMutation, EmptySubscription, RootNode,
     };
     use reqwest::{self, blocking::Response as ReqwestResponse};
-    use std::{net::SocketAddr, sync::Arc, thread, time::Duration};
+    use std::{convert::Infallible, net::SocketAddr, sync::Arc, thread, time::Duration};
 
     struct TestHyperIntegration {
         port: u16,
@@ -404,7 +404,7 @@ mod tests {
                         }
                     };
                     async move {
-                        if matches {
+                        Ok::<_, Infallible>(if matches {
                             if is_sync {
                                 super::graphql_sync(root_node, ctx, req).await
                             } else {
@@ -413,8 +413,8 @@ mod tests {
                         } else {
                             let mut resp = Response::new(Body::empty());
                             *resp.status_mut() = StatusCode::NOT_FOUND;
-                            Ok(resp)
-                        }
+                            resp
+                        })
                     }
                 }))
             }


### PR DESCRIPTION
Fix https://github.com/graphql-rust/juniper/issues/881.

Changes juniper_hyper to return `Response<Body>` instead of `Result<Response<Body>, hyper::Error>` for:
* `graphql`
* `graphql_sync`
* `graphiql`
* `playground`

Feel free to let me know if I'm missing any others!