### PR TITLE
Update versions referenced in server integration docs

### DIFF
--- a/docs/book/content/servers/hyper.md
+++ b/docs/book/content/servers/hyper.md
@@ -16,8 +16,8 @@ Juniper's Hyper integration is contained in the [`juniper_hyper`][juniper_hyper]
 
 ```toml
 [dependencies]
-juniper = "0.10"
-juniper_hyper = "0.1.0"
+juniper = "0.15.7"
+juniper_hyper = "0.8.0"
 ```
 
 Included in the source is a [small example][example] which sets up a basic GraphQL and [GraphiQL] handler.

--- a/docs/book/content/servers/iron.md
+++ b/docs/book/content/servers/iron.md
@@ -11,8 +11,8 @@ Juniper's Iron integration is contained in the `juniper_iron` crate:
 
 ```toml
 [dependencies]
-juniper = "0.10"
-juniper_iron = "0.2.0"
+juniper = "0.15.7"
+juniper_iron = "0.7.4"
 ```
 
 Included in the source is a [small

--- a/docs/book/content/servers/rocket.md
+++ b/docs/book/content/servers/rocket.md
@@ -10,8 +10,8 @@ Juniper's Rocket integration is contained in the [`juniper_rocket`][juniper_rock
 
 ```toml
 [dependencies]
-juniper = "0.10"
-juniper_rocket = "0.2.0"
+juniper = "0.15.7"
+juniper_rocket = "0.8.0"
 ```
 
 Included in the source is a [small example][example] which sets up a basic GraphQL and [GraphiQL] handler.

--- a/docs/book/content/servers/warp.md
+++ b/docs/book/content/servers/warp.md
@@ -10,8 +10,8 @@ Juniper's Warp integration is contained in the [`juniper_warp`][juniper_warp] cr
 
 ```toml
 [dependencies]
-juniper = "0.10"
-juniper_warp = "0.1.0"
+juniper = "0.15.7"
+juniper_warp = "0.7.0"
 ```
 
 Included in the source is a [small example][example] which sets up a basic GraphQL and [GraphiQL] handler.


### PR DESCRIPTION
Simple update to latest versions of `juniper` and `juniper_$SERVER` versions referenced in the server integration docs, as current versions are stale.