### PR TITLE
Use `actix-ws` for `juniper_actix` subscriptions 

### DIFF
--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -360,8 +360,11 @@ impl<S: ScalarValue> GraphQLBatchResponse<S> {
 #[cfg(feature = "expose-test-schema")]
 #[allow(missing_docs)]
 pub mod tests {
+    use std::time::Duration;
+
+    use serde_json::Value as Json;
+
     use crate::LocalBoxFuture;
-    use serde_json::{self, Value as Json};
 
     /// Normalized response content we expect to get back from
     /// the http framework integration we are testing.
@@ -598,162 +601,141 @@ pub mod tests {
         ) -> LocalBoxFuture<Result<(), anyhow::Error>>;
     }
 
-    /// WebSocket framework integration message
+    /// WebSocket framework integration message.
     pub enum WsIntegrationMessage {
-        /// Send message through the WebSocket
-        /// Takes a message as a String
-        Send(String),
-        /// Expect message to come through the WebSocket
-        /// Takes expected message as a String and a timeout in milliseconds
-        Expect(String, u64),
+        /// Send a message through a WebSocket.
+        Send(Json),
+
+        /// Expects a message to come through a WebSocket, with the specified timeout.
+        Expect(Json, Duration),
     }
 
-    /// Default value in milliseconds for how long to wait for an incoming message
-    pub const WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT: u64 = 100;
+    /// Default value in milliseconds for how long to wait for an incoming WebSocket message.
+    pub const WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
 
-    #[allow(missing_docs)]
-    pub async fn run_ws_test_suite<T: WsIntegration>(integration: &T) {
-        println!("Running WebSocket Test suite for integration");
+    pub mod graphql_ws {
+        use serde_json::json;
 
-        println!("  - test_ws_simple_subscription");
-        test_ws_simple_subscription(integration).await;
+        use super::{WsIntegration, WsIntegrationMessage, WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT};
 
-        println!("  - test_ws_invalid_json");
-        test_ws_invalid_json(integration).await;
+        #[allow(missing_docs)]
+        pub async fn run_test_suite<T: WsIntegration>(integration: &T) {
+            println!("Running `graphql-ws` test suite for integration");
 
-        println!("  - test_ws_invalid_query");
-        test_ws_invalid_query(integration).await;
-    }
+            println!("  - graphql_ws::test_simple_subscription");
+            test_simple_subscription(integration).await;
 
-    async fn test_ws_simple_subscription<T: WsIntegration>(integration: &T) {
-        let messages = vec![
-            WsIntegrationMessage::Send(
-                r#"{
-                    "type":"connection_init",
-                    "payload":{}
-                }"#
-                .into(),
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"connection_ack"
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"ka"
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
-            ),
-            WsIntegrationMessage::Send(
-                r#"{
-                    "id":"1",
-                    "type":"start",
-                    "payload":{
-                        "variables":{},
-                        "extensions":{},
-                        "operationName":null,
-                        "query":"subscription { asyncHuman { id, name, homePlanet } }"
-                    }
-                }"#
-                .into(),
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"data",
-                    "id":"1",
-                    "payload":{
-                        "data":{
-                            "asyncHuman":{
-                                "id":"1000",
-                                "name":"Luke Skywalker",
-                                "homePlanet":"Tatooine"
-                            }
-                        }
-                    }
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
-            ),
-        ];
+            println!("  - graphql_ws::test_invalid_json");
+            test_invalid_json(integration).await;
 
-        integration.run(messages).await.unwrap();
-    }
+            println!("  - graphql_ws::test_invalid_query");
+            test_invalid_query(integration).await;
+        }
 
-    async fn test_ws_invalid_json<T: WsIntegration>(integration: &T) {
-        let messages = vec![
-            WsIntegrationMessage::Send("invalid json".into()),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"connection_error",
-                    "payload":{
-                        "message":"serde error: expected value at line 1 column 1"
-                    }
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
-            ),
-        ];
+        async fn test_simple_subscription<T: WsIntegration>(integration: &T) {
+            let messages = vec![
+                WsIntegrationMessage::Send(json!({
+                    "type": "connection_init",
+                    "payload": {},
+                })),
+                WsIntegrationMessage::Expect(
+                    json!({"type": "connection_ack"}),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+                WsIntegrationMessage::Expect(
+                    json!({"type": "ka"}),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+                WsIntegrationMessage::Send(json!({
+                    "id": "1",
+                    "type": "start",
+                    "payload": {
+                        "variables": {},
+                        "extensions": {},
+                        "operationName": null,
+                        "query": "subscription { asyncHuman { id, name, homePlanet } }",
+                    },
+                })),
+                WsIntegrationMessage::Expect(
+                    json!({
+                        "type": "data",
+                        "id": "1",
+                        "payload": {
+                            "data": {
+                                "asyncHuman": {
+                                    "id": "1000",
+                                    "name": "Luke Skywalker",
+                                    "homePlanet": "Tatooine",
+                                },
+                            },
+                        },
+                    }),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+            ];
 
-        integration.run(messages).await.unwrap();
-    }
+            integration.run(messages).await.unwrap();
+        }
 
-    async fn test_ws_invalid_query<T: WsIntegration>(integration: &T) {
-        let messages = vec![
-            WsIntegrationMessage::Send(
-                r#"{
-                    "type":"connection_init",
-                    "payload":{}
-                }"#
-                .into(),
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"connection_ack"
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"ka"
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT
-            ),
-            WsIntegrationMessage::Send(
-                r#"{
-                    "id":"1",
-                    "type":"start",
-                    "payload":{
-                        "variables":{},
-                        "extensions":{},
-                        "operationName":null,
-                        "query":"subscription { asyncHuman }"
-                    }
-                }"#
-                .into(),
-            ),
-            WsIntegrationMessage::Expect(
-                r#"{
-                    "type":"error",
-                    "id":"1",
-                    "payload":[{
-                        "message":"Field \"asyncHuman\" of type \"Human!\" must have a selection of subfields. Did you mean \"asyncHuman { ... }\"?",
-                        "locations":[{
-                            "line":1,
-                            "column":16
-                        }]
-                    }]
-                }"#
-                .into(),
-                WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT
-            )
-        ];
+        async fn test_invalid_json<T: WsIntegration>(integration: &T) {
+            let messages = vec![
+                WsIntegrationMessage::Send(json!({"whatever": "invalid value"})),
+                WsIntegrationMessage::Expect(
+                    json!({
+                        "type": "connection_error",
+                        "payload": {
+                            "message": "`serde` error: missing field `type` at line 1 column 28",
+                        },
+                    }),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+            ];
 
-        integration.run(messages).await.unwrap();
+            integration.run(messages).await.unwrap();
+        }
+
+        async fn test_invalid_query<T: WsIntegration>(integration: &T) {
+            let messages = vec![
+                WsIntegrationMessage::Send(json!({
+                    "type": "connection_init",
+                    "payload": {},
+                })),
+                WsIntegrationMessage::Expect(
+                    json!({"type": "connection_ack"}),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+                WsIntegrationMessage::Expect(
+                    json!({"type": "ka"}),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+                WsIntegrationMessage::Send(json!({
+                    "id": "1",
+                    "type": "start",
+                    "payload": {
+                        "variables": {},
+                        "extensions": {},
+                        "operationName": null,
+                        "query": "subscription { asyncHuman }",
+                    },
+                })),
+                WsIntegrationMessage::Expect(
+                    json!({
+                        "type": "error",
+                        "id": "1",
+                        "payload": [{
+                            "message": "Field \"asyncHuman\" of type \"Human!\" must have a selection \
+                                        of subfields. Did you mean \"asyncHuman { ... }\"?",
+                            "locations": [{
+                                "line": 1,
+                                "column": 16,
+                            }],
+                        }],
+                    }),
+                    WS_INTEGRATION_EXPECT_DEFAULT_TIMEOUT,
+                ),
+            ];
+
+            integration.run(messages).await.unwrap();
+        }
     }
 }

--- a/juniper_actix/CHANGELOG.md
+++ b/juniper_actix/CHANGELOG.md
@@ -13,13 +13,13 @@ All user visible changes to `juniper_actix` crate will be documented in this fil
 - Switched to 4.0 version of [`actix-web` crate] and its ecosystem. ([#1034])
 - Switched to 0.16 version of [`juniper` crate].
 - Switched to 0.4 version of [`juniper_graphql_ws` crate].
-- Renamed `subscriptions::subscriptions_handler()` as `subscriptions::graphql_ws_handler()` for processing the [legacy `graphql-ws` GraphQL over WebSocket Protocol][graphql-ws]. ([#1191])
+- Switched to 0.2 version of [`actix-ws` crate]. ([#1197])
+- Renamed `subscriptions::subscriptions_handler()` as `subscriptions::graphql_ws_handler()` for processing the [legacy `graphql-ws` GraphQL over WebSocket Protocol][graphql-ws]. ([#1191], [#1197])
 
 ### Added
 
-- `subscriptions::graphql_transport_ws_handler()` allowing to process the [new `graphql-transport-ws` GraphQL over WebSocket Protocol][graphql-transport-ws]. ([#1191])
-- `subscriptions::ws_handler()` with auto-selection between the [legacy `graphql-ws` GraphQL over WebSocket Protocol][graphql-ws] and the [new `graphql-transport-ws` GraphQL over WebSocket Protocol][graphql-transport-ws], based on the `Sec-Websocket-Protocol` HTTP header value. ([#1191])
-- Support of 0.14 version of [`actix` crate]. ([#1189])
+- `subscriptions::graphql_transport_ws_handler()` allowing to process the [new `graphql-transport-ws` GraphQL over WebSocket Protocol][graphql-transport-ws]. ([#1191], [#1197])
+- `subscriptions::ws_handler()` with auto-selection between the [legacy `graphql-ws` GraphQL over WebSocket Protocol][graphql-ws] and the [new `graphql-transport-ws` GraphQL over WebSocket Protocol][graphql-transport-ws], based on the `Sec-Websocket-Protocol` HTTP header value. ([#1191], [#1197])
 
 ### Fixed
 
@@ -28,8 +28,8 @@ All user visible changes to `juniper_actix` crate will be documented in this fil
 [#1034]: /../../pull/1034
 [#1169]: /../../issues/1169
 [#1187]: /../../pull/1187
-[#1189]: /../../pull/1189
 [#1191]: /../../pull/1191
+[#1197]: /../../pull/1197
 
 
 
@@ -43,6 +43,7 @@ See [old CHANGELOG](/../../blob/juniper_actix-v0.4.0/juniper_actix/CHANGELOG.md)
 
 [`actix` crate]: https://docs.rs/actix
 [`actix-web` crate]: https://docs.rs/actix-web
+[`actix-ws` crate]: https://docs.rs/actix-ws
 [`juniper` crate]: https://docs.rs/juniper
 [`juniper_graphql_ws` crate]: https://docs.rs/juniper_graphql_ws
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/juniper_actix/Cargo.toml
+++ b/juniper_actix/Cargo.toml
@@ -19,18 +19,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-subscriptions = [
-    "dep:actix",
-    "dep:actix-web-actors",
-    "dep:juniper_graphql_ws",
-    "dep:tokio",
-]
+subscriptions = ["dep:actix-ws", "dep:juniper_graphql_ws"]
 
 [dependencies]
-actix = { version = ">=0.12, <=0.14", optional = true }
 actix-http = "3.2"
 actix-web = "4.4"
-actix-web-actors = { version = "4.1", optional = true }
+actix-ws = { version = "0.2", optional = true }
 anyhow = "1.0.47"
 futures = "0.3.22"
 juniper = { version = "0.16.0-dev", path = "../juniper", default-features = false }
@@ -39,7 +33,6 @@ http = "0.2.4"
 serde = { version = "1.0.122", features = ["derive"] }
 serde_json = "1.0.18"
 thiserror = "1.0"
-tokio = { version = "1.0", features = ["sync"], optional = true }
 
 [dev-dependencies]
 actix-cors = "0.6"

--- a/juniper_graphql_ws/CHANGELOG.md
+++ b/juniper_graphql_ws/CHANGELOG.md
@@ -16,7 +16,7 @@ All user visible changes to `juniper_graphql_ws` crate will be documented in thi
 
 ### Added
 
-- `graphql_transport_ws` module implementing [`graphql-transport-ws` GraphQL over WebSocket Protocol][proto-5.14.0] as of 5.14.0 version of [`graphql-ws` npm package] behind `graphql-transport-ws` Cargo feature. ([#1158], [#1191], [#1196], [#1022])
+- `graphql_transport_ws` module implementing [`graphql-transport-ws` GraphQL over WebSocket Protocol][proto-5.14.0] as of 5.14.0 version of [`graphql-ws` npm package] behind `graphql-transport-ws` Cargo feature. ([#1158], [#1191], [#1196], [#1197], [#1022])
 
 ### Changed
 
@@ -26,6 +26,7 @@ All user visible changes to `juniper_graphql_ws` crate will be documented in thi
 [#1158]: /../../pull/1158
 [#1191]: /../../pull/1191
 [#1196]: /../../pull/1196
+[#1197]: /../../pull/1197
 [proto-5.14.0]: https://github.com/enisdenjo/graphql-ws/blob/v5.14.0/PROTOCOL.md
 [proto-legacy]: https://github.com/apollographql/subscriptions-transport-ws/blob/v0.11.0/PROTOCOL.md
 

--- a/juniper_warp/src/lib.rs
+++ b/juniper_warp/src/lib.rs
@@ -392,8 +392,8 @@ pub mod subscriptions {
     impl fmt::Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
-                Self::Warp(e) => write!(f, "warp error: {e}"),
-                Self::Serde(e) => write!(f, "serde error: {e}"),
+                Self::Warp(e) => write!(f, "`warp` error: {e}"),
+                Self::Serde(e) => write!(f, "`serde` error: {e}"),
             }
         }
     }


### PR DESCRIPTION
Follows #1191, #1186


## Motivation

See https://github.com/graphql-rust/juniper/issues/1186#issuecomment-1730323445:
> 2. Reimplement `juniper_actix::subscritions` via actorless `actix-ws` crate instead of the current `actix-web-actors::ws` one. The whole thing with actors cooperates very badly with `juniper_graphql_ws` state machine, introducing too excessive polling, which leads to panics and abnormal WebSocket closures instead of normal ones. It also gives a feeling of fighting with actors, trying to pair them with `Stream`/`Sink`, instead of easing it. So, the actorless `actix-ws` crate should go just fine, as we have in the `juniper_warp` crate.

Also, WebSocket connections are not closed normally in `juniper_actix`, due to panics:
<img width="653" alt="Screenshot 2023-10-24 at 15 58 48" src="https://github.com/graphql-rust/juniper/assets/7114909/a0b06dc0-177e-400e-8a60-89d9225efdee">
<img width="1200" alt="Screenshot 2023-10-24 at 15 59 41" src="https://github.com/graphql-rust/juniper/assets/7114909/34fa8615-5a56-43f6-8184-54aa68188505">




## Solution

Get rid of `actix-web-actors::ws`  and use  `actix-ws` crate instead.

Now, WebSocket connections are closing as expected:
<img width="584" alt="Screenshot 2023-10-24 at 16 02 24" src="https://github.com/graphql-rust/juniper/assets/7114909/d3728450-2530-472c-b81f-6c138df24d22">
<img width="1198" alt="Screenshot 2023-10-24 at 16 02 44" src="https://github.com/graphql-rust/juniper/assets/7114909/2a9114be-5204-4353-a1c2-4d6770311771">




## Additionally

- Fixes some issues with the `graphql-transport-ws` implementation, regarding panicking for edge cases in polling.
- Adds `juniper::http` integration tests for `graphql-transport-ws` as well.