### PR TITLE
Update actix-web beta

### DIFF
--- a/docs/book/content/advanced/dataloaders.md
+++ b/docs/book/content/advanced/dataloaders.md
@@ -48,7 +48,7 @@ DataLoader caching does not replace Redis, Memcache, or any other shared applica
 
 ```toml
 [dependencies]
-actix-identity = "0.4.0-beta.2"
+actix-identity = "0.4.0-beta.4"
 actix-rt = "1.0"
 actix-web = {version = "2.0", features = []}
 juniper = { git = "https://github.com/graphql-rust/juniper" }

--- a/examples/actix_subscriptions/Cargo.toml
+++ b/examples/actix_subscriptions/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Mihai Dinculescu <mihai.dinculescu@outlook.com>"]
 publish = false
 
 [dependencies]
-actix-web = "4.0.0-beta.8"
-actix-cors = "0.6.0-beta.2"
+actix-web = "4.0.0-beta.12"
+actix-cors = "0.6.0-beta.4"
 futures = "0.3"
 env_logger = "0.9"
 serde = "1.0"

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -13,10 +13,10 @@ subscriptions = ["juniper_graphql_ws", "tokio"]
 
 [dependencies]
 actix = "0.12"
-actix-http = "3.0.0-beta.8"
+actix-http = "3.0.0-beta.13"
 http = "0.2.4"
-actix-web = "4.0.0-beta.8"
-actix-web-actors = "4.0.0-beta.6"
+actix-web = "4.0.0-beta.12"
+actix-web-actors = "4.0.0-beta.7"
 
 juniper = { version = "0.15.7", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.3.0", path = "../juniper_graphql_ws", optional = true }
@@ -30,11 +30,11 @@ tokio = { version = "1.0", features = ["sync"], optional = true }
 
 [dev-dependencies]
 actix-rt = "2"
-actix-cors = "0.6.0-beta.2"
-actix-identity = "0.4.0-beta.2"
+actix-cors = "0.6.0-beta.4"
+actix-identity = "0.4.0-beta.4"
 tokio = "1.0"
 async-stream = "0.3"
-actix-test = "0.1.0-beta.3"
+actix-test = "0.1.0-beta.6"
 
 juniper = { version = "0.15.7", path = "../juniper", features = ["expose-test-schema"] }
 

--- a/juniper_actix/src/lib.rs
+++ b/juniper_actix/src/lib.rs
@@ -471,7 +471,7 @@ mod tests {
         dev::ServiceResponse,
         http,
         http::header::CONTENT_TYPE,
-        test::{call_service, init_service, TestRequest},
+        test::{self, TestRequest},
         web::Data,
         App,
     };
@@ -514,13 +514,14 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             graphiql_handler("/abcd", None).await
         }
-        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let mut app =
+            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
         let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let resp = call_service(&mut app, req).await;
+        let resp = test::call_service(&mut app, req).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
     }
 
@@ -529,13 +530,14 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             graphiql_handler("/dogs-api/graphql", Some("/dogs-api/subscriptions")).await
         }
-        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let mut app =
+            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
         let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let mut resp = call_service(&mut app, req).await;
+        let mut resp = test::call_service(&mut app, req).await;
         let body = take_response_body_string(&mut resp).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -553,13 +555,14 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             playground_handler("/abcd", None).await
         }
-        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let mut app =
+            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
         let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let resp = call_service(&mut app, req).await;
+        let resp = test::call_service(&mut app, req).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
     }
 
@@ -568,13 +571,14 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             playground_handler("/dogs-api/graphql", Some("/dogs-api/subscriptions")).await
         }
-        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let mut app =
+            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
         let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let mut resp = call_service(&mut app, req).await;
+        let mut resp = test::call_service(&mut app, req).await;
         let body = take_response_body_string(&mut resp).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -600,14 +604,14 @@ mod tests {
             .uri("/")
             .to_request();
 
-        let mut app = init_service(
+        let mut app = test::init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::post().to(index)),
         )
         .await;
 
-        let mut resp = call_service(&mut app, req).await;
+        let mut resp = test::call_service(&mut app, req).await;
         dbg!(take_response_body_string(&mut resp).await);
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -633,14 +637,14 @@ mod tests {
             .uri("/?query=%7B%20hero%28episode%3A%20NEW_HOPE%29%20%7B%20name%20%7D%20%7D&variables=null")
             .to_request();
 
-        let mut app = init_service(
+        let mut app = test::init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::get().to(index)),
         )
         .await;
 
-        let mut resp = call_service(&mut app, req).await;
+        let mut resp = test::call_service(&mut app, req).await;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -677,14 +681,14 @@ mod tests {
             .uri("/")
             .to_request();
 
-        let mut app = init_service(
+        let mut app = test::init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::post().to(index)),
         )
         .await;
 
-        let mut resp = call_service(&mut app, req).await;
+        let mut resp = test::call_service(&mut app, req).await;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -716,14 +720,14 @@ mod tests {
                     EmptySubscription::<Database>::new(),
                 );
 
-                let mut app = init_service(
+                let mut app = test::init_service(
                     App::new()
                         .app_data(Data::new(schema))
                         .route("/", web::to(index)),
                 )
                 .await;
 
-                let resp = call_service(&mut app, req.to_request()).await;
+                let resp = test::call_service(&mut app, req.to_request()).await;
                 make_test_response(resp).await
             })
         }

--- a/juniper_actix/src/lib.rs
+++ b/juniper_actix/src/lib.rs
@@ -467,7 +467,14 @@ pub mod subscriptions {
 #[cfg(test)]
 mod tests {
     use actix_http::body::AnyBody;
-    use actix_web::{dev::ServiceResponse, http, http::header::CONTENT_TYPE, test, web::Data, App};
+    use actix_web::{
+        dev::ServiceResponse,
+        http,
+        http::header::CONTENT_TYPE,
+        test::{call_service, init_service, TestRequest},
+        web::Data,
+        App,
+    };
     use juniper::{
         http::tests::{run_http_test_suite, HttpIntegration, TestResponse},
         tests::fixtures::starwars::schema::{Database, Query},
@@ -507,14 +514,13 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             graphiql_handler("/abcd", None).await
         }
-        let mut app =
-            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
-        let req = test::TestRequest::get()
+        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let resp = test::call_service(&mut app, req).await;
+        let resp = call_service(&mut app, req).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
     }
 
@@ -523,14 +529,13 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             graphiql_handler("/dogs-api/graphql", Some("/dogs-api/subscriptions")).await
         }
-        let mut app =
-            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
-        let req = test::TestRequest::get()
+        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let mut resp = test::call_service(&mut app, req).await;
+        let mut resp = call_service(&mut app, req).await;
         let body = take_response_body_string(&mut resp).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -548,14 +553,13 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             playground_handler("/abcd", None).await
         }
-        let mut app =
-            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
-        let req = test::TestRequest::get()
+        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let resp = test::call_service(&mut app, req).await;
+        let resp = call_service(&mut app, req).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
     }
 
@@ -564,14 +568,13 @@ mod tests {
         async fn graphql_handler() -> Result<HttpResponse, Error> {
             playground_handler("/dogs-api/graphql", Some("/dogs-api/subscriptions")).await
         }
-        let mut app =
-            test::init_service(App::new().route("/", web::get().to(graphql_handler))).await;
-        let req = test::TestRequest::get()
+        let mut app = init_service(App::new().route("/", web::get().to(graphql_handler))).await;
+        let req = TestRequest::get()
             .uri("/")
             .append_header((ACCEPT, "text/html"))
             .to_request();
 
-        let mut resp = test::call_service(&mut app, req).await;
+        let mut resp = call_service(&mut app, req).await;
         let body = take_response_body_string(&mut resp).await;
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -589,7 +592,7 @@ mod tests {
             EmptySubscription::<Database>::new(),
         );
 
-        let req = test::TestRequest::post()
+        let req = TestRequest::post()
             .append_header(("content-type", "application/json; charset=utf-8"))
             .set_payload(
                 r##"{ "variables": null, "query": "{ hero(episode: NEW_HOPE) { name } }" }"##,
@@ -597,14 +600,14 @@ mod tests {
             .uri("/")
             .to_request();
 
-        let mut app = test::init_service(
+        let mut app = init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::post().to(index)),
         )
         .await;
 
-        let mut resp = test::call_service(&mut app, req).await;
+        let mut resp = call_service(&mut app, req).await;
         dbg!(take_response_body_string(&mut resp).await);
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -625,19 +628,19 @@ mod tests {
             EmptySubscription::<Database>::new(),
         );
 
-        let req = test::TestRequest::get()
+        let req = TestRequest::get()
             .append_header(("content-type", "application/json"))
             .uri("/?query=%7B%20hero%28episode%3A%20NEW_HOPE%29%20%7B%20name%20%7D%20%7D&variables=null")
             .to_request();
 
-        let mut app = test::init_service(
+        let mut app = init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::get().to(index)),
         )
         .await;
 
-        let mut resp = test::call_service(&mut app, req).await;
+        let mut resp = call_service(&mut app, req).await;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -663,7 +666,7 @@ mod tests {
             EmptySubscription::<Database>::new(),
         );
 
-        let req = test::TestRequest::post()
+        let req = TestRequest::post()
             .append_header(("content-type", "application/json"))
             .set_payload(
                 r##"[
@@ -674,14 +677,14 @@ mod tests {
             .uri("/")
             .to_request();
 
-        let mut app = test::init_service(
+        let mut app = init_service(
             App::new()
                 .app_data(Data::new(schema))
                 .route("/", web::post().to(index)),
         )
         .await;
 
-        let mut resp = test::call_service(&mut app, req).await;
+        let mut resp = call_service(&mut app, req).await;
 
         assert_eq!(resp.status(), http::StatusCode::OK);
         assert_eq!(
@@ -705,7 +708,7 @@ mod tests {
     pub struct TestActixWebIntegration;
 
     impl TestActixWebIntegration {
-        fn make_request(&self, req: test::TestRequest) -> TestResponse {
+        fn make_request(&self, req: TestRequest) -> TestResponse {
             actix_web::rt::System::new().block_on(async move {
                 let schema = Schema::new(
                     Query,
@@ -713,14 +716,14 @@ mod tests {
                     EmptySubscription::<Database>::new(),
                 );
 
-                let mut app = test::init_service(
+                let mut app = init_service(
                     App::new()
                         .app_data(Data::new(schema))
                         .route("/", web::to(index)),
                 )
                 .await;
 
-                let resp = test::call_service(&mut app, req.to_request()).await;
+                let resp = call_service(&mut app, req.to_request()).await;
                 make_test_response(resp).await
             })
         }
@@ -728,12 +731,12 @@ mod tests {
 
     impl HttpIntegration for TestActixWebIntegration {
         fn get(&self, url: &str) -> TestResponse {
-            self.make_request(test::TestRequest::get().uri(url))
+            self.make_request(TestRequest::get().uri(url))
         }
 
         fn post_json(&self, url: &str, body: &str) -> TestResponse {
             self.make_request(
-                test::TestRequest::post()
+                TestRequest::post()
                     .append_header(("content-type", "application/json"))
                     .set_payload(body.to_string())
                     .uri(url),
@@ -742,7 +745,7 @@ mod tests {
 
         fn post_graphql(&self, url: &str, body: &str) -> TestResponse {
             self.make_request(
-                test::TestRequest::post()
+                TestRequest::post()
                     .append_header(("content-type", "application/graphql"))
                     .set_payload(body.to_string())
                     .uri(url),


### PR DESCRIPTION
This PR updates `actix-web` and related crates betas and fixes conflict on [`#[test]` macro](https://github.com/actix/actix-web/blob/master/CHANGES.md#added-1). 