### PR TITLE
Fix `juniper_codegen_tests`

### DIFF
--- a/integration_tests/codegen_fail/fail/enum/derive_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/enum/derive_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL enum expects at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Enums
-
  --> fail/enum/derive_no_fields.rs:2:1
   |
 2 | pub enum Test {}
-  | ^^^
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Enums

--- a/integration_tests/codegen_fail/fail/input-object/derive_incompatible_object.stderr
+++ b/integration_tests/codegen_fail/fail/input-object/derive_incompatible_object.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `ObjectA: IsInputType<__S>` is not satisfied
-   --> fail/input-object/derive_incompatible_object.rs:6:10
-    |
-6   | #[derive(juniper::GraphQLInputObject)]
-    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjectA`
-    |
-note: required by `juniper::marker::IsInputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the derive macro `juniper::GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/input-object/derive_incompatible_object.rs:6:10
+  |
+6 | #[derive(juniper::GraphQLInputObject)]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjectA`
+  |
+  = note: this error originates in the derive macro `juniper::GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
+    --> fail/input-object/derive_incompatible_object.rs:6:10
+     |
+6    | #[derive(juniper::GraphQLInputObject)]
+     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjectA`
+     |
+note: required by a bound in `Registry::<'r, S>::arg`
+    --> $WORKSPACE/juniper/src/executor/mod.rs
+     |
+     |         T: GraphQLType<S> + FromInputValue<S>,
+     |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<'r, S>::arg`
+     = note: this error originates in the derive macro `juniper::GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
  --> fail/input-object/derive_incompatible_object.rs:6:10
@@ -18,19 +26,6 @@ error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjectA`
   |
   = note: this error originates in the derive macro `juniper::GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
-   --> fail/input-object/derive_incompatible_object.rs:6:10
-    |
-6   | #[derive(juniper::GraphQLInputObject)]
-    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjectA`
-    |
-note: required by `from_input_value`
-   --> $WORKSPACE/juniper/src/ast.rs
-    |
-    |     fn from_input_value(v: &InputValue<S>) -> Result<Self, Self::Error>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: this error originates in the derive macro `juniper::GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `to_input_value` found for struct `ObjectA` in the current scope
  --> fail/input-object/derive_incompatible_object.rs:6:10

--- a/integration_tests/codegen_fail/fail/input-object/derive_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/input-object/derive_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL input object expects at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Input-Objects
-
  --> fail/input-object/derive_no_fields.rs:2:1
   |
 2 | struct Object {}
-  | ^^^^^^
+  | ^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Input-Objects

--- a/integration_tests/codegen_fail/fail/input-object/derive_no_underscore.stderr
+++ b/integration_tests/codegen_fail/fail/input-object/derive_no_underscore.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/input-object/derive_no_underscore.rs:3:15
   |
 3 |     #[graphql(name = "__test")]
   |               ^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/input-object/derive_unique_name.stderr
+++ b/integration_tests/codegen_fail/fail/input-object/derive_unique_name.stderr
@@ -1,9 +1,9 @@
 error: GraphQL input object does not allow fields with the same name
-
-  = help: There is at least one other field with the same name `test`, possibly renamed via the #[graphql] attribute
-  = note: https://spec.graphql.org/June2018/#sec-Input-Objects
-
  --> fail/input-object/derive_unique_name.rs:4:5
   |
-4 |     #[graphql(name = "test")]
-  |     ^
+4 | /     #[graphql(name = "test")]
+5 | |     test2: String,
+  | |_________________^
+  |
+  = help: There is at least one other field with the same name `test`, possibly renamed via the #[graphql] attribute
+  = note: https://spec.graphql.org/June2018/#sec-Input-Objects

--- a/integration_tests/codegen_fail/fail/interface/argument_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/interface/argument_double_underscored.stderr
@@ -1,20 +1,19 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
-  --> $DIR/argument_double_underscored.rs:14:18
+  --> fail/interface/argument_double_underscored.rs:14:18
    |
 14 |     fn id(&self, __num: i32) -> &str {
    |                  ^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Schema
 
 error[E0412]: cannot find type `CharacterValue` in this scope
- --> $DIR/argument_double_underscored.rs:4:18
+ --> fail/interface/argument_double_underscored.rs:4:18
   |
 4 | #[graphql(impl = CharacterValue)]
   |                  ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `Character` in this scope
-  --> $DIR/argument_double_underscored.rs:10:6
+  --> fail/interface/argument_double_underscored.rs:10:6
    |
 10 | impl Character for ObjA {}
    |      ^^^^^^^^^ not found in this scope

--- a/integration_tests/codegen_fail/fail/interface/argument_non_input_type.stderr
+++ b/integration_tests/codegen_fail/fail/interface/argument_non_input_type.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
-   --> fail/interface/argument_non_input_type.rs:16:1
-    |
-16  | #[graphql_interface(for = ObjA)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
-    |
-note: required by `juniper::marker::IsInputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/interface/argument_non_input_type.rs:16:1
+   |
+16 | #[graphql_interface(for = ObjA)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
+   |
+   = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
+    --> fail/interface/argument_non_input_type.rs:16:1
+     |
+16   | #[graphql_interface(for = ObjA)]
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjA`
+     |
+note: required by a bound in `Registry::<'r, S>::arg`
+    --> $WORKSPACE/juniper/src/executor/mod.rs
+     |
+     |         T: GraphQLType<S> + FromInputValue<S>,
+     |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<'r, S>::arg`
+     = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
   --> fail/interface/argument_non_input_type.rs:16:1

--- a/integration_tests/codegen_fail/fail/interface/argument_wrong_default_array.stderr
+++ b/integration_tests/codegen_fail/fail/interface/argument_wrong_default_array.stderr
@@ -1,12 +1,11 @@
 error[E0277]: the trait bound `[bool; 2]: From<[bool; 3]>` is not satisfied
-  --> $DIR/argument_wrong_default_array.rs:12:1
+  --> fail/interface/argument_wrong_default_array.rs:12:1
    |
 12 | #[graphql_interface(for = ObjA)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<[bool; 3]>` is not implemented for `[bool; 2]`
    |
    = help: the following implementations were found:
-             <&'a [ascii::ascii_char::AsciiChar] as From<&'a ascii::ascii_str::AsciiStr>>
-             <&'a [u8] as From<&'a ascii::ascii_str::AsciiStr>>
-             <&'a mut [ascii::ascii_char::AsciiChar] as From<&'a mut ascii::ascii_str::AsciiStr>>
+             <[T; LANES] as From<Simd<T, LANES>>>
+             <[bool; LANES] as From<Mask<T, LANES>>>
    = note: required because of the requirements on the impl of `Into<[bool; 2]>` for `[bool; 3]`
    = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/interface/downcast_method_conflicts_with_external_downcast_fn.stderr
+++ b/integration_tests/codegen_fail/fail/interface/downcast_method_conflicts_with_external_downcast_fn.stderr
@@ -1,21 +1,20 @@
 error: GraphQL interface trait method `as_obja` conflicts with the external downcast function `downcast_obja` declared on the trait to downcast into the implementer type `ObjA`
-
-  = note: https://spec.graphql.org/June2018/#sec-Interfaces
-  = note: use `#[graphql(ignore)]` attribute argument to ignore this trait method for interface implementers downcasting
-
-  --> $DIR/downcast_method_conflicts_with_external_downcast_fn.rs:26:5
+  --> fail/interface/downcast_method_conflicts_with_external_downcast_fn.rs:26:5
    |
 26 |     fn as_obja(&self) -> Option<&ObjA>;
-   |     ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Interfaces
+   = note: use `#[graphql(ignore)]` attribute argument to ignore this trait method for interface implementers downcasting
 
 error[E0412]: cannot find type `CharacterValue` in this scope
- --> $DIR/downcast_method_conflicts_with_external_downcast_fn.rs:4:18
+ --> fail/interface/downcast_method_conflicts_with_external_downcast_fn.rs:4:18
   |
 4 | #[graphql(impl = CharacterValue)]
   |                  ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `Character` in this scope
-  --> $DIR/downcast_method_conflicts_with_external_downcast_fn.rs:10:6
+  --> fail/interface/downcast_method_conflicts_with_external_downcast_fn.rs:10:6
    |
 10 | impl Character for ObjA {
    |      ^^^^^^^^^ not found in this scope

--- a/integration_tests/codegen_fail/fail/interface/downcast_method_wrong_input_args.stderr
+++ b/integration_tests/codegen_fail/fail/interface/downcast_method_wrong_input_args.stderr
@@ -1,20 +1,19 @@
 error: GraphQL interface expects trait method to accept `&self` only and, optionally, `&Context`
-
-  = note: https://spec.graphql.org/June2018/#sec-Interfaces
-
-  --> $DIR/downcast_method_wrong_input_args.rs:10:10
+  --> fail/interface/downcast_method_wrong_input_args.rs:10:10
    |
 10 |     fn a(&self, ctx: &(), rand: u8) -> Option<&Human> {
-   |          ^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Interfaces
 
 error[E0412]: cannot find type `CharacterValue` in this scope
-  --> $DIR/downcast_method_wrong_input_args.rs:16:18
+  --> fail/interface/downcast_method_wrong_input_args.rs:16:18
    |
 16 | #[graphql(impl = CharacterValue)]
    |                  ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `Character` in this scope
-  --> $DIR/downcast_method_wrong_input_args.rs:22:6
+  --> fail/interface/downcast_method_wrong_input_args.rs:22:6
    |
 22 | impl Character for Human {}
    |      ^^^^^^^^^ not found in this scope

--- a/integration_tests/codegen_fail/fail/interface/downcast_method_wrong_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/interface/downcast_method_wrong_return_type.stderr
@@ -1,11 +1,10 @@
 error: GraphQL interface expects trait method return type to be `Option<&ImplementerType>` only
-
-  = note: https://spec.graphql.org/June2018/#sec-Interfaces
-
   --> fail/interface/downcast_method_wrong_return_type.rs:10:40
    |
 10 |     fn a(&self, ctx: &(), rand: u8) -> &Human {
-   |                                        ^
+   |                                        ^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Interfaces
 
 error[E0412]: cannot find type `CharacterValue` in this scope
   --> fail/interface/downcast_method_wrong_return_type.rs:16:18

--- a/integration_tests/codegen_fail/fail/interface/field_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/interface/field_double_underscored.stderr
@@ -1,11 +1,10 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
   --> fail/interface/field_double_underscored.rs:14:8
    |
 14 |     fn __id(&self) -> &str {
    |        ^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Schema
 
 error[E0412]: cannot find type `CharacterValue` in this scope
  --> fail/interface/field_double_underscored.rs:4:18

--- a/integration_tests/codegen_fail/fail/interface/field_non_output_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/interface/field_non_output_return_type.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `ObjB: IsOutputType<__S>` is not satisfied
-   --> fail/interface/field_non_output_return_type.rs:17:1
-    |
-17  | #[graphql_interface(for = ObjA)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
-    |
-note: required by `juniper::marker::IsOutputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/interface/field_non_output_return_type.rs:17:1
+   |
+17 | #[graphql_interface(for = ObjA)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
+   |
+   = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/interface/fields_duplicate.stderr
+++ b/integration_tests/codegen_fail/fail/interface/fields_duplicate.stderr
@@ -1,11 +1,16 @@
 error: GraphQL interface must have a different name for each field
-
-  = note: https://spec.graphql.org/June2018/#sec-Interfaces
-
   --> fail/interface/fields_duplicate.rs:13:1
    |
-13 | trait Character {
-   | ^^^^^
+13 | / trait Character {
+14 | |     fn id(&self) -> &str {
+15 | |         "funA"
+16 | |     }
+...  |
+21 | |     }
+22 | | }
+   | |_^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Interfaces
 
 error[E0412]: cannot find type `CharacterValue` in this scope
  --> fail/interface/fields_duplicate.rs:4:18

--- a/integration_tests/codegen_fail/fail/interface/implementer_non_object_type.stderr
+++ b/integration_tests/codegen_fail/fail/interface/implementer_non_object_type.stderr
@@ -4,22 +4,12 @@ error[E0277]: the trait bound `ObjA: GraphQLObject<__S>` is not satisfied
 15 | #[graphql_interface(for = ObjA)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `ObjA`
    |
-note: required by `juniper::GraphQLObject::mark`
-  --> $WORKSPACE/juniper/src/types/marker.rs
-   |
-   |     fn mark() {}
-   |     ^^^^^^^^^
    = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ObjA: IsOutputType<__S>` is not satisfied
-   --> fail/interface/implementer_non_object_type.rs:15:1
-    |
-15  | #[graphql_interface(for = ObjA)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjA`
-    |
-note: required by `juniper::marker::IsOutputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/interface/implementer_non_object_type.rs:15:1
+   |
+15 | #[graphql_interface(for = ObjA)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjA`
+   |
+   = note: this error originates in the attribute macro `graphql_interface` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/interface/name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/interface/name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
- --> $DIR/name_double_underscored.rs:4:7
+ --> fail/interface/name_double_underscored.rs:4:7
   |
 4 | trait __Character {
   |       ^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/interface/no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/interface/no_fields.stderr
@@ -1,20 +1,19 @@
 error: GraphQL interface must have at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Interfaces
-
-  --> $DIR/no_fields.rs:13:1
+  --> fail/interface/no_fields.rs:13:1
    |
 13 | trait Character {}
-   | ^^^^^
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Interfaces
 
 error[E0412]: cannot find type `CharacterValue` in this scope
- --> $DIR/no_fields.rs:4:18
+ --> fail/interface/no_fields.rs:4:18
   |
 4 | #[graphql(impl = CharacterValue)]
   |                  ^^^^^^^^^^^^^^ not found in this scope
 
 error[E0405]: cannot find trait `Character` in this scope
-  --> $DIR/no_fields.rs:10:6
+  --> fail/interface/no_fields.rs:10:6
    |
 10 | impl Character for ObjA {}
    |      ^^^^^^^^^ not found in this scope

--- a/integration_tests/codegen_fail/fail/object/argument_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/object/argument_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/object/argument_double_underscored.rs:7:18
   |
 7 |     fn id(&self, __num: i32) -> &str {
   |                  ^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/object/argument_non_input_type.stderr
+++ b/integration_tests/codegen_fail/fail/object/argument_non_input_type.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
-   --> fail/object/argument_non_input_type.rs:10:1
-    |
-10  | #[graphql_object]
-    | ^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
-    |
-note: required by `juniper::marker::IsInputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/object/argument_non_input_type.rs:10:1
+   |
+10 | #[graphql_object]
+   | ^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
+   |
+   = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
+    --> fail/object/argument_non_input_type.rs:10:1
+     |
+10   | #[graphql_object]
+     | ^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjA`
+     |
+note: required by a bound in `Registry::<'r, S>::arg`
+    --> $WORKSPACE/juniper/src/executor/mod.rs
+     |
+     |         T: GraphQLType<S> + FromInputValue<S>,
+     |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<'r, S>::arg`
+     = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
   --> fail/object/argument_non_input_type.rs:10:1

--- a/integration_tests/codegen_fail/fail/object/argument_wrong_default_array.stderr
+++ b/integration_tests/codegen_fail/fail/object/argument_wrong_default_array.stderr
@@ -1,12 +1,11 @@
 error[E0277]: the trait bound `[bool; 2]: From<[bool; 3]>` is not satisfied
- --> $DIR/argument_wrong_default_array.rs:5:1
+ --> fail/object/argument_wrong_default_array.rs:5:1
   |
 5 | #[graphql_object]
   | ^^^^^^^^^^^^^^^^^ the trait `From<[bool; 3]>` is not implemented for `[bool; 2]`
   |
   = help: the following implementations were found:
-            <&'a [ascii::ascii_char::AsciiChar] as From<&'a ascii::ascii_str::AsciiStr>>
-            <&'a [u8] as From<&'a ascii::ascii_str::AsciiStr>>
-            <&'a mut [ascii::ascii_char::AsciiChar] as From<&'a mut ascii::ascii_str::AsciiStr>>
+            <[T; LANES] as From<Simd<T, LANES>>>
+            <[bool; LANES] as From<Mask<T, LANES>>>
   = note: required because of the requirements on the impl of `Into<[bool; 2]>` for `[bool; 3]`
   = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/object/attr_field_non_output_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/object/attr_field_non_output_return_type.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `ObjB: IsOutputType<__S>` is not satisfied
-   --> fail/object/attr_field_non_output_return_type.rs:10:1
-    |
-10  | #[graphql_object]
-    | ^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
-    |
-note: required by `juniper::marker::IsOutputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/object/attr_field_non_output_return_type.rs:10:1
+   |
+10 | #[graphql_object]
+   | ^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
+   |
+   = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/object/attr_fields_duplicate.stderr
+++ b/integration_tests/codegen_fail/fail/object/attr_fields_duplicate.stderr
@@ -1,8 +1,7 @@
 error: GraphQL object must have a different name for each field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
  --> fail/object/attr_fields_duplicate.rs:6:6
   |
 6 | impl ObjA {
   |      ^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/object/attr_name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/object/attr_name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/object/attr_name_double_underscored.rs:6:6
   |
 6 | impl __Obj {
   |      ^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/object/attr_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/object/attr_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL object must have at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
  --> fail/object/attr_no_fields.rs:6:6
   |
 6 | impl Obj {}
   |      ^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/object/derive_field_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_field_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/object/derive_field_double_underscored.rs:5:5
   |
 5 |     __test: String,
   |     ^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/object/derive_field_non_output_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_field_non_output_return_type.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `ObjB: IsOutputType<__S>` is not satisfied
-   --> fail/object/derive_field_non_output_return_type.rs:8:10
-    |
-8   | #[derive(GraphQLObject)]
-    |          ^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
-    |
-note: required by `juniper::marker::IsOutputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the derive macro `GraphQLObject` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/object/derive_field_non_output_return_type.rs:8:10
+  |
+8 | #[derive(GraphQLObject)]
+  |          ^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
+  |
+  = note: this error originates in the derive macro `GraphQLObject` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/object/derive_fields_duplicate.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_fields_duplicate.stderr
@@ -1,8 +1,11 @@
 error: GraphQL object must have a different name for each field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
  --> fail/object/derive_fields_duplicate.rs:4:1
   |
-4 | struct ObjA {
-  | ^^^^^^
+4 | / struct ObjA {
+5 | |     id: String,
+6 | |     #[graphql(name = "id")]
+7 | |     id2: String,
+8 | | }
+  | |_^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/object/derive_name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/object/derive_name_double_underscored.rs:4:8
   |
 4 | struct __Obj {
   |        ^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/object/derive_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL object must have at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
  --> fail/object/derive_no_fields.rs:4:1
   |
 4 | struct Obj {}
-  | ^^^^^^
+  | ^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/object/derive_wrong_item.stderr
+++ b/integration_tests/codegen_fail/fail/object/derive_wrong_item.stderr
@@ -2,4 +2,4 @@ error: GraphQL object can only be derived for structs
  --> fail/object/derive_wrong_item.rs:4:1
   |
 4 | enum Character {}
-  | ^^^^
+  | ^^^^^^^^^^^^^^^^^

--- a/integration_tests/codegen_fail/fail/scalar/impl_invalid_url.stderr
+++ b/integration_tests/codegen_fail/fail/scalar/impl_invalid_url.stderr
@@ -1,5 +1,5 @@
 error: Invalid URL: relative URL without a base
- --> fail/scalar/impl_invalid_url.rs:5:22
+ --> fail/scalar/impl_invalid_url.rs:5:18
   |
 5 | #[graphql_scalar(specified_by_url = "not an url")]
   |                  ^^^^^^^^^^^^^^^^

--- a/integration_tests/codegen_fail/fail/subscription/argument_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/argument_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
   --> fail/subscription/argument_double_underscored.rs:11:24
    |
 11 |     async fn id(&self, __num: i32) -> Stream<'static, &'static str> {
    |                        ^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/subscription/argument_non_input_type.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/argument_non_input_type.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
-   --> fail/subscription/argument_non_input_type.rs:15:1
-    |
-15  | #[graphql_subscription]
-    | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
-    |
-note: required by `juniper::marker::IsInputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/subscription/argument_non_input_type.rs:15:1
+   |
+15 | #[graphql_subscription]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsInputType<__S>` is not implemented for `ObjA`
+   |
+   = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
+    --> fail/subscription/argument_non_input_type.rs:15:1
+     |
+15   | #[graphql_subscription]
+     | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `FromInputValue<__S>` is not implemented for `ObjA`
+     |
+note: required by a bound in `Registry::<'r, S>::arg`
+    --> $WORKSPACE/juniper/src/executor/mod.rs
+     |
+     |         T: GraphQLType<S> + FromInputValue<S>,
+     |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<'r, S>::arg`
+     = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
   --> fail/subscription/argument_non_input_type.rs:15:1

--- a/integration_tests/codegen_fail/fail/subscription/argument_wrong_default_array.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/argument_wrong_default_array.stderr
@@ -1,12 +1,11 @@
 error[E0277]: the trait bound `[bool; 2]: From<[bool; 3]>` is not satisfied
-  --> $DIR/argument_wrong_default_array.rs:10:1
+  --> fail/subscription/argument_wrong_default_array.rs:10:1
    |
 10 | #[graphql_subscription]
    | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<[bool; 3]>` is not implemented for `[bool; 2]`
    |
    = help: the following implementations were found:
-             <&'a [ascii::ascii_char::AsciiChar] as From<&'a ascii::ascii_str::AsciiStr>>
-             <&'a [u8] as From<&'a ascii::ascii_str::AsciiStr>>
-             <&'a mut [ascii::ascii_char::AsciiChar] as From<&'a mut ascii::ascii_str::AsciiStr>>
+             <[T; LANES] as From<Simd<T, LANES>>>
+             <[bool; LANES] as From<Mask<T, LANES>>>
    = note: required because of the requirements on the impl of `Into<[bool; 2]>` for `[bool; 3]`
    = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/subscription/field_non_output_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/field_non_output_return_type.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `ObjB: IsOutputType<__S>` is not satisfied
-   --> fail/subscription/field_non_output_return_type.rs:15:1
-    |
-15  | #[graphql_subscription]
-    | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
-    |
-note: required by `juniper::marker::IsOutputType::mark`
-   --> $WORKSPACE/juniper/src/types/marker.rs
-    |
-    |     fn mark() {}
-    |     ^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> fail/subscription/field_non_output_return_type.rs:15:1
+   |
+15 | #[graphql_subscription]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `IsOutputType<__S>` is not implemented for `ObjB`
+   |
+   = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/subscription/field_not_async.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/field_not_async.stderr
@@ -1,9 +1,8 @@
 error: GraphQL object synchronous resolvers are not supported
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-  = note: Specify that this function is async: `async fn foo()`
-
   --> fail/subscription/field_not_async.rs:11:5
    |
 11 |     fn id(&self) -> Stream<'static, bool> {
-   |     ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Objects
+   = note: Specify that this function is async: `async fn foo()`

--- a/integration_tests/codegen_fail/fail/subscription/fields_duplicate.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/fields_duplicate.stderr
@@ -1,8 +1,7 @@
 error: GraphQL object must have a different name for each field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
   --> fail/subscription/fields_duplicate.rs:10:6
    |
 10 | impl ObjA {
    |      ^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/subscription/name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
   --> fail/subscription/name_double_underscored.rs:10:6
    |
 10 | impl __Obj {
    |      ^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/subscription/no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/subscription/no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL object must have at least one field
-
-  = note: https://spec.graphql.org/June2018/#sec-Objects
-
  --> fail/subscription/no_fields.rs:6:6
   |
 6 | impl Obj {}
   |      ^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Objects

--- a/integration_tests/codegen_fail/fail/union/derive_wrong_item.stderr
+++ b/integration_tests/codegen_fail/fail/union/derive_wrong_item.stderr
@@ -2,4 +2,4 @@ error: GraphQL union can only be derived for enums and structs
  --> fail/union/derive_wrong_item.rs:4:1
   |
 4 | union Character { id: i32 }
-  | ^^^^^
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/integration_tests/codegen_fail/fail/union/enum_external_resolver_fn_conflicts_with_variant_external_resolver_fn.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_external_resolver_fn_conflicts_with_variant_external_resolver_fn.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union variant `Human` already has external resolver function `resolve_fn1` declared on the enum
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/enum_external_resolver_fn_conflicts_with_variant_external_resolver_fn.rs:6:15
   |
 6 |     #[graphql(with = resolve_fn2)]
   |               ^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/enum_name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/union/enum_name_double_underscored.rs:4:6
   |
 4 | enum __Character {
   |      ^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/union/enum_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union expects at least one union variant
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/enum_no_fields.rs:4:1
   |
 4 | enum Character {}
-  | ^^^^
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/enum_non_object_variant.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_non_object_variant.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `Test: GraphQLObject<__S>` is not satisfied
-  --> fail/union/enum_non_object_variant.rs:9:10
-   |
-9  | #[derive(GraphQLUnion)]
-   |          ^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
-   |
-note: required by `juniper::GraphQLObject::mark`
-  --> $WORKSPACE/juniper/src/types/marker.rs
-   |
-   |     fn mark() {}
-   |     ^^^^^^^^^
-   = note: this error originates in the derive macro `GraphQLUnion` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/union/enum_non_object_variant.rs:9:10
+  |
+9 | #[derive(GraphQLUnion)]
+  |          ^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
+  |
+  = note: this error originates in the derive macro `GraphQLUnion` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/union/enum_same_type_pretty.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_same_type_pretty.stderr
@@ -1,8 +1,10 @@
 error: GraphQL union must have a different type for each union variant
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/enum_same_type_pretty.rs:4:1
   |
-4 | enum Character {
-  | ^^^^
+4 | / enum Character {
+5 | |     A(u8),
+6 | |     B(u8),
+7 | | }
+  | |_^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/enum_wrong_variant_field.stderr
+++ b/integration_tests/codegen_fail/fail/union/enum_wrong_variant_field.stderr
@@ -1,17 +1,15 @@
 error: GraphQL union enum allows only unnamed variants with a single field, e.g. `Some(T)`
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/enum_wrong_variant_field.rs:5:5
   |
 5 |     A { human: Human },
   |     ^
-
-error: GraphQL union enum allows only unnamed variants with a single field, e.g. `Some(T)`
-
+  |
   = note: https://spec.graphql.org/June2018/#sec-Unions
 
+error: GraphQL union enum allows only unnamed variants with a single field, e.g. `Some(T)`
   --> fail/union/enum_wrong_variant_field.rs:10:6
    |
 10 |     A(Human, u8),
    |      ^^^^^^^^^^^
+   |
+   = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/struct_name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/union/struct_name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/union/struct_name_double_underscored.rs:5:8
   |
 5 | struct __Character;
   |        ^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/union/struct_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/union/struct_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union expects at least one union variant
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/struct_no_fields.rs:4:1
   |
 4 | struct Character;
-  | ^^^^^^
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/struct_non_object_variant.stderr
+++ b/integration_tests/codegen_fail/fail/union/struct_non_object_variant.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `Test: GraphQLObject<__S>` is not satisfied
-  --> fail/union/struct_non_object_variant.rs:9:10
-   |
-9  | #[derive(GraphQLUnion)]
-   |          ^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
-   |
-note: required by `juniper::GraphQLObject::mark`
-  --> $WORKSPACE/juniper/src/types/marker.rs
-   |
-   |     fn mark() {}
-   |     ^^^^^^^^^
-   = note: this error originates in the derive macro `GraphQLUnion` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/union/struct_non_object_variant.rs:9:10
+  |
+9 | #[derive(GraphQLUnion)]
+  |          ^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
+  |
+  = note: this error originates in the derive macro `GraphQLUnion` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/union/trait_fail_infer_context.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_fail_infer_context.stderr
@@ -1,20 +1,10 @@
 error[E0277]: the trait bound `CustomContext: FromContext<SubContext>` is not satisfied
-   --> fail/union/trait_fail_infer_context.rs:3:1
-    |
-3   |   #[graphql_union]
-    |   ^^^^^^^^^^^^^^^^ expected an implementor of trait `FromContext<SubContext>`
-4   |   trait Character {
-    |  _______-
-5   | |     fn a(&self, ctx: &SubContext) -> Option<&Human>;
-6   | |     fn b(&self, ctx: &CustomContext) -> Option<&Droid>;
-    | |________- required by a bound introduced by this call
-    |
-note: required by `juniper::FromContext::from`
-   --> $WORKSPACE/juniper/src/executor/mod.rs
-    |
-    |     fn from(value: &T) -> &Self;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: this error originates in the attribute macro `graphql_union` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/union/trait_fail_infer_context.rs:3:1
+  |
+3 | #[graphql_union]
+  | ^^^^^^^^^^^^^^^^ the trait `FromContext<SubContext>` is not implemented for `CustomContext`
+  |
+  = note: this error originates in the attribute macro `graphql_union` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
  --> fail/union/trait_fail_infer_context.rs:3:1

--- a/integration_tests/codegen_fail/fail/union/trait_method_conflicts_with_external_resolver_fn.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_method_conflicts_with_external_resolver_fn.stderr
@@ -1,9 +1,8 @@
 error: GraphQL union trait method `a` conflicts with the external resolver function `some_fn` declared on the trait to resolve the variant type `Human`
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-  = note: use `#[graphql(ignore)]` attribute to ignore this trait method for union variants resolution
-
  --> fail/union/trait_method_conflicts_with_external_resolver_fn.rs:5:5
   |
 5 |     fn a(&self) -> Option<&Human>;
-  |     ^^
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions
+  = note: use `#[graphql(ignore)]` attribute to ignore this trait method for union variants resolution

--- a/integration_tests/codegen_fail/fail/union/trait_name_double_underscored.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_name_double_underscored.stderr
@@ -1,8 +1,7 @@
 error: All types and directives defined within a schema must not have a name which begins with `__` (two underscores), as this is used exclusively by GraphQL’s introspection system.
-
-  = note: https://spec.graphql.org/June2018/#sec-Schema
-
  --> fail/union/trait_name_double_underscored.rs:4:7
   |
 4 | trait __Character {
   |       ^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Schema

--- a/integration_tests/codegen_fail/fail/union/trait_no_fields.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_no_fields.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union expects at least one union variant
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/trait_no_fields.rs:4:1
   |
 4 | trait Character {}
-  | ^^^^^
+  | ^^^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/trait_non_object_variant.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_non_object_variant.stderr
@@ -1,12 +1,7 @@
 error[E0277]: the trait bound `Test: GraphQLObject<__S>` is not satisfied
-  --> fail/union/trait_non_object_variant.rs:9:1
-   |
-9  | #[graphql_union]
-   | ^^^^^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
-   |
-note: required by `juniper::GraphQLObject::mark`
-  --> $WORKSPACE/juniper/src/types/marker.rs
-   |
-   |     fn mark() {}
-   |     ^^^^^^^^^
-   = note: this error originates in the attribute macro `graphql_union` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> fail/union/trait_non_object_variant.rs:9:1
+  |
+9 | #[graphql_union]
+  | ^^^^^^^^^^^^^^^^ the trait `GraphQLObject<__S>` is not implemented for `Test`
+  |
+  = note: this error originates in the attribute macro `graphql_union` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/integration_tests/codegen_fail/fail/union/trait_same_type_pretty.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_same_type_pretty.stderr
@@ -1,8 +1,10 @@
 error: GraphQL union must have a different type for each union variant
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/trait_same_type_pretty.rs:4:1
   |
-4 | trait Character {
-  | ^^^^^
+4 | / trait Character {
+5 | |     fn a(&self) -> Option<&u8>;
+6 | |     fn b(&self) -> Option<&u8>;
+7 | | }
+  | |_^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/trait_with_attr_on_method.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_with_attr_on_method.stderr
@@ -1,9 +1,8 @@
 error: GraphQL union cannot use #[graphql(with = ...)] attribute on a trait method
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-  = note: instead use #[graphql(ignore)] on the method with #[graphql_union(on ... = ...)] on the trait itself
-
  --> fail/union/trait_with_attr_on_method.rs:5:15
   |
 5 |     #[graphql(with = something)]
   |               ^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions
+  = note: instead use #[graphql(ignore)] on the method with #[graphql_union(on ... = ...)] on the trait itself

--- a/integration_tests/codegen_fail/fail/union/trait_wrong_method_input_args.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_wrong_method_input_args.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union expects trait method to accept `&self` only and, optionally, `&Context`
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/trait_wrong_method_input_args.rs:5:10
   |
 5 |     fn a(&self, ctx: &(), rand: u8) -> Option<&Human>;
-  |          ^
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions

--- a/integration_tests/codegen_fail/fail/union/trait_wrong_method_return_type.stderr
+++ b/integration_tests/codegen_fail/fail/union/trait_wrong_method_return_type.stderr
@@ -1,8 +1,7 @@
 error: GraphQL union expects trait method return type to be `Option<&VariantType>` only
-
-  = note: https://spec.graphql.org/June2018/#sec-Unions
-
  --> fail/union/trait_wrong_method_return_type.rs:5:20
   |
 5 |     fn a(&self) -> &Human;
-  |                    ^
+  |                    ^^^^^^
+  |
+  = note: https://spec.graphql.org/June2018/#sec-Unions


### PR DESCRIPTION
## Synopsis

For now `juniper_codegen_tests` fails on latest nightly




## Solution

Fix those assertions. 




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
