### PR TITLE
Use smartstring for name of field (#819).

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -46,6 +46,7 @@ graphql-parser = { version = "0.3", optional = true }
 indexmap = { version = "1.0", features = ["serde-1"] }
 serde = { version = "1.0.8", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.2", default-features = false, optional = true }
+smartstring = "0.2.6"
 static_assertions = "1.1"
 url = { version = "2.0", optional = true }
 uuid = { version = "0.8", default-features = false, optional = true }

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -1158,7 +1158,7 @@ where
         T: GraphQLType<S> + ?Sized,
     {
         Field {
-            name: name.to_owned(),
+            name: smartstring::SmartString::from(name),
             description: None,
             arguments: None,
             field_type: self.get_type::<T>(info),
@@ -1176,7 +1176,7 @@ where
         I: GraphQLType<S>,
     {
         Field {
-            name: name.to_owned(),
+            name: smartstring::SmartString::from(name),
             description: None,
             arguments: None,
             field_type: self.get_type::<I>(info),

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -297,7 +297,7 @@ impl<'a> Lexer<'a> {
         }
 
         // Make sure we are on a valid char boundary.
-        let escape = &self
+        let escape = self
             .source
             .get(start_idx..=end_idx)
             .ok_or_else(|| Spanning::zero_width(&self.position, LexerError::UnterminatedString))?;

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -158,7 +158,7 @@ pub enum MetaType<'a, S = DefaultScalarValue> {
 #[derive(Debug, Clone)]
 pub struct Field<'a, S> {
     #[doc(hidden)]
-    pub name: String,
+    pub name: smartstring::alias::String,
     #[doc(hidden)]
     pub description: Option<String>,
     #[doc(hidden)]

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -318,8 +318,8 @@ impl<'a, S> Field<'a, S>
 where
     S: crate::ScalarValue + 'a,
 {
-    fn name(&self) -> &String {
-        &self.name
+    fn name(&self) -> String {
+        self.name.clone().into()
     }
 
     fn description(&self) -> &Option<String> {


### PR DESCRIPTION
Replaced name of field with a `smartstring` instead of `String`. Running `cargo bench --features expose-test-schema` indicates a slight improvement on the `query_type_name` test and slightly lower performance on the `introspection_query` test. Here is an example of two runs:

**Master**:
test introspection_query ... bench:     962,848 ns/iter (+/- 70,973)
test query_type_name     ... bench:      11,557 ns/iter (+/- 894)

**This PR/branch**:
test introspection_query ... bench:     978,076 ns/iter (+/- 70,523)
test query_type_name     ... bench:      11,354 ns/iter (+/- 1,471)