### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          components: rust-src
       - run: rustup default ${{ matrix.toolchain }}
 
+      - run: cargo install cargo-careful
+        if: ${{ matrix.toolchain == 'nightly' }}
+
       - run: make test.cargo crate=${{ matrix.crate }}
+                  careful=${{ (matrix.toolchain == 'nightly' && 'yes')
+                           ||                                   'no' }}
 
   test-book:
     name: test Book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
           components: clippy
 
@@ -59,9 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
 
@@ -78,11 +76,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - run: cargo clippy -p juniper_benchmarks --benches -- -D warnings
       - run: cargo bench -p juniper_benchmarks
@@ -107,11 +103,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
+      - run: rustup default ${{ matrix.toolchain }}
 
       - run: cargo check -p example_${{ matrix.example }}
 
@@ -141,11 +136,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       # TODO: Enable once MSRV is supported.
       #- run: cargo +nightly update -Z minimal-versions
@@ -162,9 +155,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
 
       - name: Parse crate name
@@ -211,11 +203,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
+      - run: rustup default ${{ matrix.toolchain }}
 
       - run: make test.cargo crate=${{ matrix.crate }}
 
@@ -237,11 +228,10 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
+      - run: rustup default ${{ matrix.toolchain }}
 
       - run: cargo install mdbook
 
@@ -261,12 +251,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown
+      - run: rustup default ${{ matrix.toolchain }}
 
       - run: cargo check --target wasm32-unknown-unknown -p ${{ matrix.crate }}
 
@@ -278,7 +267,7 @@ jobs:
   #############
 
   release-check:
-    name: Check release automation
+    name: check release
     if: ${{ !startsWith(github.ref, 'refs/tags/juniper') }}
     strategy:
       fail-fast: false
@@ -296,9 +285,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
 
       - run: cargo install cargo-release
@@ -306,8 +294,29 @@ jobs:
       - run: make cargo.release crate=${{ matrix.crate }} ver=minor
                                 exec=no install=no
 
+  release-crate:
+    name: release on crates.io
+    needs: ["release-github"]
+    if: ${{ startsWith(github.ref, 'refs/tags/juniper') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Parse crate name
+        id: crate
+        run: echo ::set-output
+                  name=NAME::$(printf "$GITHUB_REF" | cut -d '/' -f3
+                                                    | cut -d '@' -f1)
+
+      - name: Publish crate
+        run: cargo publish -p ${{ steps.crate.outputs.NAME }}
+                           --token ${{ secrets.CRATESIO_TOKEN }}
+
   release-github:
-    name: Release on GitHub
+    name: release on GitHub
     needs:
       - bench
       - clippy
@@ -351,28 +360,6 @@ jobs:
             [API docs](https://docs.rs/${{ steps.crate.outputs.NAME }}/${{ steps.release.outputs.VERSION }})
             [Changelog](${{ steps.changelog.outputs.LINK }})
           prerelease: ${{ contains(steps.release.outputs.VERSION, '-') }}
-
-  release-crate:
-    name: Release on crates.io
-    needs: ["release-github"]
-    if: ${{ startsWith(github.ref, 'refs/tags/juniper') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
-      - name: Parse crate name
-        id: crate
-        run: echo ::set-output
-                  name=NAME::$(printf "$GITHUB_REF" | cut -d '/' -f3
-                                                    | cut -d '@' -f1)
-
-      - name: Publish crate
-        run: cargo publish -p ${{ steps.crate.outputs.NAME }}
-                           --token ${{ secrets.CRATESIO_TOKEN }}
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - clippy
       - example
       - feature
+      - msrv
       - release-check
       - rustfmt
       - test
@@ -139,9 +140,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
 
-      # TODO: Enable once MSRV is supported.
-      #- run: cargo +nightly update -Z minimal-versions
+      - run: cargo +nightly update -Z minimal-versions
 
       - run: cargo check -p ${{ matrix.crate }} --no-default-features
                    ${{ matrix.feature != '<none>'
@@ -149,6 +152,41 @@ jobs:
                        || '' }}
         env:
           RUSTFLAGS: -D warnings
+
+  msrv:
+    name: MSRV
+    strategy:
+      fail-fast: false
+      matrix:
+        msrv: ["1.62.0"]
+        crate:
+          - juniper_codegen
+          - juniper
+          - juniper_subscriptions
+          - juniper_graphql_ws
+          - juniper_actix
+          - juniper_hyper
+          - juniper_iron
+          - juniper_rocket
+          - juniper_warp
+        os:
+          - ubuntu
+          - macOS
+          - windows
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.msrv }}
+      - run: rustup default ${{ matrix.msrv }}
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - run: cargo +nightly update -Z minimal-versions
+
+      - run: make test.cargo crate=${{ matrix.crate }}
 
   package:
     if: ${{ startsWith(github.ref, 'refs/tags/juniper') }}
@@ -323,6 +361,7 @@ jobs:
       - clippy
       - example
       - feature
+      - msrv
       - package
       - rustfmt
       - test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           - juniper_graphql_ws
           - juniper_actix
           - juniper_hyper
-          - juniper_iron
+          #- juniper_iron
           - juniper_rocket
           - juniper_warp
         os:
@@ -197,13 +197,14 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Parse crate name
-        id: crate
-        run: echo ::set-output
-                  name=NAME::$(printf "$GITHUB_REF" | cut -d '/' -f3
-                                                    | cut -d '@' -f1)
+      - name: Parse crate name and version from Git tag
+        id: tag
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/(([a-z_]+)-v([0-9]+\.[0-9]+\.[0-9]+(-.+)?))$'
 
-      - run: cargo package -p ${{ steps.crate.outputs.NAME }}
+      - run: cargo package -p ${{ steps.tag.outputs.group2 }}
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-          targets: wasm32-unknown-unknown
+          target: wasm32-unknown-unknown
       - run: rustup default ${{ matrix.toolchain }}
 
       - run: cargo check --target wasm32-unknown-unknown -p ${{ matrix.crate }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: ["master"]
-    tags: ["juniper*@*"]
+    tags: ["juniper*"]
   pull_request:
     branches: ["master"]
 
@@ -305,14 +305,15 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Parse crate name
-        id: crate
-        run: echo ::set-output
-                  name=NAME::$(printf "$GITHUB_REF" | cut -d '/' -f3
-                                                    | cut -d '@' -f1)
+      - name: Parse crate name and version from Git tag
+        id: tag
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/(([a-z_]+)-v([0-9]+\.[0-9]+\.[0-9]+(-.+)?))$'
 
-      - name: Publish crate
-        run: cargo publish -p ${{ steps.crate.outputs.NAME }}
+      - name: Publish `${{ steps.tag.outputs.group2 }}` crate
+        run: cargo publish -p ${{ steps.tag.outputs.group2 }}
                            --token ${{ secrets.CRATESIO_TOKEN }}
 
   release-github:
@@ -332,34 +333,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Parse crate name
-        id: crate
-        run: echo ::set-output
-                  name=NAME::$(printf "$GITHUB_REF" | cut -d '/' -f3
-                                                    | cut -d '@' -f1)
-      - name: Parse release version
-        id: release
-        run: echo ::set-output
-                  name=VERSION::$(printf "$GITHUB_REF" | cut -d '@' -f2)
-
+      - name: Parse crate name and version from Git tag
+        id: tag
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/(([a-z_]+)-v([0-9]+\.[0-9]+\.[0-9]+(-.+)?))$'
       - name: Verify release version matches crate's Cargo manifest
-        run: >-
-          test "${{ steps.release.outputs.VERSION }}" \
-            == "$(grep -m1 'version = "' ${{ steps.crate.outputs.NAME }}/Cargo.toml | cut -d '"' -f2)"
+        run: |
+          test "${{ steps.tag.outputs.group3 }}" \
+            == "$(grep -m1 'version = "' \
+                       ${{ steps.tag.outputs.group2 }}/Cargo.toml \
+                  | cut -d '"' -f2)"
+
       - name: Parse CHANGELOG link
         id: changelog
         run: echo ::set-output
-                  name=LINK::${{ github.server_url }}/${{ github.repository }}/blob/${{ steps.crate.outputs.NAME }}%40${{ steps.release.outputs.VERSION }}//${{ steps.crate.outputs.NAME }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.release.outputs.VERSION }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' ${{ steps.crate.outputs.NAME }}/CHANGELOG.md)
+                  name=link::${{ github.server_url }}/${{ github.repository }}/blob/${{ steps.tag.outputs.group1 }}/${{ steps.tag.outputs.group2 }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.tag.outputs.group3 }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' ${{ steps.tag.outputs.group2 }}/CHANGELOG.md)
 
       - uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.crate.outputs.NAME }} ${{ steps.release.outputs.VERSION }}
+          name: ${{ steps.tag.outputs.group2 }} ${{ steps.tag.outputs.group3 }}
           body: |
-            [API docs](https://docs.rs/${{ steps.crate.outputs.NAME }}/${{ steps.release.outputs.VERSION }})
-            [Changelog](${{ steps.changelog.outputs.LINK }})
-          prerelease: ${{ contains(steps.release.outputs.VERSION, '-') }}
+            [API docs](https://docs.rs/${{ steps.tag.outputs.group2 }}/${{ steps.tag.outputs.group3 }})
+            [Changelog](${{ steps.changelog.outputs.link }})
+          prerelease: ${{ contains(steps.tag.outputs.group3, '-') }}
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,21 @@ endif
 # Run Rust tests of project crates.
 #
 # Usage:
-#	make test.cargo [crate=<crate-name>]
+#	make test.cargo [crate=<crate-name>] [careful=(no|yes)]
 
 test.cargo:
-	cargo $(if $(call eq,$(crate),juniper_codegen_tests),+nightly,) test \
-		$(if $(call eq,$(crate),),--workspace,-p $(crate)) --all-features
+ifeq ($(careful),yes)
+ifeq ($(shell cargo install --list | grep cargo-careful),)
+	cargo install cargo-careful
+endif
+ifeq ($(shell rustup component list --toolchain=nightly \
+              | grep 'rust-src (installed)'),)
+	rustup component add --toolchain=nightly rust-src
+endif
+endif
+	cargo $(if $(call eq,$(careful),yes),+nightly careful,\
+	      $(if $(call eq,$(crate),juniper_codegen_tests),+nightly,)) \
+		test $(if $(call eq,$(crate),),--workspace,-p $(crate)) --all-features
 
 
 

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -32,30 +32,38 @@ default = [
     "uuid",
 ]
 chrono-clock = ["chrono", "chrono/clock"]
+chrono-tz = ["dep:chrono-tz", "dep:regex"]
 expose-test-schema = ["anyhow", "serde_json"]
+graphql-parser = ["dep:graphql-parser", "dep:void"]
 schema-language = ["graphql-parser"]
 
 [dependencies]
-anyhow = { version = "1.0.32", default-features = false, optional = true }
+anyhow = { version = "1.0.47", default-features = false, optional = true }
 async-trait = "0.1.39"
 bigdecimal = { version = "0.3", optional = true }
 bson = { version = "2.4", features = ["chrono-0_4"], optional = true }
 chrono = { version = "0.4.20", features = ["alloc"], default-features = false, optional = true }
-chrono-tz = { version = "0.6", default-features = false, optional = true }
+chrono-tz = { version = "0.7", default-features = false, optional = true }
 fnv = "1.0.3"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 futures-enum = { version = "0.1.12", default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "1.0", features = ["serde-1"] }
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen" }
-rust_decimal = { version = "1.0", default-features = false, optional = true }
-serde = { version = "1.0.103", features = ["derive"] }
+rust_decimal = { version = "1.20", default-features = false, optional = true }
+serde = { version = "1.0.122", features = ["derive"] }
 serde_json = { version = "1.0.18", default-features = false, optional = true }
 smartstring = "1.0"
 static_assertions = "1.1"
 time = { version = "0.3", features = ["formatting", "macros", "parsing"], optional = true }
 url = { version = "2.0", optional = true }
 uuid = { version = "1.0", default-features = false, optional = true }
+
+# Fixes for MSRV check.
+# TODO: Try remove on upgrade of `chrono-tz` crate.
+regex = { version = "1.6", default-features = false, optional = true }
+# TODO: Remove on upgrade to 4.0.1 version of `graphql-parser`.
+void = { version = "1.0.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -49,8 +49,8 @@ graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "1.0", features = ["serde-1"] }
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen" }
 rust_decimal = { version = "1.0", default-features = false, optional = true }
-serde = { version = "1.0.8", features = ["derive"] }
-serde_json = { version = "1.0.2", default-features = false, optional = true }
+serde = { version = "1.0.103", features = ["derive"] }
+serde_json = { version = "1.0.18", default-features = false, optional = true }
 smartstring = "1.0"
 static_assertions = "1.1"
 time = { version = "0.3", features = ["formatting", "macros", "parsing"], optional = true }
@@ -64,7 +64,7 @@ getrandom = { version = "0.2", features = ["js"] }
 bencher = "0.1.2"
 chrono = { version = "0.4.20", features = ["alloc"], default-features = false }
 pretty_assertions = "1.0.0"
-serde_json = "1.0.2"
+serde_json = "1.0.18"
 tokio = { version = "1.0", features = ["macros", "time", "rt-multi-thread"] }
 
 [[bench]]

--- a/juniper/README.md
+++ b/juniper/README.md
@@ -4,6 +4,7 @@ Juniper (GraphQL server library for Rust)
 [![Crates.io](https://img.shields.io/crates/v/juniper.svg?maxAge=2592000)](https://crates.io/crates/juniper)
 [![Documentation](https://docs.rs/juniper/badge.svg)](https://docs.rs/juniper)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Juniper Book] ([current][Juniper Book] | [edge][Juniper Book edge])
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper/CHANGELOG.md)

--- a/juniper/release.toml
+++ b/juniper/release.toml
@@ -78,12 +78,14 @@ replace = "juniper = { version = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "...master\\)"
 replace = "...{{crate_name}}-v{{version}})"
 

--- a/juniper/release.toml
+++ b/juniper/release.toml
@@ -80,15 +80,15 @@ replace = "juniper = { version = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
 exactly = 1
 search = "...master\\)"
-replace = "...{{crate_name}}%40{{version}})"
+replace = "...{{crate_name}}-v{{version}})"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 2
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -31,8 +31,8 @@ futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.4.0-dev", path = "../juniper_graphql_ws", optional = true }
 http = "0.2.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.103", features = ["derive"] }
+serde_json = "1.0.18"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["sync"], optional = true }
 

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -19,22 +19,31 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-subscriptions = ["juniper_graphql_ws", "tokio"]
+subscriptions = [
+    "dep:actix",
+    "dep:actix-web-actors",
+    "dep:juniper_graphql_ws",
+    "dep:tokio",
+]
 
 [dependencies]
-actix = "0.13"
-actix-http = "3.0"
-actix-web = "4.0"
-actix-web-actors = "4.1.0"
-anyhow = "1.0"
+actix = { version = ">=0.12,<=0.13", optional = true }
+actix-http = "3.2"
+actix-web = "4.2.1"
+actix-web-actors = { version = "4.1", optional = true }
+anyhow = "1.0.47"
 futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.4.0-dev", path = "../juniper_graphql_ws", optional = true }
 http = "0.2.4"
-serde = { version = "1.0.103", features = ["derive"] }
+serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.18"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["sync"], optional = true }
+
+# Fixes for MSRV check.
+# TODO: Try remove on upgrade to 4.3 version of `actix-web` crate.
+derive_more = { version = "0.99.8", default-features = false }
 
 [dev-dependencies]
 actix-cors = "0.6"

--- a/juniper_actix/README.md
+++ b/juniper_actix/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_actix.svg?maxAge=2592000)](https://crates.io/crates/juniper_actix)
 [![Documentation](https://docs.rs/juniper_actix/badge.svg)](https://docs.rs/juniper_actix)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_actix/CHANGELOG.md)
 

--- a/juniper_actix/release.toml
+++ b/juniper_actix/release.toml
@@ -2,10 +2,10 @@
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_actix/release.toml
+++ b/juniper_actix/release.toml
@@ -1,6 +1,7 @@
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -32,4 +32,4 @@ url = "2.0"
 derive_more = "0.99.7"
 futures = "0.3.22"
 juniper = { path = "../juniper" }
-serde = "1.0"
+serde = "1.0.103"

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -23,13 +23,13 @@ proc-macro = true
 
 [dependencies]
 proc-macro-error = "1.0.2"
-proc-macro2 = "1.0.1"
-quote = "1.0.3"
+proc-macro2 = "1.0.4"
+quote = "1.0.9"
 syn = { version = "1.0.90", features = ["extra-traits", "full", "parsing", "visit", "visit-mut"], default-features = false }
 url = "2.0"
 
 [dev-dependencies]
-derive_more = "0.99.7"
+derive_more = "0.99.8"
 futures = "0.3.22"
 juniper = { path = "../juniper" }
-serde = "1.0.103"
+serde = "1.0.122"

--- a/juniper_codegen/README.md
+++ b/juniper_codegen/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_codegen.svg?maxAge=2592000)](https://crates.io/crates/juniper_codegen)
 [![Documentation](https://docs.rs/juniper_codegen/badge.svg)](https://docs.rs/juniper_codegen)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_codegen/CHANGELOG.md)
 

--- a/juniper_codegen/release.toml
+++ b/juniper_codegen/release.toml
@@ -6,7 +6,8 @@ replace = "{{crate_name}} = { version = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_codegen/release.toml
+++ b/juniper_codegen/release.toml
@@ -8,10 +8,10 @@ replace = "{{crate_name}} = { version = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 2
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_graphql_ws/Cargo.toml
+++ b/juniper_graphql_ws/Cargo.toml
@@ -17,8 +17,8 @@ exclude = ["/release.toml"]
 [dependencies]
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_subscriptions = { version = "0.17.0-dev", path = "../juniper_subscriptions" }
-serde = { version = "1.0.8", features = ["derive"], default-features = false }
+serde = { version = "1.0.103", features = ["derive"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "rt", "time"], default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.18"

--- a/juniper_graphql_ws/Cargo.toml
+++ b/juniper_graphql_ws/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["/release.toml"]
 [dependencies]
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_subscriptions = { version = "0.17.0-dev", path = "../juniper_subscriptions" }
-serde = { version = "1.0.103", features = ["derive"], default-features = false }
+serde = { version = "1.0.122", features = ["derive"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "rt", "time"], default-features = false }
 
 [dev-dependencies]

--- a/juniper_graphql_ws/README.md
+++ b/juniper_graphql_ws/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_graphql_ws.svg?maxAge=2592000)](https://crates.io/crates/juniper_graphql_ws)
 [![Documentation](https://docs.rs/juniper_graphql_ws/badge.svg)](https://docs.rs/juniper_graphql_ws)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_graphql_ws/CHANGELOG.md)
 

--- a/juniper_graphql_ws/release.toml
+++ b/juniper_graphql_ws/release.toml
@@ -14,10 +14,10 @@ replace = "juniper_graphql_ws = { version = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 2
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_graphql_ws/release.toml
+++ b/juniper_graphql_ws/release.toml
@@ -12,7 +12,8 @@ replace = "juniper_graphql_ws = { version = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/examples/", "/release.toml"]
 futures = "0.3.22"
 hyper = { version = "0.14", features = ["server", "runtime"] }
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
-serde_json = "1.0"
+serde_json = "1.0.18"
 tokio = "1.0"
 url = "2.0"
 

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -16,11 +16,15 @@ exclude = ["/examples/", "/release.toml"]
 
 [dependencies]
 futures = "0.3.22"
-hyper = { version = "0.14", features = ["server", "runtime"] }
+hyper = { version = "0.14.7", features = ["server", "runtime"] }
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 serde_json = "1.0.18"
 tokio = "1.0"
 url = "2.0"
+
+# Fixes for MSRV check.
+# TODO: Try remove on upgrade of `hyper` crate.
+http-body = "0.4.5"
 
 [dev-dependencies]
 juniper = { version = "0.16.0-dev", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_hyper/README.md
+++ b/juniper_hyper/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_hyper.svg?maxAge=2592000)](https://crates.io/crates/juniper_hyper)
 [![Documentation](https://docs.rs/juniper_hyper/badge.svg)](https://docs.rs/juniper_hyper)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_hyper/CHANGELOG.md)
 

--- a/juniper_hyper/release.toml
+++ b/juniper_hyper/release.toml
@@ -6,7 +6,8 @@ replace = "juniper_hyper = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_hyper/release.toml
+++ b/juniper_hyper/release.toml
@@ -8,10 +8,10 @@ replace = "juniper_hyper = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_iron/Cargo.toml
+++ b/juniper_iron/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/examples/", "/release.toml"]
 futures = "0.3.22"
 iron = ">= 0.5, < 0.7"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
-serde_json = "1.0.2"
+serde_json = "1.0.18"
 urlencoded = ">= 0.5, < 0.7"
 
 [dev-dependencies]

--- a/juniper_iron/README.md
+++ b/juniper_iron/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_iron.svg?maxAge=2592000)](https://crates.io/crates/juniper_iron)
 [![Documentation](https://docs.rs/juniper_iron/badge.svg)](https://docs.rs/juniper_iron)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_iron/CHANGELOG.md)
 

--- a/juniper_iron/release.toml
+++ b/juniper_iron/release.toml
@@ -8,10 +8,10 @@ replace = "juniper_iron = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_iron/release.toml
+++ b/juniper_iron/release.toml
@@ -6,7 +6,8 @@ replace = "juniper_iron = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["/examples/", "/tests/", "/release.toml"]
 futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 rocket = { version = "=0.5.0-rc.2", default-features = false }
-serde_json = "1.0.2"
+serde_json = "1.0.18"
 
 [dev-dependencies]
 juniper = { version = "0.16.0-dev", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_rocket/Cargo.toml
+++ b/juniper_rocket/Cargo.toml
@@ -23,5 +23,12 @@ juniper = { version = "0.16.0-dev", path = "../juniper", default-features = fals
 rocket = { version = "=0.5.0-rc.2", default-features = false }
 serde_json = "1.0.18"
 
+# Fixes for MSRV check.
+# TODO: Try remove on upgrade of `rocket` crate.
+either = "1.8"
+inlinable_string = "0.1.15"
+proc-macro2-diagnostics = "0.9.1"
+tempfile = "3.3"
+
 [dev-dependencies]
 juniper = { version = "0.16.0-dev", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_rocket/README.md
+++ b/juniper_rocket/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_rocket.svg?maxAge=2592000)](https://crates.io/crates/juniper_rocket)
 [![Documentation](https://docs.rs/juniper_rocket/badge.svg)](https://docs.rs/juniper_rocket)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_rocket/CHANGELOG.md)
 

--- a/juniper_rocket/release.toml
+++ b/juniper_rocket/release.toml
@@ -8,10 +8,10 @@ replace = "juniper_rocket = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_rocket/release.toml
+++ b/juniper_rocket/release.toml
@@ -6,7 +6,8 @@ replace = "juniper_rocket = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_subscriptions/Cargo.toml
+++ b/juniper_subscriptions/Cargo.toml
@@ -19,5 +19,5 @@ futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.18"
 tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/juniper_subscriptions/README.md
+++ b/juniper_subscriptions/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_subscriptions.svg?maxAge=2592000)](https://crates.io/crates/juniper_subscriptions)
 [![Documentation](https://docs.rs/juniper_subscriptions/badge.svg)](https://docs.rs/juniper_subscriptions)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_subscriptions/CHANGELOG.md)
 

--- a/juniper_subscriptions/release.toml
+++ b/juniper_subscriptions/release.toml
@@ -12,7 +12,8 @@ replace = "juniper_subscriptions = { version = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/juniper_subscriptions/release.toml
+++ b/juniper_subscriptions/release.toml
@@ -14,10 +14,10 @@ replace = "juniper_subscriptions = { version = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -32,6 +32,10 @@ thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 warp = { version = "0.3.2", default-features = false }
 
+# Fixes for MSRV check.
+# TODO: Try remove on upgrade of `warp` crate.
+headers = "0.3.8"
+
 [dev-dependencies]
 env_logger = "0.9"
 juniper = { version = "0.16.0-dev", path = "../juniper", features = ["expose-test-schema"] }

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -26,8 +26,8 @@ anyhow = "1.0"
 futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.4.0-dev", path = "../juniper_graphql_ws", optional = true }
-serde = { version = "1.0.75", features = ["derive"] }
-serde_json = "1.0.24"
+serde = { version = "1.0.103", features = ["derive"] }
+serde_json = "1.0.18"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 warp = "0.3"

--- a/juniper_warp/Cargo.toml
+++ b/juniper_warp/Cargo.toml
@@ -19,18 +19,18 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-subscriptions = ["juniper_graphql_ws"]
+subscriptions = ["dep:juniper_graphql_ws", "warp/websocket"]
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.47"
 futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.4.0-dev", path = "../juniper_graphql_ws", optional = true }
-serde = { version = "1.0.103", features = ["derive"] }
+serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.18"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
-warp = "0.3"
+warp = { version = "0.3.2", default-features = false }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/juniper_warp/README.md
+++ b/juniper_warp/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_warp.svg?maxAge=2592000)](https://crates.io/crates/juniper_warp)
 [![Documentation](https://docs.rs/juniper_warp/badge.svg)](https://docs.rs/juniper_warp)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
+[![Rust 1.62+](https://img.shields.io/badge/rustc-1.62+-lightgray.svg "Rust 1.62+")](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/master/juniper_warp/CHANGELOG.md)
 

--- a/juniper_warp/release.toml
+++ b/juniper_warp/release.toml
@@ -8,10 +8,10 @@ replace = "juniper_warp = \"{{version}}\""
 file = "CHANGELOG.md"
 exactly = 1
 search = "## master"
-replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}%40{{version}}/{{crate_name}}"
+replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 
 [[pre-release-replacements]]
 file = "README.md"
 exactly = 3
 search = "graphql-rust/juniper/blob/[^/]+/"
-replace = "graphql-rust/juniper/blob/{{crate_name}}%40{{version}}/"
+replace = "graphql-rust/juniper/blob/{{crate_name}}-v{{version}}/"

--- a/juniper_warp/release.toml
+++ b/juniper_warp/release.toml
@@ -6,7 +6,8 @@ replace = "juniper_warp = \"{{version}}\""
 
 [[pre-release-replacements]]
 file = "CHANGELOG.md"
-exactly = 1
+max = 1
+min = 0
 search = "## master"
 replace = "## [{{version}}] · {{date}}\n[{{version}}]: /../../tree/{{crate_name}}-v{{version}}/{{crate_name}}"
 

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
 allow-branch = ["*"]
 pre-release-commit-message = "Prepare {{version}} release of `{{crate_name}}` crate"
 tag-message = "{{version}} version of `{{crate_name}}` crate"
-tag-name = "{{crate_name}}@{{version}}"
+tag-name = "{{crate_name}}-v{{version}}"


### PR DESCRIPTION
This PR improves/updates CI pipeline and project toolchain.

- [x] switch to `dtolnay/rust-toolchain` GitHub action
- [x] revert to `<crate_name>-v<version>` format of release Git tag 
- [x] enable MSRV check
- [x] integrate `cargo-careful`for nightly versions
- [x] tune up release automation to not break right after commiting