### PR TITLE
Un-deprecate the select_child, has_child, and child_names methods

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -1,6 +1,6 @@
 # master
 
-- No changes yet
+- Un-deprecate select_child, has_child, and child_names methods ([#900]https://github.com/graphql-rust/juniper/pull/#900)
 
 # [[0.15.3] 2021-01-27](https://github.com/graphql-rust/juniper/releases/tag/juniper-0.15.3)
 

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -340,14 +340,11 @@ pub trait LookAheadMethods<'sel, S> {
 
     /// Get the the child selection for a given field
     /// If a child has an alias, it will only match if the alias matches `name`
-    #[deprecated(note = "please use `children` to access the child selections instead")]
     fn select_child(&self, name: &str) -> Option<&Self>;
 
     /// Check if a given child selection with a name exists
     /// If a child has an alias, it will only match if the alias matches `name`
-    #[deprecated(note = "please use `children` to access the child selections instead")]
     fn has_child(&self, name: &str) -> bool {
-        #[allow(deprecated)]
         self.select_child(name).is_some()
     }
 
@@ -366,7 +363,6 @@ pub trait LookAheadMethods<'sel, S> {
     }
 
     /// Get the (possibly aliased) names of the top level children for the current selection
-    #[deprecated(note = "please use `children` to access the child selections instead")]
     fn child_names(&self) -> Vec<&'sel str>;
 
     /// Get an iterator over the children for the current selection
@@ -1307,7 +1303,6 @@ query Hero {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn check_select_child() {
         let lookahead: LookAheadSelection<DefaultScalarValue> = LookAheadSelection {
             name: "hero",
@@ -1459,7 +1454,6 @@ fragment heroFriendNames on Hero {
     }
 
     #[test]
-    #[allow(deprecated)]
     fn check_visitability() {
         let docs = parse_document_source::<DefaultScalarValue>(
             "


### PR DESCRIPTION
- Issues with removing them documented in issue #878