### PR TITLE
Remove indirect time 0.1.44 dependency by chrono

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -40,7 +40,7 @@ anyhow = { version = "1.0.32", default-features = false, optional = true }
 async-trait = "0.1.39"
 bigdecimal = { version = "0.3", optional = true }
 bson = { version = "2.4", features = ["chrono-0_4"], optional = true }
-chrono = { version = "0.4", features = ["alloc"], default-features = false, optional = true }
+chrono = { version = "0.4.20", features = ["alloc"], default-features = false, optional = true }
 chrono-tz = { version = "0.6", default-features = false, optional = true }
 fnv = "1.0.3"
 futures = { version = "0.3.1", features = ["alloc"], default-features = false }
@@ -62,7 +62,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 bencher = "0.1.2"
-chrono = { version = "0.4", features = ["alloc"], default-features = false }
+chrono = { version = "0.4.20", features = ["alloc"], default-features = false }
 pretty_assertions = "1.0.0"
 serde_json = "1.0.2"
 tokio = { version = "1.0", features = ["macros", "time", "rt-multi-thread"] }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dev-dependencies]
 async-trait = "0.1.39"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 derive_more = "0.99"
 fnv = "1.0"
 futures = "0.3"

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dev-dependencies]
 async-trait = "0.1.39"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.20", default-features = false }
 derive_more = "0.99"
 fnv = "1.0"
 futures = "0.3"


### PR DESCRIPTION
By default chrono uses time 0.1.44, which has a vulnerability:
https://rustsec.org/advisories/RUSTSEC-2020-0071

chrono 0.4.20 does not depend on the vulnerable parts of the time 0.1.x
versions, see https://github.com/chronotope/chrono/releases/tag/v0.4.20

This change is to satisfy simple dependency scanners.