### PR TITLE
Provide access for integration GraphQLRequest wrappers to its inner types (#930)

### DIFF
--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 - Compatibility with the latest `juniper`.
+- Provide `AsRef` and `AsMut` implementation for `GraphQLRequest` to its inner type ([#968](https://github.com/graphql-rust/juniper/pull/968), [#930](https://github.com/graphql-rust/juniper/issues/930)).
 
 # [[0.8.0] 2021-07-08](https://github.com/graphql-rust/juniper/releases/tag/juniper_rocket-0.8.0)
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -65,6 +65,18 @@ pub struct GraphQLRequest<S = DefaultScalarValue>(GraphQLBatchRequest<S>)
 where
     S: ScalarValue;
 
+impl<S: ScalarValue> AsRef<GraphQLBatchRequest<S>> for GraphQLRequest<S> {
+    fn as_ref(&self) -> &GraphQLBatchRequest<S> {
+        &self.0
+    }
+}
+
+impl<S: ScalarValue> AsMut<GraphQLBatchRequest<S>> for GraphQLRequest<S> {
+    fn as_mut(&mut self) -> &mut GraphQLBatchRequest<S> {
+        &mut self.0
+    }
+}
+
 /// Simple wrapper around the result of executing a GraphQL query
 pub struct GraphQLResponse(pub Status, pub String);
 


### PR DESCRIPTION
Fixes #930

For all `juniper_*` integrations makes `juniper::GraphQLBatchRequest` accessible from newtype wrappers.