### PR TITLE
Fix subscription error extensions (#925)

### DIFF
--- a/integration_tests/juniper_tests/src/issue_925.rs
+++ b/integration_tests/juniper_tests/src/issue_925.rs
@@ -1,0 +1,69 @@
+use juniper::*;
+
+use futures::stream::BoxStream;
+
+#[derive(juniper::GraphQLObject)]
+struct User {
+    name: String,
+}
+
+struct Error;
+
+impl<S: ScalarValue> IntoFieldError<S> for Error {
+    fn into_field_error(self) -> FieldError<S> {
+        let a = Value::Scalar(S::from(42));
+        let mut extensions = Object::with_capacity(1);
+        let _ = extensions.add_field("a", a);
+        FieldError::new("oops", Value::Object(extensions))
+    }
+}
+
+struct SubscriptionsRoot;
+
+#[graphql_subscription(name = "Subscription")]
+impl SubscriptionsRoot {
+    async fn users() -> Result<BoxStream<'static, User>, Error> {
+        Ok(users_stream()?)
+    }
+}
+
+fn users_stream() -> Result<BoxStream<'static, User>, Error> {
+    Err(Error)
+}
+
+struct Query;
+
+#[juniper::graphql_object]
+impl Query {
+    fn users() -> Vec<User> {
+        vec![]
+    }
+}
+
+type Schema = juniper::RootNode<'static, Query, EmptyMutation<()>, SubscriptionsRoot>;
+
+#[tokio::test]
+async fn test_error_extensions() {
+    let sub = r#"
+        subscription Users {
+            users {
+                name
+            }
+        }
+    "#;
+
+    let (_, errors) = juniper::resolve_into_stream(
+        sub,
+        None,
+        &Schema::new(Query, EmptyMutation::new(), SubscriptionsRoot),
+        &Variables::new(),
+        &(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        errors.first().unwrap().error().extensions(),
+        &graphql_value!({ "a": 42 })
+    );
+}

--- a/integration_tests/juniper_tests/src/lib.rs
+++ b/integration_tests/juniper_tests/src/lib.rs
@@ -23,4 +23,6 @@ mod issue_914;
 #[cfg(test)]
 mod issue_922;
 #[cfg(test)]
+mod issue_925;
+#[cfg(test)]
 mod pre_parse;

--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -1271,7 +1271,7 @@ impl GraphQLTypeDefiniton {
                 quote!(
                     #name => {
                         ::juniper::futures::FutureExt::boxed(async move {
-                            let res #_type = { #code };
+                            let res #_type = async { #code }.await;
                             let res = ::juniper::IntoFieldResult::<_, #scalar>::into_result(res)?;
                             let executor= executor.as_owned_executor();
                             let f = res.then(move |res| {


### PR DESCRIPTION
Closes #925 

Using sync code block for wrapping user defined code was causing `?` to short circuit the whole outer async block, which does not return a user defined error but `FieldError` itself.    
So user defined errors were implicitly converted into `FieldError`'s via `std::convert::Into`, the default implementation of which does not set `FieldError::extensions` at all.