### PR TITLE
Spanned arguments

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -53,6 +53,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - Removed lifetime parameter from `ParseError`, `GraphlQLError`, `GraphQLBatchRequest` and `GraphQLRequest`. ([#1081], [#528])
 - Upgraded [GraphiQL] to 3.0.9 version (requires new [`graphql-transport-ws` GraphQL over WebSocket Protocol] integration on server, see `juniper_warp/examples/subscription.rs`). ([#1188], [#1193], [#1204])
 - Made `LookAheadMethods::children()` method to return slice instead of `Vec`. ([#1200])
+- Added `Spanning` to `Arguments` and `LookAheadArguments`. ([#1206])
 
 ### Added
 
@@ -131,6 +132,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1199]: /../../pull/1199
 [#1200]: /../../pull/1200
 [#1204]: /../../pull/1204
+[#1206]: /../../pull/1206
 [ba1ed85b]: /../../commit/ba1ed85b3c3dd77fbae7baf6bc4e693321a94083
 [CVE-2022-31173]: /../../security/advisories/GHSA-4rx6-g5vg-5f3j
 

--- a/juniper/src/parser/utils.rs
+++ b/juniper/src/parser/utils.rs
@@ -90,6 +90,15 @@ impl<T> Spanning<T> {
         }
     }
 
+    /// Convert the item to a reference
+    pub fn as_ref(&self) -> Spanning<&T> {
+        Spanning {
+            item: &self.item,
+            start: self.start,
+            end: self.end,
+        }
+    }
+
     /// Modifies the contents of the spanned item in case `f` returns [`Some`],
     /// or returns [`None`] otherwise.
     pub fn and_then<O, F: Fn(T) -> Option<O>>(self, f: F) -> Option<Spanning<O>> {

--- a/juniper/src/schema/meta.rs
+++ b/juniper/src/schema/meta.rs
@@ -12,7 +12,7 @@ use crate::{
     schema::model::SchemaType,
     types::base::TypeKind,
     value::{DefaultScalarValue, ParseScalarValue},
-    FieldError,
+    FieldError, Spanning,
 };
 
 /// Whether an item is deprecated, with context.
@@ -202,7 +202,7 @@ pub struct Argument<'a, S> {
     #[doc(hidden)]
     pub arg_type: Type<'a>,
     #[doc(hidden)]
-    pub default_value: Option<InputValue<S>>,
+    pub default_value: Option<Spanning<InputValue<S>>>,
 }
 
 impl<'a, S> Argument<'a, S> {
@@ -739,7 +739,7 @@ impl<'a, S> Argument<'a, S> {
     /// Overwrites any previously set default value.
     #[must_use]
     pub fn default_value(mut self, val: InputValue<S>) -> Self {
-        self.default_value = Some(val);
+        self.default_value = Some(Spanning::unlocated(val));
         self
     }
 }

--- a/juniper/src/schema/schema.rs
+++ b/juniper/src/schema/schema.rs
@@ -386,7 +386,7 @@ impl<'a, S: ScalarValue + 'a> Argument<'a, S> {
 
     #[graphql(name = "defaultValue")]
     fn default_value_(&self) -> Option<String> {
-        self.default_value.as_ref().map(ToString::to_string)
+        self.default_value.as_ref().map(|v| v.item.to_string())
     }
 }
 

--- a/juniper/src/schema/translate/graphql_parser.rs
+++ b/juniper/src/schema/translate/graphql_parser.rs
@@ -89,7 +89,7 @@ impl GraphQLParserTranslator {
             default_value: input
                 .default_value
                 .as_ref()
-                .map(|x| GraphQLParserTranslator::translate_value(x)),
+                .map(|x| GraphQLParserTranslator::translate_value(&x.item)),
             directives: vec![],
         }
     }

--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -245,7 +245,12 @@ where
                         m.item
                             .iter()
                             .filter_map(|(k, v)| {
-                                v.item.clone().into_const(exec_vars).map(|v| (k.item, v))
+                                let value = v.item.clone().into_const(exec_vars)?;
+                                Some((k.item, Spanning {
+                                    item: value,
+                                    start: v.start,
+                                    end: v.end,
+                                }))
                             })
                             .collect()
                     }),

--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -246,11 +246,14 @@ where
                             .iter()
                             .filter_map(|(k, v)| {
                                 let value = v.item.clone().into_const(exec_vars)?;
-                                Some((k.item, Spanning {
-                                    item: value,
-                                    start: v.start,
-                                    end: v.end,
-                                }))
+                                Some((
+                                    k.item,
+                                    Spanning {
+                                        item: value,
+                                        start: v.start,
+                                        end: v.end,
+                                    },
+                                ))
                             })
                             .collect()
                     }),

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -68,13 +68,13 @@ pub enum TypeKind {
 /// Field argument container
 #[derive(Debug)]
 pub struct Arguments<'a, S = DefaultScalarValue> {
-    args: Option<IndexMap<&'a str, InputValue<S>>>,
+    args: Option<IndexMap<&'a str, Spanning<InputValue<S>>>>,
 }
 
 impl<'a, S> Arguments<'a, S> {
     #[doc(hidden)]
     pub fn new(
-        mut args: Option<IndexMap<&'a str, InputValue<S>>>,
+        mut args: Option<IndexMap<&'a str, Spanning<InputValue<S>>>>,
         meta_args: &'a Option<Vec<Argument<S>>>,
     ) -> Self
     where
@@ -117,9 +117,17 @@ impl<'a, S> Arguments<'a, S> {
         self.args
             .as_ref()
             .and_then(|args| args.get(name))
+            .map(|spanning| &spanning.item)
             .map(InputValue::convert)
             .transpose()
             .map_err(IntoFieldError::into_field_error)
+    }
+
+    /// Gets a direct reference to the spanned argument input value
+    pub fn get_input_value(&self, name: &str) -> Option<&Spanning<InputValue<S>>> {
+        self.args
+            .as_ref()
+            .and_then(|args| args.get(name))
     }
 }
 
@@ -473,7 +481,12 @@ where
                             m.item
                                 .iter()
                                 .filter_map(|(k, v)| {
-                                    v.item.clone().into_const(exec_vars).map(|v| (k.item, v))
+                                    let value = v.item.clone().into_const(exec_vars)?;
+                                    Some((k.item, Spanning {
+                                        item: value,
+                                        start: v.start,
+                                        end: v.end,
+                                    }))
                                 })
                                 .collect()
                         }),

--- a/juniper/src/types/base.rs
+++ b/juniper/src/types/base.rs
@@ -125,9 +125,7 @@ impl<'a, S> Arguments<'a, S> {
 
     /// Gets a direct reference to the spanned argument input value
     pub fn get_input_value(&self, name: &str) -> Option<&Spanning<InputValue<S>>> {
-        self.args
-            .as_ref()
-            .and_then(|args| args.get(name))
+        self.args.as_ref().and_then(|args| args.get(name))
     }
 }
 
@@ -482,11 +480,14 @@ where
                                 .iter()
                                 .filter_map(|(k, v)| {
                                     let value = v.item.clone().into_const(exec_vars)?;
-                                    Some((k.item, Spanning {
-                                        item: value,
-                                        start: v.start,
-                                        end: v.end,
-                                    }))
+                                    Some((
+                                        k.item,
+                                        Spanning {
+                                            item: value,
+                                            start: v.start,
+                                            end: v.end,
+                                        },
+                                    ))
                                 })
                                 .collect()
                         }),

--- a/juniper/src/types/subscriptions.rs
+++ b/juniper/src/types/subscriptions.rs
@@ -317,7 +317,12 @@ where
                         m.item
                             .iter()
                             .filter_map(|(k, v)| {
-                                v.item.clone().into_const(exec_vars).map(|v| (k.item, v))
+                                let value = v.item.clone().into_const(exec_vars)?;
+                                Some((k.item, Spanning {
+                                    item: value,
+                                    start: v.start,
+                                    end: v.end,
+                                }))
                             })
                             .collect()
                     }),

--- a/juniper/src/types/subscriptions.rs
+++ b/juniper/src/types/subscriptions.rs
@@ -318,11 +318,14 @@ where
                             .iter()
                             .filter_map(|(k, v)| {
                                 let value = v.item.clone().into_const(exec_vars)?;
-                                Some((k.item, Spanning {
-                                    item: value,
-                                    start: v.start,
-                                    end: v.end,
-                                }))
+                                Some((
+                                    k.item,
+                                    Spanning {
+                                        item: value,
+                                        start: v.start,
+                                        end: v.end,
+                                    },
+                                ))
                             })
                             .collect()
                     }),


### PR DESCRIPTION
This change improves diagnostics when performing manual/domain-specific post-validation of arguments using `LookAheadArguments`. In the case of an error, the produced error message may be able to refer to the exact position in the problematic GraphQL arguments.

I figure this breaking change can be seriously considered, as Juniper looks set for a breaking release anyway.