### PR TITLE
Eliminate tokio dependency in juniper_rocket_async

### DIFF
--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.1"
 juniper = { version = "0.15.4", path = "../juniper", default-features = false }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "master", default-features = false }
 serde_json = "1.0.2"
-tokio = { version = "1", features = ["macros", "rt"] }
 
 [dev-dependencies]
 juniper = { version = "0.15.4", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -572,7 +572,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[rocket::async_test]
     async fn test_rocket_integration() {
         let rocket = make_rocket();
         let client = Client::untracked(rocket).await.expect("valid rocket");
@@ -581,7 +581,7 @@ mod tests {
         http_tests::run_http_test_suite(&integration);
     }
 
-    #[tokio::test]
+    #[rocket::async_test]
     async fn test_operation_names() {
         #[post("/", data = "<request>")]
         fn post_graphql_assert_operation_name_handler(


### PR DESCRIPTION
The `tokio` dependency is only required for tests and should have been in the `dev-dependencies` section in `Cargo.toml`.

Since `rocket` already ships with a async test annotation `tokio` can be removed completely.