### PR TITLE
Add support for `Request<T>` where `T` is a type that implements `hyper::body::Body` trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,17 +153,17 @@ jobs:
           - juniper_graphql_ws
           - juniper_actix
           - juniper_axum
-          - juniper_hyper
+          #- juniper_hyper
           - juniper_rocket
           - juniper_warp
         os:
           - ubuntu
           - macOS
           - windows
-        #include:
-        #  - { msrv: "1.75.0", crate: "juniper_actix", os: "ubuntu" }
-        #  - { msrv: "1.75.0", crate: "juniper_actix", os: "macOS" }
-        #  - { msrv: "1.75.0", crate: "juniper_actix", os: "windows" }
+        include:
+          - { msrv: "1.79.0", crate: "juniper_hyper", os: "ubuntu" }
+          - { msrv: "1.79.0", crate: "juniper_hyper", os: "macOS" }
+          - { msrv: "1.79.0", crate: "juniper_hyper", os: "windows" }
     runs-on: ${{ matrix.os }}-latest
     steps:
       - uses: actions/checkout@v4

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -10,9 +10,11 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 
 ### BC Breaks
 
-- Bumped up [MSRV] to 1.75. ([#1272])
+- Bumped up [MSRV] to 1.79. ([#1263])
+- Made `hyper::Request` in `graphql()` and `graphql_sync()` functions generic over `T: hyper::body::Body`. ([#1263], [#1102])
 
-[#1272]: /../../pull/1272
+[#1102]: /../../issues/1102
+[#1263]: /../../pull/1263
 
 
 
@@ -25,12 +27,10 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 - Switched to 0.16 version of [`juniper` crate].
 - Switched to 1 version of [`hyper` crate]. ([#1217])
 - Changed return type of all functions from `Response<Body>` to `Response<String>`. ([#1101], [#1096])
-- Add support for `Request<T>` where `T` is a type that implements `hyper::body::Body` trait. ([#1263])
 
 [#1096]: /../../issues/1096
 [#1101]: /../../pull/1101
 [#1217]: /../../pull/1217
-[#1263]: /../../pull/1263
 
 
 

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -14,10 +14,12 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 - Switched to 0.16 version of [`juniper` crate].
 - Switched to 1 version of [`hyper` crate]. ([#1217])
 - Changed return type of all functions from `Response<Body>` to `Response<String>`. ([#1101], [#1096])
+- Add support for `Request<T>` where `T` is a type that implements `hyper::body::Body` trait. ([#1263])
 
 [#1096]: /../../issues/1096
 [#1101]: /../../pull/1101
 [#1217]: /../../pull/1217
+[#1263]: /../../pull/1263
 
 
 

--- a/juniper_hyper/CHANGELOG.md
+++ b/juniper_hyper/CHANGELOG.md
@@ -11,7 +11,7 @@ All user visible changes to `juniper_hyper` crate will be documented in this fil
 ### BC Breaks
 
 - Bumped up [MSRV] to 1.79. ([#1263])
-- Made `hyper::Request` in `graphql()` and `graphql_sync()` functions generic over `T: hyper::body::Body`. ([#1263], [#1102])
+- Made `hyper::Request` in `graphql()` and `graphql_sync()` functions generic over `B: hyper::body::Body`. ([#1263], [#1102])
 
 [#1102]: /../../issues/1102
 [#1263]: /../../pull/1263

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "juniper_hyper"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.79"
 description = "`juniper` GraphQL integration with `hyper`."
 license = "BSD-2-Clause"
 authors = [

--- a/juniper_hyper/README.md
+++ b/juniper_hyper/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/juniper_hyper.svg?maxAge=2592000)](https://crates.io/crates/juniper_hyper)
 [![Documentation](https://docs.rs/juniper_hyper/badge.svg)](https://docs.rs/juniper_hyper)
 [![CI](https://github.com/graphql-rust/juniper/workflows/CI/badge.svg?branch=master "CI")](https://github.com/graphql-rust/juniper/actions?query=workflow%3ACI+branch%3Amaster)
-[![Rust 1.75+](https://img.shields.io/badge/rustc-1.75+-lightgray.svg "Rust 1.75+")](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
+[![Rust 1.79+](https://img.shields.io/badge/rustc-1.79+-lightgray.svg "Rust 1.79+")](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html)
 
 - [Changelog](https://github.com/graphql-rust/juniper/blob/juniper_hyper-v0.9.0/juniper_hyper/CHANGELOG.md)
 

--- a/juniper_hyper/src/lib.rs
+++ b/juniper_hyper/src/lib.rs
@@ -401,12 +401,7 @@ mod tests {
         }
     }
 
-    static mut PORT: u16 = 3001;
-    async fn run_hyper_integration(is_sync: bool, is_custom_type: bool) {
-        let port = unsafe {
-            PORT = PORT.wrapping_add(1);
-            PORT
-        } + if is_sync { 1000 } else { 0 };
+    async fn run_hyper_integration(port: u16, is_sync: bool, is_custom_type: bool) {
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
 
         let db = Arc::new(Database::new());
@@ -509,23 +504,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_hyper_integration() {
-        run_hyper_integration(false, false).await
+        run_hyper_integration(3000, false, false).await
     }
 
     #[tokio::test]
     async fn test_sync_hyper_integration() {
-        run_hyper_integration(true, false).await
+        run_hyper_integration(3001, true, false).await
     }
 
     #[tokio::test]
     /// run test for a custom request type - `Request<Vec<u8>>`
     async fn test_custom_hyper_integration() {
-        run_hyper_integration(false, false).await
+        run_hyper_integration(3002, false, false).await
     }
 
     #[tokio::test]
     /// run test for a custom request type - `Request<Vec<u8>>` in sync mode
     async fn test_custom_sync_hyper_integration() {
-        run_hyper_integration(true, true).await
+        run_hyper_integration(3003, true, true).await
     }
 }


### PR DESCRIPTION
Should resolve #1102 

> ## Problem
> Attempts to use any other hyper request type aside `Request<hyper::body::Incoming>` fails with a compile-time error of type mismatch

> ## Solution
> Add generic support for valid supported hyper `Request` or any custom `Request` that has a body which implements `hyper::body::Body`
> 
> ## Checklist
> * [x]  Tests are added
> * [x]  CHANGELOG entry is added
> * [x]  ~Documentation is updated~ (not required)

