### PR TITLE
Implement HashSet support the same way as Vec

### DIFF
--- a/juniper/src/macros/reflect.rs
+++ b/juniper/src/macros/reflect.rs
@@ -1,6 +1,6 @@
 //! Compile-time reflection of Rust types into GraphQL types.
 
-use std::{rc::Rc, sync::Arc};
+use std::{collections::HashSet, rc::Rc, sync::Arc};
 
 use futures::future::BoxFuture;
 
@@ -72,6 +72,10 @@ impl<S, T: BaseType<S>> BaseType<S> for Vec<T> {
     const NAME: Type = T::NAME;
 }
 
+impl<S, T: BaseType<S>> BaseType<S> for HashSet<T> {
+    const NAME: Type = T::NAME;
+}
+
 impl<S, T: BaseType<S>> BaseType<S> for [T] {
     const NAME: Type = T::NAME;
 }
@@ -130,6 +134,10 @@ impl<S, T: BaseSubTypes<S>, E> BaseSubTypes<S> for Result<T, E> {
 }
 
 impl<S, T: BaseSubTypes<S>> BaseSubTypes<S> for Vec<T> {
+    const NAMES: Types = T::NAMES;
+}
+
+impl<S, T: BaseSubTypes<S>> BaseSubTypes<S> for HashSet<T> {
     const NAMES: Types = T::NAMES;
 }
 
@@ -226,6 +234,10 @@ impl<S, T: WrappedType<S>, E> WrappedType<S> for Result<T, E> {
 }
 
 impl<S, T: WrappedType<S>> WrappedType<S> for Vec<T> {
+    const VALUE: u128 = T::VALUE * 10 + 3;
+}
+
+impl<S, T: WrappedType<S>> WrappedType<S> for HashSet<T> {
     const VALUE: u128 = T::VALUE * 10 + 3;
 }
 

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     mem::{self, MaybeUninit},
     ptr,
 };
@@ -220,7 +221,7 @@ where
     }
 }
 
-impl<S, T> GraphQLType<S> for std::collections::HashSet<T>
+impl<S, T> GraphQLType<S> for HashSet<T>
 where
     T: GraphQLType<S>,
     S: ScalarValue,
@@ -237,7 +238,7 @@ where
     }
 }
 
-impl<S, T> GraphQLValue<S> for std::collections::HashSet<T>
+impl<S, T> GraphQLValue<S> for HashSet<T>
 where
     T: GraphQLValue<S>,
     S: ScalarValue,
@@ -256,6 +257,24 @@ where
         executor: &Executor<Self::Context, S>,
     ) -> ExecutionResult<S> {
         resolve_into_list(executor, info, self.iter())
+    }
+}
+
+impl<S, T> GraphQLValueAsync<S> for HashSet<T>
+where
+    T: GraphQLValueAsync<S>,
+    T::TypeInfo: Sync,
+    T::Context: Sync,
+    S: ScalarValue + Send + Sync,
+{
+    fn resolve_async<'a>(
+        &'a self,
+        info: &'a Self::TypeInfo,
+        _: Option<&'a [Selection<S>]>,
+        executor: &'a Executor<Self::Context, S>,
+    ) -> crate::BoxFuture<'a, ExecutionResult<S>> {
+        let f = resolve_into_list_async(executor, info, self.iter());
+        Box::pin(f)
     }
 }
 

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -220,6 +220,45 @@ where
     }
 }
 
+impl<S, T> GraphQLType<S> for std::collections::HashSet<T>
+where
+    T: GraphQLType<S>,
+    S: ScalarValue,
+{
+    fn name(_: &Self::TypeInfo) -> Option<&'static str> {
+        None
+    }
+
+    fn meta<'r>(info: &Self::TypeInfo, registry: &mut Registry<'r, S>) -> MetaType<'r, S>
+    where
+        S: 'r,
+    {
+        registry.build_list_type::<T>(info, None).into_meta()
+    }
+}
+
+impl<S, T> GraphQLValue<S> for std::collections::HashSet<T>
+where
+    T: GraphQLValue<S>,
+    S: ScalarValue,
+{
+    type Context = T::Context;
+    type TypeInfo = T::TypeInfo;
+
+    fn type_name(&self, _: &Self::TypeInfo) -> Option<&'static str> {
+        None
+    }
+
+    fn resolve(
+        &self,
+        info: &Self::TypeInfo,
+        _: Option<&[Selection<S>]>,
+        executor: &Executor<Self::Context, S>,
+    ) -> ExecutionResult<S> {
+        resolve_into_list(executor, info, self.iter())
+    }
+}
+
 impl<S, T> GraphQLType<S> for [T]
 where
     S: ScalarValue,

--- a/juniper/src/types/marker.rs
+++ b/juniper/src/types/marker.rs
@@ -249,6 +249,17 @@ where
     }
 }
 
+impl<S, T> IsOutputType<S> for std::collections::HashSet<T>
+where
+    T: IsOutputType<S>,
+    S: ScalarValue,
+{
+    #[inline]
+    fn mark() {
+        T::mark()
+    }
+}
+
 impl<S, T> IsOutputType<S> for [T]
 where
     T: IsOutputType<S>,


### PR DESCRIPTION
This PR implements support for converting HashSet<T> into GraphQL exactly the same way as Vec<T>. Only output-related traits were implemented:

* IsOutputType
* GraphQLType
* BaseType
* WrapType
* GraphQLValueAsync

## Use case 

Consider this struct
```rust
#[derive(Debug, Serialize, Deserialize, Eq, Clone, GraphQLObject)]
#[graphql(scalar = RustScalarValue)]
pub struct KeywordCounter {
    pub full_list: Vec<String>,        // <---- a list, works fine as-is
    pub unique_list: HashSet<String>,  // <---- the same as full_list from GQL perspective, but fails because of no HashSet impl      
    pub c: u64,                        // <---- a custom scalar, works fine
}
```
