### PR TITLE
Update book links to fix 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 [iron_examples]: https://github.com/graphql-rust/juniper/tree/master/juniper_iron/examples
 [hyper]: https://hyper.rs
 [rocket]: https://rocket.rs
-[book]: https://graphql-rust.github.io/juniper/current
+[book]: https://graphql-rust.github.io
 [book_master]: https://graphql-rust.github.io/juniper/master
-[book_index]: https://graphql-rust.github.io/juniper
-[book_quickstart]: https://graphql-rust.github.io/juniper/current/quickstart.html
+[book_index]: https://graphql-rust.github.io
+[book_quickstart]: https://graphql-rust.github.io/quickstart.html
 [docsrs]: https://docs.rs/juniper
 [warp]: https://github.com/seanmonstar/warp
 [warp_examples]: https://github.com/graphql-rust/juniper/tree/master/juniper_warp/examples


### PR DESCRIPTION
A few of the book links were 404'ing and this PR updates them. Please let me know if the updates I have made are not intended.