### PR TITLE
juniper_codegen: macro hygiene for graphql_subscription

### DIFF
--- a/juniper_codegen/src/util/mod.rs
+++ b/juniper_codegen/src/util/mod.rs
@@ -1399,7 +1399,7 @@ impl GraphQLTypeDefiniton {
                     executor: &'ref_e ::juniper::Executor<'ref_e, 'e, Self::Context, #scalar>,
                 ) -> std::pin::Pin<Box<
                         dyn ::juniper::futures::future::Future<
-                            Output = Result<
+                            Output = std::result::Result<
                                 ::juniper::Value<::juniper::ValuesStream<'res, #scalar>>,
                                 ::juniper::FieldError<#scalar>
                             >


### PR DESCRIPTION
Fully qualify `std::result::Result` such that it doesn't collide with locally defined type aliases for `Result`. This improves macro hygiene.