### PR TITLE
Update iron link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 [graphql]: http://graphql.org
 [graphiql]: https://github.com/graphql/graphiql
 [playground]: https://github.com/prisma/graphql-playground
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphql_spec]: http://facebook.github.io/graphql
 [schema_language]: https://graphql.org/learn/schema/#type-language
 [schema_approach]: https://blog.logrocket.com/code-first-vs-schema-first-development-graphql/

--- a/docs/book/content/README.md
+++ b/docs/book/content/README.md
@@ -56,7 +56,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 
 [graphql]: http://graphql.org
 [graphiql]: https://github.com/graphql/graphiql
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphql_spec]: http://facebook.github.io/graphql
 [test_schema_rs]: https://github.com/graphql-rust/juniper/blob/master/juniper/src/tests/schema.rs
 [tokio]: https://github.com/tokio-rs/tokio

--- a/docs/book/content/servers/iron.md
+++ b/docs/book/content/servers/iron.md
@@ -117,6 +117,6 @@ impl Root {
 # }
 ```
 
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphiql]: https://github.com/graphql/graphiql
 [mount]: https://github.com/iron/mount

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -73,7 +73,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 
 [graphql]: http://graphql.org
 [graphiql]: https://github.com/graphql/graphiql
-[iron]: http://ironframework.io
+[iron]: https://github.com/iron/iron
 [graphql_spec]: http://facebook.github.io/graphql
 [test_schema_rs]: https://github.com/graphql-rust/juniper/blob/master/juniper/src/tests/schema.rs
 [tokio]: https://github.com/tokio-rs/tokio


### PR DESCRIPTION
The iron project has lost control of the ironframework[dot]io domain and it is apparently now serving malicious content: https://github.com/iron/iron/issues/632

This updates the iron URL to point to the GitHub repo instead.