### PR TITLE
Rework codegen for GraphQL objects

### DIFF
--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -143,6 +143,7 @@ pub fn derive_input_object(input: TokenStream) -> TokenStream {
     }
 }
 
+// TODO
 #[proc_macro_error]
 #[proc_macro_derive(GraphQLObject, attributes(graphql))]
 pub fn derive_object(input: TokenStream) -> TokenStream {
@@ -495,7 +496,7 @@ pub fn graphql_object(args: TokenStream, input: TokenStream) -> TokenStream {
 /// struct UserID(String);
 ///
 /// #[juniper::graphql_scalar(
-///     // You can rename the type for GraphQL by specifying the name here.    
+///     // You can rename the type for GraphQL by specifying the name here.
 ///     name = "MyName",
 ///     // You can also specify a description here.
 ///     // If present, doc comments will be ignored.


### PR DESCRIPTION
Part of #421  
Superseeds #441   
Fixes #525, #697, #814, #827, #875, #880

This PR migrates `#[derive(GraphQLObject)]`, `#[graphql_object]` and `#[graphql_subscription]` macro implementations to the same machinery used by `#[graphql_interface]`.

Additionally, it changes codegen in the way, that computed fields are not desugared into async blocks, but rather are preserved as methods and called directly.

## Checklist
- [ ] Implemented
- [ ] Old code is cleaned
- [ ] Covered with integration tests
- [ ] Covered with codegen failure tests
- [ ] Documantation is updated
- [ ] Changelog entry added
