### PR TITLE
Fixes Issue 914

### DIFF
--- a/integration_tests/juniper_tests/src/issue_914.rs
+++ b/integration_tests/juniper_tests/src/issue_914.rs
@@ -1,0 +1,85 @@
+use juniper::*;
+
+struct Query;
+
+#[derive(GraphQLObject)]
+struct Foo {
+    bar: Bar,
+}
+
+#[derive(GraphQLObject)]
+struct Bar {
+    a: i32,
+    b: i32,
+}
+
+#[graphql_object]
+impl Query {
+    fn foo() -> Foo {
+        let bar = Bar { a: 1, b: 2 };
+        Foo { bar }
+    }
+}
+
+type Schema = juniper::RootNode<'static, Query, EmptyMutation, EmptySubscription>;
+
+#[tokio::test]
+async fn test_fragments_on_nexted_types_dont_override_previous_selections() {
+    let query = r#"
+        query Query {
+            foo {
+                ...BarA
+                ...BarB
+            }
+        }
+
+        fragment BarA on Foo {
+            bar {
+                a
+            }
+        }
+
+        fragment BarB on Foo {
+            bar {
+                b
+            }
+        }
+    "#;
+
+    let (async_value, errors) = juniper::execute(
+        query,
+        None,
+        &Schema::new(Query, EmptyMutation::new(), EmptySubscription::new()),
+        &Variables::new(),
+        &(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(errors.len(), 0);
+
+    let (sync_value, errors) = juniper::execute_sync(
+        query,
+        None,
+        &Schema::new(Query, EmptyMutation::new(), EmptySubscription::new()),
+        &Variables::new(),
+        &(),
+    )
+    .unwrap();
+    assert_eq!(errors.len(), 0);
+
+    assert_eq!(async_value, sync_value);
+
+    let bar = async_value
+        .as_object_value()
+        .unwrap()
+        .get_field_value("foo")
+        .unwrap()
+        .as_object_value()
+        .unwrap()
+        .get_field_value("bar")
+        .unwrap()
+        .as_object_value()
+        .unwrap();
+    assert!(bar.contains_field("a"), "Field a should be selected");
+    assert!(bar.contains_field("b"), "Field b should be selected");
+}

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -19,4 +19,6 @@ mod issue_407;
 #[cfg(test)]
 mod issue_500;
 #[cfg(test)]
+mod issue_914;
+#[cfg(test)]
 mod pre_parse;

--- a/juniper/src/value/object.rs
+++ b/juniper/src/value/object.rs
@@ -28,14 +28,26 @@ impl<S> Object<S> {
 
     /// Add a new field with a value
     ///
-    /// If there is already a field with the same name the old value
-    /// is returned
+    /// If there is already a field for the given key
+    /// any both values are objects, they are merged.
+    ///
+    /// Otherwise the existing value is replaced and
+    /// returned.
     pub fn add_field<K>(&mut self, k: K, value: Value<S>) -> Option<Value<S>>
     where
         K: Into<String>,
         for<'a> &'a str: PartialEq<K>,
     {
-        self.key_value_list.insert(k.into(), value)
+        let key: String = k.into();
+        match (value, self.key_value_list.get_mut(&key)) {
+            (Value::<S>::Object(obj_val), Some(Value::<S>::Object(existing_obj))) => {
+                for (key, val) in obj_val.into_iter() {
+                    existing_obj.add_field::<String>(key, val);
+                }
+                None
+            },
+            (non_obj_val, _) => self.key_value_list.insert(key, non_obj_val),
+        }
     }
 
     /// Check if the object already contains a field with the given name

--- a/juniper/src/value/object.rs
+++ b/juniper/src/value/object.rs
@@ -45,7 +45,7 @@ impl<S> Object<S> {
                     existing_obj.add_field::<String>(key, val);
                 }
                 None
-            },
+            }
             (non_obj_val, _) => self.key_value_list.insert(key, non_obj_val),
         }
     }


### PR DESCRIPTION
Closes #914 

This fixes the issue raised and adds a test to prevent future regressions.

Note that this slightly changes to public api of `juniper::Object`'s: `add_field` will now check if a new field exists and is an object, and in that case merge the objects keys instead of replacing the old object.

It might also make sense to not return anything from that function (which is a breaking change of the public interface, but seems to compile without modification to the existing uses in the juniper crate, I think the behavior was originally copied from `std::collections::HashMap`).