### PR TITLE
Fix build with `default-features = false`

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -48,7 +48,7 @@ graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "1.0", features = ["serde-1"] }
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen" }
 rust_decimal = { version = "1.0", default-features = false, optional = true }
-serde = { version = "1.0.8", features = ["derive", "std"], default-features = false }
+serde = { version = "1.0.8", features = ["derive"] }
 serde_json = { version = "1.0.2", default-features = false, optional = true }
 smartstring = "1.0"
 static_assertions = "1.1"
@@ -63,6 +63,7 @@ uuid_08 = { version = "0.8", package = "uuid", default-features = false, feature
 
 [dev-dependencies]
 bencher = "0.1.2"
+chrono = { version = "0.4", features = ["alloc"], default-features = false }
 pretty_assertions = "1.0.0"
 serde_json = "1.0.2"
 tokio = { version = "1.0", features = ["macros", "time", "rt-multi-thread"] }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -48,7 +48,7 @@ graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "1.0", features = ["serde-1"] }
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen" }
 rust_decimal = { version = "1.0", default-features = false, optional = true }
-serde = { version = "1.0.8", features = ["derive"], default-features = false }
+serde = { version = "1.0.8", features = ["derive", "std"], default-features = false }
 serde_json = { version = "1.0.2", default-features = false, optional = true }
 smartstring = "1.0"
 static_assertions = "1.1"

--- a/juniper/src/integrations/bson.rs
+++ b/juniper/src/integrations/bson.rs
@@ -43,7 +43,7 @@ mod utc_date_time {
 
 #[cfg(test)]
 mod test {
-    use bson::oid::ObjectId;
+    use bson::{oid::ObjectId, DateTime as UtcDateTime};
 
     use crate::{graphql_input_value, FromInputValue, InputValue};
 
@@ -58,10 +58,8 @@ mod test {
         assert_eq!(parsed, id);
     }
 
-    #[cfg(chrono)]
-    #[cfg_attr(chrono, test)]
+    #[test]
     fn utcdatetime_from_input() {
-        use bson::DateTime as UtcDateTime;
         use chrono::{DateTime, Utc};
 
         let raw = "2020-03-23T17:38:32.446+00:00";

--- a/juniper/src/integrations/bson.rs
+++ b/juniper/src/integrations/bson.rs
@@ -43,8 +43,7 @@ mod utc_date_time {
 
 #[cfg(test)]
 mod test {
-    use bson::{oid::ObjectId, DateTime as UtcDateTime};
-    use chrono::{DateTime, Utc};
+    use bson::oid::ObjectId;
 
     use crate::{graphql_input_value, FromInputValue, InputValue};
 
@@ -59,8 +58,12 @@ mod test {
         assert_eq!(parsed, id);
     }
 
-    #[test]
+    #[cfg(chrono)]
+    #[cfg_attr(chrono, test)]
     fn utcdatetime_from_input() {
+        use bson::DateTime as UtcDateTime;
+        use chrono::{DateTime, Utc};
+
         let raw = "2020-03-23T17:38:32.446+00:00";
         let input: InputValue = graphql_input_value!((raw));
 


### PR DESCRIPTION
## Solution

- Enable `serde/std` feature flag for `juniper` crate;
- Mark `bson` integration unit tests that uses `chrono` with `#[cfg(chrono)]`.

## Checklist

- Created PR:
    - [x] In [draft mode](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests)
    - [x] Name contains `Draft:` prefix
    - [x] Name contains issue reference
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review](https://help.github.com/en/articles/reviewing-changes-in-pull-requests) is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft:` prefix is removed
    - [x] All temporary labels are removed