### PR TITLE
refactor: Use auto_enums instead of futures-enum

### DIFF
--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -49,13 +49,13 @@ uuid = ["dep:uuid"]
 [dependencies]
 anyhow = { version = "1.0.47", optional = true }
 async-trait = "0.1.39"
+auto_enums = "0.8"
 bigdecimal = { version = "0.4", optional = true }
 bson = { version = "2.4", features = ["chrono-0_4"], optional = true }
 chrono = { version = "0.4.30", features = ["alloc"], default-features = false, optional = true }
 chrono-tz = { version = "0.8", default-features = false, optional = true }
 fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
-futures-enum = { version = "0.1.12", default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
 juniper_codegen = { version = "0.16.0-dev", path = "../juniper_codegen" }

--- a/juniper/src/types/async_await.rs
+++ b/juniper/src/types/async_await.rs
@@ -1,5 +1,7 @@
 use std::future;
 
+use auto_enums::enum_derive;
+
 use crate::{
     ast::Selection,
     executor::{ExecutionResult, Executor},
@@ -181,7 +183,7 @@ where
 {
     use futures::stream::{FuturesOrdered, StreamExt as _};
 
-    #[derive(futures_enum::Future)]
+    #[enum_derive(Future)]
     enum AsyncValueFuture<A, B, C, D> {
         Field(A),
         FragmentSpread(B),


### PR DESCRIPTION
`auto_enums` is from the same author as `futures-enum` ([taiki-e](https://github.com/taiki-e)), and `auto_enums` appears more up-to-date. But the most important thing is that this gets rid of `syn 1` from juniper's non-dev dependencies.