### PR TITLE
fix: bump bson version from 2.4 to 2.7

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -49,7 +49,7 @@ uuid = ["dep:uuid"]
 anyhow = { version = "1.0.47", default-features = false, optional = true }
 async-trait = "0.1.39"
 bigdecimal = { version = "0.4", optional = true }
-bson = { version = "2.4", features = ["chrono-0_4"], optional = true }
+bson = { version = "2.7", features = ["chrono-0_4"], optional = true }
 chrono = { version = "0.4.30", features = ["alloc"], default-features = false, optional = true }
 chrono-tz = { version = "0.8", default-features = false, optional = true }
 fnv = "1.0.3"


### PR DESCRIPTION
Was exploring the mongodb driver in rust with juniper, i was trying to retrieve the _id of the mongodb with ```ObjectId```, found out that the traits in this juniper crate were implemented for the bson of version 2.4 and there in mongodb it's 2.7 that we are allowed to use, so to keep juniper compatible with the latest version of mongodb, juniper's bson crate version must be updated.