### PR TITLE
juniper_rocket_async: bump to 0.5.0-rc.1

### DIFF
--- a/juniper_rocket_async/Cargo.toml
+++ b/juniper_rocket_async/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/graphql-rust/juniper"
 [dependencies]
 futures = "0.3.1"
 juniper = { version = "0.15.6", path = "../juniper", default-features = false }
-rocket = { git = "https://github.com/SergioBenitez/Rocket", branch = "master", default-features = false }
+rocket = { version = "0.5.0-rc.1", default-features = false }
 serde_json = "1.0.2"
 
 [dev-dependencies]

--- a/juniper_rocket_async/src/lib.rs
+++ b/juniper_rocket_async/src/lib.rs
@@ -322,7 +322,10 @@ where
 {
     type Error = String;
 
-    async fn from_data(req: &'r Request<'_>, data: Data) -> data::Outcome<Self, Self::Error> {
+    async fn from_data(
+        req: &'r Request<'_>,
+        data: Data<'r>,
+    ) -> data::Outcome<'r, Self, Self::Error> {
         use rocket::tokio::io::AsyncReadExt as _;
 
         let content_type = req


### PR DESCRIPTION
From now on `dependabot` will take care of bumping rocket to a newer release.