### PR TITLE
juniper_rocket: make request limit configurable

### DIFF
--- a/juniper_rocket/CHANGELOG.md
+++ b/juniper_rocket/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Compatibility with the latest `juniper`.
 - Provide `AsRef` and `AsMut` implementation for `GraphQLRequest` to its inner type ([#968](https://github.com/graphql-rust/juniper/pull/968), [#930](https://github.com/graphql-rust/juniper/issues/930)).
+- Ability to set custom request body size limit ([#1044](https://github.com/graphql-rust/juniper/pull/1044)).
 
 # [[0.8.0] 2021-07-08](https://github.com/graphql-rust/juniper/releases/tag/juniper_rocket-0.8.0)
 

--- a/juniper_rocket/src/lib.rs
+++ b/juniper_rocket/src/lib.rs
@@ -349,8 +349,9 @@ where
         };
 
         Box::pin(async move {
+            let limit = req.limits().get("graphql").unwrap_or(BODY_LIMIT.bytes());
+            let mut reader = data.open(limit);
             let mut body = String::new();
-            let mut reader = data.open(BODY_LIMIT.bytes());
             if let Err(e) = reader.read_to_string(&mut body).await {
                 return Failure((Status::InternalServerError, format!("{:?}", e)));
             }


### PR DESCRIPTION
Before, it was not possible to set a different request body size limit. Now, the configurable limit value from Rocket's `Limits` struct [1] is obtained with a fallback to the hardcoded value in case no value has been configured.

[1] https://api.rocket.rs/master/rocket/data/struct.Limits.html

I'm running into the hardcoded limit now and therefore would really appreciate if a release of juniper_rocket could be made after this has been merged.