### PR TITLE
Switch releasing commands from a blocklist to an allowlist

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,6 +2,8 @@
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = "true"
 CARGO_MAKE_CARGO_ALL_FEATURES = ""
+CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = "integration_tests/*;examples/*;juniper_benchmarks;"
+
 
 # Run `RELEASE_LEVEL=(patch|major|minor) cargo make release` to push a new release of every crate.
 #
@@ -9,15 +11,6 @@ CARGO_MAKE_CARGO_ALL_FEATURES = ""
 # to push a new release of a subset of crates.
 [tasks.release]
 condition = { env_set = [ "RELEASE_LEVEL" ] }
-workspace = false
-run_task = { name = "release-INTERNAL", fork = true }
-
-# Hack to filter out crates we do not want to release.
-# See <https://github.com/sagiegurari/cargo-make/issues/212#issuecomment-481123564>
-[tasks.release-INTERNAL]
-private = true
-condition = { env_set = [ "RELEASE_LEVEL" ] }
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
 command = "cargo-release"
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/release.toml", "${RELEASE_LEVEL}"]
 
@@ -28,15 +21,6 @@ args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/releas
 # to do a dry run of a subset of crates.
 [tasks.release-dry-run]
 condition = { env_set = [ "RELEASE_LEVEL" ] }
-workspace = false
-run_task = { name = "release-dry-run-INTERNAL", fork = true }
-
-# Hack to filter out crates we do not want to release.
-# See <https://github.com/sagiegurari/cargo-make/issues/212#issuecomment-481123564>
-[tasks.release-dry-run-INTERNAL]
-private = true
-condition = { env_set = [ "RELEASE_LEVEL" ] }
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
 description = "Run `cargo-release --dry-run` for every crate"
 command = "cargo-release"
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
@@ -48,15 +32,6 @@ args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/releas
 # Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2;" cargo make release-local-test` to actually make changes locally but
 # not push some crates up to crates.io or Github.
 [tasks.release-local-test]
-condition = { env_set = [ "RELEASE_LEVEL" ] }
-workspace = false
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
-run_task = { name = "release-local-test-INTERNAL", fork = true }
-
-# Hack to filter out crates we do not want to release.
-# See <https://github.com/sagiegurari/cargo-make/issues/212#issuecomment-481123564>
-[tasks.release-local-test-INTERNAL]
-private = true
 condition = { env_set = [ "RELEASE_LEVEL" ] }
 description = "Run `cargo-release` for every crate, but only make changes locally"
 command = "cargo-release"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,21 +3,12 @@
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = "true"
 CARGO_MAKE_CARGO_ALL_FEATURES = ""
 
-#
 # Run `RELEASE_LEVEL=(patch|major|minor) cargo make release` to push a new release of every crate.
-# Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_SKIP_MEMBERS="crate1;crate2;" cargo make release`
-# to push a new release of some crates.
 #
-
+# Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2;" cargo make release`
+# to push a new release of a subset of crates.
 [tasks.release]
 condition = { env_set = [ "RELEASE_LEVEL" ] }
-workspace = false
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
-run_task = { name = "release-INTERNAL", fork = true }
-
-
-[tasks.release-some]
-condition = { env_set = [ "RELEASE_LEVEL", "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" ] }
 workspace = false
 run_task = { name = "release-INTERNAL", fork = true }
 
@@ -26,27 +17,19 @@ run_task = { name = "release-INTERNAL", fork = true }
 [tasks.release-INTERNAL]
 private = true
 condition = { env_set = [ "RELEASE_LEVEL" ] }
+env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
 command = "cargo-release"
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/release.toml", "${RELEASE_LEVEL}"]
 
 
-#
 # Run `RELEASE_LEVEL=(patch|major|minor) cargo make release-dry-run` to do a dry run.
-# Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_SKIP_MEMBERS="crate1;crate2;" cargo make release-some-dry-run`
-# to do a dry run with some crates.
 #
-
+# Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2;" cargo make release-dry-run`
+# to do a dry run of a subset of crates.
 [tasks.release-dry-run]
 condition = { env_set = [ "RELEASE_LEVEL" ] }
 workspace = false
-env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
 run_task = { name = "release-dry-run-INTERNAL", fork = true }
-
-[tasks.release-some-dry-run]
-condition = { env_set = [ "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS", "RELEASE_LEVEL" ] }
-workspace = false
-run_task = { name = "release-some-dry-run-INTERNAL", fork = true }
-
 
 # Hack to filter out crates we do not want to release.
 # See <https://github.com/sagiegurari/cargo-make/issues/212#issuecomment-481123564>
@@ -58,25 +41,17 @@ description = "Run `cargo-release --dry-run` for every crate"
 command = "cargo-release"
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/../_build/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
 
-#
-# Run `RELEASE_LEVEL=(patch|major|minor) cargo make release-local-test` to do actually make changes locally but
-# not push them up to crates.io or Github.
-# Run `RELEASE_LEVEL=(patch|major|minor) cargo make release-some-local-test` to do actually make changes locally but
-# not push some crates up to crates.io or Github.
-#
 
+# Run `RELEASE_LEVEL=(patch|major|minor) cargo make release-local-test` to actually make changes locally but
+# not push them up to crates.io or Github.
+#
+# Run `RELEASE_LEVEL=(patch|major|minor) CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2;" cargo make release-local-test` to actually make changes locally but
+# not push some crates up to crates.io or Github.
 [tasks.release-local-test]
 condition = { env_set = [ "RELEASE_LEVEL" ] }
 workspace = false
 env = { "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS" = "integration_tests/*;examples/*;juniper_benchmarks;" }
 run_task = { name = "release-local-test-INTERNAL", fork = true }
-
-
-[tasks.release-some-local-test]
-condition = { env_set = [ "CARGO_MAKE_WORKSPACE_SKIP_MEMBERS", "RELEASE_LEVEL" ] }
-workspace = false
-run_task = { name = "release-local-test-INTERNAL", fork = true }
-
 
 # Hack to filter out crates we do not want to release.
 # See <https://github.com/sagiegurari/cargo-make/issues/212#issuecomment-481123564>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,11 +20,11 @@ We use [`cargo-make`](cargo-make) and [`cargo-release`](cargo-release) to automa
 
 ## Preparing for a release
 
-There are two general classes of release and each require running different automation commands:
+There are two general classes of releases:
 
-1. All public workspace crates should be released and all share the same release level ("patch", "minor", "major"). _These commands take the form `release-[whatever]`._
+1. All public workspace crates should be released and all share the same release level ("patch", "minor", "major").
 
-2. A subset of workspace crates need to be released, or not all crate releases share the same release level. _These commands start with `release-skip-[whatever]`._
+2. A subset of workspace crates need to be released, or not all crate releases share the same release level.
 
 **All release commands must be run from the root directory of the repository.**
 
@@ -32,24 +32,19 @@ There are two general classes of release and each require running different auto
 
 For each crate, determine the desired release level (`patch`, `minor`, `major`). Set the `RELEASE_LEVEL` env variable to the desired release level.
 
-## Determine which crates to exclude
+## Determine which crates to release
 
-If a subset of workspace crates need to be released, or not all crate releases share the same release level, set the `CARGO_MAKE_WORKSPACE_SKIP_MEMBERS` env
-variable to filter out specific workspace crates. The value is a list of semicolon-delineated crate names or a regular expression.
-
-**Important:** You likely want to always exclude `integration_tests/*`.
+If a subset of workspace crates need to be released, or not all crate releases share the same release level, set the `CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS` env
+variable to choose specific workspace crates. The value is a list of semicolon-delineated crate names or a regular expressions.
 
 ## Dry run
 
 It is a good idea to do a dry run to sanity check what actions will be performed.
 
 - For case #1 above, run `cargo make release-dry-run`.
+- For case #2 above, run `CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2" cargo make release-dry-run`.
 
   If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL`.
-
-- For case #2 above, run `cargo make release-some-dry-run`.
-
-  If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL` or `CARGO_MAKE_WORKSPACE_SKIP_MEMBERS`.
 
 ## Local test
 
@@ -58,12 +53,9 @@ In a local test, all the release actions are performed on your local checkout
 but nothing is pushed to Github or crates.io.
 
 - For case #1 above, run `cargo make release-local-test`.
+- For case #2 above, run `CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2" cargo make release-local-test`.
 
   If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL`.
-
-- For case #2 above, run `cargo make release-some-local-test`.
-
-  If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL` or `CARGO_MAKE_WORKSPACE_SKIP_MEMBERS`.
 
 After, your local git repository should have the changes ready to push to Github.
 Use `git rebase -i HEAD~10` and drop the new commits.
@@ -74,12 +66,9 @@ After testing locally and via a dry run, it is time to release. A release
 consists of bumping versions, starting a new changelog section, pushing a tag to Github, and updating crates.io. This should all be handled by running the automated commands.
 
 - For case #1 above, run `cargo make release`.
+- For case #2 above, run `CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS="crate1;crate2" cargo make release`.
 
-  If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL`.
-
-- For case #2 above, run `cargo make release-some`.
-
-  If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL` or `CARGO_MAKE_WORKSPACE_SKIP_MEMBERS`.
+  If the command finishes super quickly with no output you likely did not set `RELEASE_LEVEL`,
 
 [cargo-make]: https://github.com/sagiegurari/cargo-make
 [cargo-release]: https://github.com/sunng87/cargo-release

--- a/juniper/Makefile.toml
+++ b/juniper/Makefile.toml
@@ -3,13 +3,13 @@
 [env]
 CARGO_MAKE_CARGO_ALL_FEATURES = ""
 
-[tasks.release-INTERNAL]
+[tasks.release]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
 
-[tasks.release-dry-run-INTERNAL]
+[tasks.release-dry-run]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
 
-[tasks.release-local-test-INTERNAL]
+[tasks.release-local-test]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]
 
 [tasks.test]

--- a/juniper_codegen/Makefile.toml
+++ b/juniper_codegen/Makefile.toml
@@ -1,11 +1,11 @@
 # This is needed as the release config is at a different path than the top-level
 # release config.
 
-[tasks.release-INTERNAL]
+[tasks.release]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
 
-[tasks.release-dry-run-INTERNAL]
+[tasks.release-dry-run]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
 
-[tasks.release-local-test-INTERNAL]
+[tasks.release-local-test]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]

--- a/juniper_graphql_ws/Makefile.toml
+++ b/juniper_graphql_ws/Makefile.toml
@@ -1,13 +1,13 @@
 # This is needed as the release config is at a different path than the top-level
 # release config.
 
-[tasks.release-INTERNAL]
+[tasks.release]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
 
-[tasks.release-dry-run-INTERNAL]
+[tasks.release-dry-run]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
 
-[tasks.release-local-test-INTERNAL]
+[tasks.release-local-test]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]
 
 [env]

--- a/juniper_subscriptions/Makefile.toml
+++ b/juniper_subscriptions/Makefile.toml
@@ -2,13 +2,13 @@
 # This is needed as the release config is at a different path than the top-level
 # release config.
 
-[tasks.release-INTERNAL]
+[tasks.release]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "${RELEASE_LEVEL}"]
 
-[tasks.release-dry-run-INTERNAL]
+[tasks.release-dry-run]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--dry-run", "${RELEASE_LEVEL}"]
 
-[tasks.release-local-test-INTERNAL]
+[tasks.release-local-test]
 args = ["release", "--config", "${CARGO_MAKE_WORKING_DIRECTORY}/release.toml", "--no-confirm", "--skip-publish", "--skip-push", "--skip-tag", "${RELEASE_LEVEL}"]
 
 [env]


### PR DESCRIPTION
This is much better as we can hardocde the crates to filter out in
one place, can selectively release certain crates easily,
and only have one command instead of the "-some" hack