### PR TITLE
Avoid an unecessary clone in `LookAheadMethods::children`

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -52,6 +52,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
     - Removed `scalar-naivetime` [Cargo feature].
 - Removed lifetime parameter from `ParseError`, `GraphlQLError`, `GraphQLBatchRequest` and `GraphQLRequest`. ([#1081], [#528])
 - Upgraded [GraphiQL] to 3.0.8 version (requires new [`graphql-transport-ws` GraphQL over WebSocket Protocol] integration on server, see `juniper_warp/examples/subscription.rs`). ([#1188], [#1193], [#1203])
+- Made `LookAheadMethods::children()` method to return slice instead of `Vec`. ([#1200])
 
 ### Added
 
@@ -128,6 +129,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1190]: /../../pull/1190
 [#1193]: /../../pull/1193
 [#1199]: /../../pull/1199
+[#1200]: /../../pull/1200
 [#1203]: /../../pull/1203
 [ba1ed85b]: /../../commit/ba1ed85b3c3dd77fbae7baf6bc4e693321a94083
 [CVE-2022-31173]: /../../security/advisories/GHSA-4rx6-g5vg-5f3j

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -364,7 +364,9 @@ pub trait LookAheadMethods<'sel, S> {
     fn child_names(&self) -> Vec<&'sel str>;
 
     /// Get an iterator over the children for the current selection
-    fn children(&self) -> Vec<&Self>;
+    fn children(&self) -> &[Self]
+    where
+        Self: Sized;
 
     /// Get the parent type in case there is any for this selection
     fn applies_for(&self) -> Option<&str>;
@@ -395,8 +397,8 @@ impl<'a, S> LookAheadMethods<'a, S> for ConcreteLookAheadSelection<'a, S> {
         !self.children.is_empty()
     }
 
-    fn children(&self) -> Vec<&Self> {
-        self.children.iter().collect()
+    fn children(&self) -> &[Self] {
+        &self.children
     }
 
     fn applies_for(&self) -> Option<&str> {
@@ -432,8 +434,8 @@ impl<'a, S> LookAheadMethods<'a, S> for LookAheadSelection<'a, S> {
         !self.children.is_empty()
     }
 
-    fn children(&self) -> Vec<&Self> {
-        self.children.iter().collect()
+    fn children(&self) -> &[Self] {
+        &self.children
     }
 
     fn applies_for(&self) -> Option<&str> {


### PR DESCRIPTION
Depending on how the trait will be used in the future this might not be a good idear.
Another possibility would be to return `impl Iterator<Item=&Self>` this is already possible in nightly and was stablized two weeks ago https://github.com/rust-lang/rust/pull/115822