### PR TITLE
Implement `Clone` and `PartialEq` for `GraphQLResponse` (#103)

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -71,6 +71,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - `LookAheadMethods::field_original_name()` and `LookAheadMethods::field_alias()` methods. ([#1199])
 - [`anyhow` crate] integration behind `anyhow` and `backtrace` [Cargo feature]s. ([#1215], [#988])
 - `RootNode::disable_introspection()` applying additional `validation::rules::disable_introspection`, and `RootNode::enable_introspection()` reverting it. ([#1227], [#456])
+- `Clone` and `PartialEq` implementations for `GraphQLResponse`. ([#1228], [#103])
 
 ### Changed
 
@@ -88,6 +89,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - Incorrect error when explicit `null` provided for `null`able list input parameter. ([#1086], [#1085])
 - Stack overflow on nested GraphQL fragments. ([CVE-2022-31173])
 
+[#103]: /../../issues/103
 [#113]: /../../issues/113
 [#456]: /../../issues/456
 [#503]: /../../issues/503
@@ -143,6 +145,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1215]: /../../pull/1215
 [#1221]: /../../pull/1221
 [#1227]: /../../pull/1227
+[#1228]: /../../pull/1228
 [ba1ed85b]: /../../commit/ba1ed85b3c3dd77fbae7baf6bc4e693321a94083
 [CVE-2022-31173]: /../../security/advisories/GHSA-4rx6-g5vg-5f3j
 

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -87,7 +87,7 @@ where
 ///
 /// All execution errors contain the source position in the query of the field
 /// that failed to resolve. It also contains the field stack.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ExecutionError<S> {
     location: SourcePosition,
     path: Vec<String>,

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -163,7 +163,7 @@ where
 /// This struct implements Serialize, so you can simply serialize this
 /// to JSON and send it over the wire. Use the `is_ok` method to determine
 /// whether to send a 200 or 400 HTTP status code.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GraphQLResponse<S = DefaultScalarValue>(
     Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError>,
 );

--- a/juniper/src/http/mod.rs
+++ b/juniper/src/http/mod.rs
@@ -163,7 +163,7 @@ where
 /// This struct implements Serialize, so you can simply serialize this
 /// to JSON and send it over the wire. Use the `is_ok` method to determine
 /// whether to send a 200 or 400 HTTP status code.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GraphQLResponse<S = DefaultScalarValue>(
     Result<(Value<S>, Vec<ExecutionError<S>>), GraphQLError>,
 );

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -98,7 +98,7 @@ pub use crate::{
 
 /// An error that prevented query execution
 #[allow(missing_docs)]
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GraphQLError {
     ParseError(Spanning<ParseError>),
     ValidationError(Vec<RuleError>),

--- a/juniper/src/parser/lexer.rs
+++ b/juniper/src/parser/lexer.rs
@@ -51,7 +51,7 @@ pub enum Token<'a> {
 }
 
 /// Error when tokenizing the input source
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LexerError {
     /// An unknown character was found
     ///

--- a/juniper/src/parser/parser.rs
+++ b/juniper/src/parser/parser.rs
@@ -5,7 +5,7 @@ use smartstring::alias::String;
 use crate::parser::{Lexer, LexerError, Spanning, Token};
 
 /// Error while parsing a GraphQL query
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParseError {
     /// An unexpected token occurred in the source
     // TODO: Previously was `Token<'a>`.

--- a/juniper/src/validation/context.rs
+++ b/juniper/src/validation/context.rs
@@ -10,7 +10,7 @@ use crate::schema::{meta::MetaType, model::SchemaType};
 use crate::parser::SourcePosition;
 
 /// Query validation error
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RuleError {
     locations: Vec<SourcePosition>,
     message: String,


### PR DESCRIPTION
Resolves #103 

Provides `Clone` and `PartialEq` implementations for a `GraphQLResponse`, so it can be tossed around.