### PR TITLE
fix: Three tests because of updated compiler(?)

### DIFF
--- a/tests/codegen/fail/interface/trait/argument_non_input_type.stderr
+++ b/tests/codegen/fail/interface/trait/argument_non_input_type.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
              <uuid::Uuid as IsInputType<__S>>
              <url::Url as IsInputType<__S>>
              <bson::datetime::DateTime as IsInputType<__S>>
-             <juniper::schema::model::DirectiveLocation as IsInputType<__S>>
+             <bson::oid::ObjectId as IsInputType<__S>>
            and $N others
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
@@ -29,7 +29,7 @@ error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
             <uuid::Uuid as FromInputValue<__S>>
             <url::Url as FromInputValue<__S>>
             <bson::datetime::DateTime as FromInputValue<__S>>
-            <juniper::schema::model::DirectiveLocation as FromInputValue<__S>>
+            <bson::oid::ObjectId as FromInputValue<__S>>
           and $N others
 note: required by a bound in `Registry::<'r, S>::arg`
  --> $WORKSPACE/juniper/src/executor/mod.rs

--- a/tests/codegen/fail/object/argument_non_input_type.stderr
+++ b/tests/codegen/fail/object/argument_non_input_type.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
              <uuid::Uuid as IsInputType<__S>>
              <url::Url as IsInputType<__S>>
              <bson::datetime::DateTime as IsInputType<__S>>
-             <juniper::schema::model::DirectiveLocation as IsInputType<__S>>
+             <bson::oid::ObjectId as IsInputType<__S>>
            and $N others
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
@@ -29,7 +29,7 @@ error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
              <uuid::Uuid as FromInputValue<__S>>
              <url::Url as FromInputValue<__S>>
              <bson::datetime::DateTime as FromInputValue<__S>>
-             <juniper::schema::model::DirectiveLocation as FromInputValue<__S>>
+             <bson::oid::ObjectId as FromInputValue<__S>>
            and $N others
 note: required by a bound in `Registry::<'r, S>::arg`
   --> $WORKSPACE/juniper/src/executor/mod.rs
@@ -55,6 +55,6 @@ error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
              <uuid::Uuid as FromInputValue<__S>>
              <url::Url as FromInputValue<__S>>
              <bson::datetime::DateTime as FromInputValue<__S>>
-             <juniper::schema::model::DirectiveLocation as FromInputValue<__S>>
+             <bson::oid::ObjectId as FromInputValue<__S>>
            and $N others
    = note: this error originates in the attribute macro `graphql_object` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/codegen/fail/subscription/argument_non_input_type.stderr
+++ b/tests/codegen/fail/subscription/argument_non_input_type.stderr
@@ -20,7 +20,7 @@ error[E0277]: the trait bound `ObjA: IsInputType<__S>` is not satisfied
              <uuid::Uuid as IsInputType<__S>>
              <url::Url as IsInputType<__S>>
              <bson::datetime::DateTime as IsInputType<__S>>
-             <juniper::schema::model::DirectiveLocation as IsInputType<__S>>
+             <bson::oid::ObjectId as IsInputType<__S>>
            and $N others
 
 error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
@@ -37,7 +37,7 @@ error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
              <uuid::Uuid as FromInputValue<__S>>
              <url::Url as FromInputValue<__S>>
              <bson::datetime::DateTime as FromInputValue<__S>>
-             <juniper::schema::model::DirectiveLocation as FromInputValue<__S>>
+             <bson::oid::ObjectId as FromInputValue<__S>>
            and $N others
 note: required by a bound in `Registry::<'r, S>::arg`
   --> $WORKSPACE/juniper/src/executor/mod.rs
@@ -63,6 +63,6 @@ error[E0277]: the trait bound `ObjA: FromInputValue<__S>` is not satisfied
              <uuid::Uuid as FromInputValue<__S>>
              <url::Url as FromInputValue<__S>>
              <bson::datetime::DateTime as FromInputValue<__S>>
-             <juniper::schema::model::DirectiveLocation as FromInputValue<__S>>
+             <bson::oid::ObjectId as FromInputValue<__S>>
            and $N others
    = note: this error originates in the attribute macro `graphql_subscription` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
In #1212 there are three test failures unrelated to the change. Unsure why they fail, but my guess is that a newer rustc has a change in error reporting.
