### PR TITLE
Fixed docs/book build (missing #)

### DIFF
--- a/docs/book/content/SUMMARY.md
+++ b/docs/book/content/SUMMARY.md
@@ -1,3 +1,4 @@
+#
 - [Introduction](README.md)
 - [Quickstart](quickstart.md)
 


### PR DESCRIPTION
mdbook refused to build/serve the full contents of the book due to the missing title. It should not be required and may be a recent regression in their code, but the book builds fine after I pit that # at the top.