### PR TITLE
Change body type of `juniper-hyper` functions from `Body` to `String`

### DIFF
--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -11,6 +11,7 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 ### BC Breaks
 
 - Switched to 0.16 version of [`juniper` crate].
+- Changed the return type of all functions from `Response<Body>` to `Response<String>`
 
 
 

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -11,7 +11,10 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 ### BC Breaks
 
 - Switched to 0.16 version of [`juniper` crate].
-- Changed the return type of all functions from `Response<Body>` to `Response<String>`
+- Changed return type of all functions from `Response<Body>` to `Response<String>`. ([#1101], [#1096])
+
+[#1096]: /../../issues/1096
+[#1101]: /../../pull/1101
 
 
 

--- a/juniper_hyper/examples/hyper_server.rs
+++ b/juniper_hyper/examples/hyper_server.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, sync::Arc};
 use hyper::{
     server::Server,
     service::{make_service_fn, service_fn},
-    Body, Method, Response, StatusCode,
+    Method, Response, StatusCode,
 };
 use juniper::{
     tests::fixtures::starwars::schema::{Database, Query},
@@ -38,7 +38,7 @@ async fn main() {
                             juniper_hyper::graphql(root_node, ctx, req).await
                         }
                         _ => {
-                            let mut response = Response::new(Body::empty());
+                            let mut response = Response::new(String::new());
                             *response.status_mut() = StatusCode::NOT_FOUND;
                             response
                         }


### PR DESCRIPTION
All responses were created from strings anyway (via `Body::from`), but `String` implements the `Body` trait directly. With this change, it is easy to inspect the response body, which is not true for `Body`.

Fixes #1096