### PR TITLE
Add `arbitrary` support

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -26,6 +26,7 @@ default = [
     "url",
     "uuid",
 ]
+arbitrary = ["dep:arbitrary", "smartstring/arbitrary"]
 expose-test-schema = ["anyhow", "serde_json"]
 graphql-parser-integration = ["graphql-parser"]
 scalar-naivetime = []
@@ -35,6 +36,7 @@ schema-language = ["graphql-parser-integration"]
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen"  }
 
 anyhow = { version = "1.0.32", optional = true, default-features = false }
+arbitrary = { version = "1.1", optional = true, features = ["derive"] }
 async-trait = "0.1.39"
 bson = { version = "2.0", features = ["chrono-0_4"], optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -21,6 +21,7 @@ pub struct Lexer<'a> {
 ///
 /// This is only used for tagging how the lexer has interpreted a value literal
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub enum ScalarToken<'a> {
     String(&'a str),
@@ -30,6 +31,7 @@ pub enum ScalarToken<'a> {
 
 /// A single token in the input source
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub enum Token<'a> {
     Name(&'a str),

--- a/juniper/src/parser/utils.rs
+++ b/juniper/src/parser/utils.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 /// A reference to a line and column in an input source file
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SourcePosition {
     index: usize,
     line: usize,
@@ -14,6 +15,7 @@ pub struct SourcePosition {
 /// character pointed by the `start` field and ending just before the `end`
 /// marker.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Spanning<T> {
     /// The wrapped item
     pub item: T,

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -17,6 +17,7 @@ use crate::{
 
 /// Whether an item is deprecated, with context.
 #[derive(Debug, PartialEq, Hash, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum DeprecationStatus {
     /// The field/variant is not deprecated.
     Current,
@@ -54,8 +55,66 @@ pub struct ScalarMeta<'a, S> {
     pub(crate) parse_fn: for<'b> fn(ScalarToken<'b>) -> Result<S, ParseError<'b>>,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S> arbitrary::Arbitrary<'a> for ScalarMeta<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let name: Cow<'a, str> = u.arbitrary()?;
+        let description: Option<String> = u.arbitrary()?;
+        let specified_by_url: Option<Cow<'a, str>> = u.arbitrary()?;
+
+        let parsing_should_fail = *u.choose(&[true, false])?;
+
+        fn ok_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            Ok(())
+        }
+
+        fn err_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            // TODO: Make this arbitrary
+            Err(FieldError::new(
+                String::from("Arbitrary error"),
+                juniper::Value::Null,
+            ))
+        }
+
+        let try_parse_fn = if parsing_should_fail {
+            err_try_fn
+        } else {
+            ok_try_fn
+        };
+
+        fn ok_parse_fn<'a, S: arbitrary::Arbitrary<'a>>(_: ScalarToken) -> Result<S, ParseError> {
+            // TODO: Thread this through / don't hardcode.
+            let mut u = arbitrary::Unstructured::new(&[1, 2, 3, 4]);
+            Ok(S::arbitrary(&mut u).expect("arbitrary"))
+        }
+
+        fn err_parse_fn<'a, S: arbitrary::Arbitrary<'a>>(_: ScalarToken) -> Result<S, ParseError> {
+            // TODO: Make this arbitrary
+            Err(ParseError::UnexpectedEndOfFile)
+        }
+
+        let parse_fn = if parsing_should_fail {
+            err_parse_fn
+        } else {
+            ok_parse_fn
+        };
+
+        Ok(Self {
+            name,
+            description,
+            specified_by_url,
+            try_parse_fn,
+            parse_fn,
+        })
+    }
+}
+
 /// List type metadata
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ListMeta<'a> {
     #[doc(hidden)]
     pub of_type: Type<'a>,
@@ -66,6 +125,7 @@ pub struct ListMeta<'a> {
 
 /// Nullable type metadata
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NullableMeta<'a> {
     #[doc(hidden)]
     pub of_type: Type<'a>,
@@ -73,6 +133,7 @@ pub struct NullableMeta<'a> {
 
 /// Object type metadata
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ObjectMeta<'a, S> {
     #[doc(hidden)]
     pub name: Cow<'a, str>,
@@ -85,6 +146,7 @@ pub struct ObjectMeta<'a, S> {
 }
 
 /// Enum type metadata
+//#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EnumMeta<'a, S> {
     #[doc(hidden)]
     pub name: Cow<'a, str>,
@@ -95,8 +157,48 @@ pub struct EnumMeta<'a, S> {
     pub(crate) try_parse_fn: for<'b> fn(&'b InputValue<S>) -> Result<(), FieldError<S>>,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S> arbitrary::Arbitrary<'a> for EnumMeta<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let name: Cow<'a, str> = u.arbitrary()?;
+        let description: Option<String> = u.arbitrary()?;
+        let values: Vec<EnumValue> = u.arbitrary()?;
+
+        let parsing_should_fail = *u.choose(&[true, false])?;
+
+        fn ok_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            Ok(())
+        }
+
+        fn err_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            // TODO: Make this arbitrary
+            Err(FieldError::new(
+                String::from("Arbitrary error"),
+                juniper::Value::Null,
+            ))
+        }
+
+        let try_parse_fn = if parsing_should_fail {
+            err_try_fn
+        } else {
+            ok_try_fn
+        };
+
+        Ok(Self {
+            name,
+            description,
+            values,
+            try_parse_fn,
+        })
+    }
+}
+
 /// Interface type metadata
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterfaceMeta<'a, S> {
     #[doc(hidden)]
     pub name: Cow<'a, str>,
@@ -108,6 +210,7 @@ pub struct InterfaceMeta<'a, S> {
 
 /// Union type metadata
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UnionMeta<'a> {
     #[doc(hidden)]
     pub name: Cow<'a, str>,
@@ -118,6 +221,7 @@ pub struct UnionMeta<'a> {
 }
 
 /// Input object metadata
+//#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InputObjectMeta<'a, S> {
     #[doc(hidden)]
     pub name: Cow<'a, str>,
@@ -128,11 +232,51 @@ pub struct InputObjectMeta<'a, S> {
     pub(crate) try_parse_fn: for<'b> fn(&'b InputValue<S>) -> Result<(), FieldError<S>>,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S> arbitrary::Arbitrary<'a> for InputObjectMeta<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let name: Cow<'a, str> = u.arbitrary()?;
+        let description: Option<String> = u.arbitrary()?;
+        let input_fields: Vec<Argument<'a, S>> = u.arbitrary()?;
+
+        let parsing_should_fail = *u.choose(&[true, false])?;
+
+        fn ok_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            Ok(())
+        }
+
+        fn err_try_fn<S>(_: &InputValue<S>) -> Result<(), FieldError<S>> {
+            // TODO: Make this arbitrary
+            Err(FieldError::new(
+                String::from("Arbitrary error"),
+                juniper::Value::Null,
+            ))
+        }
+
+        let try_parse_fn = if parsing_should_fail {
+            err_try_fn
+        } else {
+            ok_try_fn
+        };
+
+        Ok(Self {
+            name,
+            description,
+            input_fields,
+            try_parse_fn,
+        })
+    }
+}
+
 /// A placeholder for not-yet-registered types
 ///
 /// After a type's `meta` method has been called but before it has returned, a placeholder type
 /// is inserted into a registry to indicate existence.
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PlaceholderMeta<'a> {
     #[doc(hidden)]
     pub of_type: Type<'a>,
@@ -161,8 +305,33 @@ pub enum MetaType<'a, S = DefaultScalarValue> {
     Placeholder(PlaceholderMeta<'a>),
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S> arbitrary::Arbitrary<'a> for MetaType<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let num_choices = 9;
+
+        let ty = match u.int_in_range::<u8>(1..=num_choices)? {
+            1 => MetaType::Scalar(u.arbitrary::<ScalarMeta<'a, S>>()?),
+            2 => MetaType::List(u.arbitrary::<ListMeta<'a>>()?),
+            3 => MetaType::Nullable(u.arbitrary::<NullableMeta<'a>>()?),
+            4 => MetaType::Object(u.arbitrary::<ObjectMeta<'a, S>>()?),
+            5 => MetaType::Enum(u.arbitrary::<EnumMeta<'a, S>>()?),
+            6 => MetaType::Interface(u.arbitrary::<InterfaceMeta<'a, S>>()?),
+            7 => MetaType::Union(u.arbitrary::<UnionMeta<'a>>()?),
+            8 => MetaType::InputObject(u.arbitrary::<InputObjectMeta<'a, S>>()?),
+            9 => MetaType::Placeholder(u.arbitrary::<PlaceholderMeta<'a>>()?),
+            _ => unreachable!(),
+        };
+        Ok(ty)
+    }
+}
+
 /// Metadata for a field
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Field<'a, S> {
     #[doc(hidden)]
     pub name: smartstring::alias::String,
@@ -186,6 +355,7 @@ impl<'a, S> Field<'a, S> {
 
 /// Metadata for an argument to a field
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Argument<'a, S> {
     #[doc(hidden)]
     pub name: String,
@@ -207,6 +377,7 @@ impl<'a, S> Argument<'a, S> {
 
 /// Metadata for a single value in an enum
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EnumValue {
     /// The name of the enum value
     ///

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, fmt};
 use fnv::FnvHashMap;
 #[cfg(feature = "graphql-parser-integration")]
 use graphql_parser::schema::Document;
+use graphql_parser::schema::ObjectType;
 
 use crate::{
     ast::Type,
@@ -46,6 +47,43 @@ pub struct RootNode<
     pub schema: SchemaType<'a, S>,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, QueryT, MutationT, SubscriptionT, S> arbitrary::Arbitrary<'a>
+    for RootNode<'a, QueryT, MutationT, SubscriptionT, S>
+where
+    QueryT: GraphQLType<S>,
+    MutationT: GraphQLType<S>,
+    SubscriptionT: GraphQLType<S>,
+    QueryT: arbitrary::Arbitrary<'a>,
+    <QueryT as crate::types::base::GraphQLValue<S>>::TypeInfo: arbitrary::Arbitrary<'a>,
+    MutationT: arbitrary::Arbitrary<'a>,
+    <MutationT as crate::types::base::GraphQLValue<S>>::TypeInfo: arbitrary::Arbitrary<'a>,
+    SubscriptionT: arbitrary::Arbitrary<'a>,
+    <SubscriptionT as crate::types::base::GraphQLValue<S>>::TypeInfo: arbitrary::Arbitrary<'a>,
+    S: ScalarValue,
+    S: arbitrary::Arbitrary<'a>,
+    S: 'a,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let query_type: QueryT = u.arbitrary()?;
+        let query_info: QueryT::TypeInfo = u.arbitrary()?;
+        let mutation_type: MutationT = u.arbitrary()?;
+        let mutation_info: MutationT::TypeInfo = u.arbitrary()?;
+        let subscription_type: SubscriptionT = u.arbitrary()?;
+        let subscription_info: SubscriptionT::TypeInfo = u.arbitrary()?;
+        let schema: SchemaType<'a, S> = u.arbitrary()?;
+        Ok(Self {
+            query_type,
+            query_info,
+            mutation_type,
+            mutation_info,
+            subscription_type,
+            subscription_info,
+            schema,
+        })
+    }
+}
+
 /// Metadata for a schema
 #[derive(Debug)]
 pub struct SchemaType<'a, S> {
@@ -59,6 +97,49 @@ pub struct SchemaType<'a, S> {
 
 impl<'a, S> Context for SchemaType<'a, S> {}
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S: 'a> arbitrary::Arbitrary<'a> for SchemaType<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        use std::str::FromStr;
+        let description: Option<Cow<'a, str>> = u.arbitrary()?;
+        let query_type_name: String = u.arbitrary()?;
+        let mutation_type_name: Option<String> = u.arbitrary()?;
+        let subscription_type_name: Option<String> = u.arbitrary()?;
+        let directives: FnvHashMap<String, DirectiveType<'a, S>> = u.arbitrary()?;
+
+        // Custom handling we call `expect()` in some places that depends on the data.
+        let mut types: FnvHashMap<Name, MetaType<'a, S>> = u.arbitrary()?;
+        types.insert(
+            Name::from_str(&query_type_name).map_err(|_| arbitrary::Error::IncorrectFormat)?,
+            MetaType::Object(ObjectMeta::arbitrary(u)?),
+        );
+        if let Some(ref mtn) = mutation_type_name {
+            types.insert(
+                Name::from_str(&mtn.as_str()).map_err(|_| arbitrary::Error::IncorrectFormat)?,
+                MetaType::Object(ObjectMeta::arbitrary(u)?),
+            );
+        }
+        if let Some(ref stn) = subscription_type_name {
+            types.insert(
+                Name::from_str(&stn.as_str()).map_err(|_| arbitrary::Error::IncorrectFormat)?,
+                MetaType::Object(ObjectMeta::arbitrary(u)?),
+            );
+        }
+
+        Ok(Self {
+            description,
+            types,
+            query_type_name,
+            mutation_type_name,
+            subscription_type_name,
+            directives,
+        })
+    }
+}
+
 #[derive(Clone)]
 pub enum TypeType<'a, S: 'a> {
     Concrete(&'a MetaType<'a, S>),
@@ -66,7 +147,33 @@ pub enum TypeType<'a, S: 'a> {
     List(Box<TypeType<'a, S>>, Option<usize>),
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, S: 'a> arbitrary::Arbitrary<'a> for TypeType<'a, S>
+where
+    S: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let num_choices = 2;
+
+        let ty = match u.int_in_range::<u8>(1..=num_choices)? {
+            // TODO: Arbitrary reference.
+            // 1 => {
+            //    let x = u.arbitrary::<MetaType<'a, S>>()?;
+            //    TypeType::Concrete(&x)
+            // }
+            1 | 2 => TypeType::NonNull(u.arbitrary::<Box<TypeType<'a, S>>>()?),
+            3 => TypeType::List(
+                u.arbitrary::<Box<TypeType<'a, S>>>()?,
+                u.arbitrary::<Option<usize>>()?,
+            ),
+            _ => unreachable!(),
+        };
+        Ok(ty)
+    }
+}
+
 #[derive(Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct DirectiveType<'a, S> {
     pub name: String,
     pub description: Option<String>,
@@ -76,6 +183,7 @@ pub struct DirectiveType<'a, S> {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, GraphQLEnum)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[graphql(name = "__DirectiveLocation", internal)]
 pub enum DirectiveLocation {
     Query,

--- a/juniper/src/types/name.rs
+++ b/juniper/src/types/name.rs
@@ -17,6 +17,7 @@ fn is_ascii_digit(c: char) -> bool {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Name(String);
 
 impl Name {

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -408,6 +408,16 @@ impl<T> Default for EmptyMutation<T> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T> arbitrary::Arbitrary<'a> for EmptyMutation<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(_u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(EmptyMutation::new())
+    }
+}
+
 /// Utillity type to define read-only schemas
 ///
 /// If you instantiate `RootNode` with this as the subscription,
@@ -465,6 +475,16 @@ impl<T> Default for EmptySubscription<T> {
     #[inline]
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, T> arbitrary::Arbitrary<'a> for EmptySubscription<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(_u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(EmptySubscription::new())
     }
 }
 

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -407,6 +407,7 @@ pub trait ScalarValue:
 ///
 /// [0]: https://spec.graphql.org/June2018
 #[derive(Clone, Debug, PartialEq, Serialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(untagged)]
 pub enum DefaultScalarValue {
     /// [`Int` scalar][0] as a signed 32‐bit numeric non‐fractional value.


### PR DESCRIPTION
This adds optional support for https://github.com/rust-fuzz/arbitrary/ behind
the `arbitrary` feature flag (off by default).

This will be used in a future pull request to enable fuzzing using `cargo-fuzz`