### PR TITLE
Pin rocket to specific revision 

### DIFF
--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/graphql-rust/juniper"
 [dependencies]
 futures = "0.3.1"
 juniper = { version = "0.15.4", path = "../juniper", default-features = false }
-rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "master", default-features = false }
+rocket = { git = "https://github.com/SergioBenitez/Rocket", rev = "50c9e88cf91cbcc6298cbd04282aebf6fba69b88", default-features = false }
 serde_json = "1.0.2"
 tokio = { version = "1", features = ["macros", "rt"] }
 


### PR DESCRIPTION
Rocket is in active development with many breaking
changes. To prevent breaking the CI for unrelated
pull requests pin rocket down to a specific revision
instead of following master blindly.

This project is already struggling with breaking changes in the nightly compiler. That's the reason why this PR fails CI, too.