### PR TITLE
Fix `operation_name` not being set in `juniper_hyper` (#1169)

### DIFF
--- a/juniper_actix/CHANGELOG.md
+++ b/juniper_actix/CHANGELOG.md
@@ -14,7 +14,13 @@ All user visible changes to `juniper_actix` crate will be documented in this fil
 - Switched to 0.16 version of [`juniper` crate].
 - Switched to 0.4 version of [`juniper_graphql_ws` crate].
 
+### Fixed
+
+- `operationName` not being set. ([#1187], [#1169])
+
 [#1034]: /../../pull/1034
+[#1169]: /../../issues/1169
+[#1187]: /../../pull/1187
 
 
 

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -212,7 +212,7 @@ where
     S: ScalarValue,
 {
     let mut query = None;
-    let operation_name = None;
+    let mut operation_name = None;
     let mut variables = None;
     for (key, value) in form_urlencoded::parse(input.as_bytes()).into_owned() {
         match key.as_ref() {
@@ -226,6 +226,7 @@ where
                 if operation_name.is_some() {
                     return Err(invalid_err("operationName"));
                 }
+                operation_name = Some(value)
             }
             "variables" => {
                 if variables.is_some() {


### PR DESCRIPTION
Resolves #1169


## Synopsis

See https://github.com/graphql-rust/juniper/issues/1169#issue-1726260032

> **Describe the bug** The code block
> 
> https://github.com/graphql-rust/juniper/blob/a648dd727519991c2e3c762af16eac027b2acec2/juniper_hyper/src/lib.rs#L225-L229
> 
> seems to be missing a statement where operation_name would be set to `Some(value)`.
> 
> **To Reproduce** Steps to reproduce the behavior: Just read through code. See the variable is defined a `None` and nowhere is being set.




## Solution

Set the missing `operation_name`, as suggested.

