### PR TITLE
Add integration for Jiff date/time types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           - { feature: chrono-clock, crate: juniper }
           - { feature: chrono-tz, crate: juniper }
           - { feature: expose-test-schema, crate: juniper }
+          - { feature: jiff, crate: juniper }
           - { feature: rust_decimal, crate: juniper }
           - { feature: schema-language, crate: juniper }
           - { feature: time, crate: juniper }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ your Schemas automatically.
 - [url][url]
 - [chrono][chrono]
 - [chrono-tz][chrono-tz]
+- [jiff][jiff]
 - [time][time]
 - [bson][bson]
 
@@ -119,6 +120,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 [url]: https://crates.io/crates/url
 [chrono]: https://crates.io/crates/chrono
 [chrono-tz]: https://crates.io/crates/chrono-tz
+[jiff]: https://crates.io/crates/jiff
 [time]: https://crates.io/crates/time
 [bson]: https://crates.io/crates/bson
 [juniper-from-schema]: https://github.com/davidpdrsn/juniper-from-schema

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -31,6 +31,7 @@ Introduction
 - [`bigdecimal`]
 - [`bson`]
 - [`chrono`], [`chrono-tz`]
+- [`jiff`]
 - [`rust_decimal`]
 - [`time`]
 - [`url`]
@@ -63,6 +64,7 @@ Introduction
 [`bson`]: https://docs.rs/bson
 [`chrono`]: https://docs.rs/chrono
 [`chrono-tz`]: https://docs.rs/chrono-tz
+[`jiff`]: https://docs.rs/jiff
 [`juniper`]: https://docs.rs/juniper
 [`juniper_actix`]: https://docs.rs/juniper_actix
 [`juniper_axum`]: https://docs.rs/juniper_axum

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -400,6 +400,7 @@ mod date_scalar {
 | [`jiff::civil::Time`]       | [`LocalTime`]    | [`jiff`]         |
 | [`jiff::civil::DateTime`]   | `LocalDateTime`  | [`jiff`]         |
 | [`jiff::Timestamp`]         | [`DateTime`]     | [`jiff`]         |
+| [`jiff::Span`]              | [`Duration`]     | [`jiff`]         |
 | [`time::Date`]              | [`Date`]         | [`time`]         |
 | [`time::Time`]              | [`LocalTime`]    | [`time`]         |
 | [`time::PrimitiveDateTime`] | `LocalDateTime`  | [`time`]         |
@@ -426,12 +427,14 @@ mod date_scalar {
 [`Date`]: https://graphql-scalars.dev/docs/scalars/date
 [`DateTime`]: https://graphql-scalars.dev/docs/scalars/date-time
 [`Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
+[`Duration`]: https://graphql-scalars.dev/docs/scalars/duration
 [`ID`]: https://spec.graphql.org/October2021#sec-ID
 [`jiff`]: https://docs.rs/jiff
 [`jiff::civil::Date`]: https://docs.rs/jiff/latest/jiff/civil/struct.Date.html
 [`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::civil::DateTime`]: https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html
 [`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`jiff::Span`]: https://docs.rs/jiff/latest/jiff/struct.Span.html
 [`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date
 [`LocalTime`]: https://graphql-scalars.dev/docs/scalars/local-time
 [`rust_decimal`]: https://docs.rs/rust_decimal

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -396,6 +396,10 @@ mod date_scalar {
 | [`chrono::DateTime`]        | [`DateTime`]     | [`chrono`]       |
 | [`chrono_tz::Tz`]           | `TimeZone`       | [`chrono-tz`]    |
 | [`Decimal`]                 | `Decimal`        | [`rust_decimal`] |
+| [`jiff::civil::Date`]       | [`LocalDate`]    | [`jiff`]         |
+| [`jiff::civil::Time`]       | [`LocalTime`]    | [`jiff`]         |
+| [`jiff::civil::DateTime`]   | `LocalDateTime`  | [`jiff`]         |
+| [`jiff::Timestamp`]         | [`DateTime`]     | [`jiff`]         |
 | [`time::Date`]              | [`Date`]         | [`time`]         |
 | [`time::Time`]              | [`LocalTime`]    | [`time`]         |
 | [`time::PrimitiveDateTime`] | `LocalDateTime`  | [`time`]         |
@@ -423,6 +427,12 @@ mod date_scalar {
 [`DateTime`]: https://graphql-scalars.dev/docs/scalars/date-time
 [`Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`ID`]: https://spec.graphql.org/October2021#sec-ID
+[`jiff`]: https://docs.rs/jiff
+[`jiff::civil::Date`]: https://docs.rs/jiff/latest/jiff/civil/struct.Date.html
+[`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
+[`jiff::civil::DateTime`]: https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html
+[`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date
 [`LocalTime`]: https://graphql-scalars.dev/docs/scalars/local-time
 [`rust_decimal`]: https://docs.rs/rust_decimal
 [`ScalarValue`]: https://docs.rs/juniper/0.16.1/juniper/trait.ScalarValue.html

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -431,10 +431,10 @@ mod date_scalar {
 [`ID`]: https://spec.graphql.org/October2021#sec-ID
 [`jiff`]: https://docs.rs/jiff
 [`jiff::civil::Date`]: https://docs.rs/jiff/latest/jiff/civil/struct.Date.html
-[`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::civil::DateTime`]: https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html
-[`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::Span`]: https://docs.rs/jiff/latest/jiff/struct.Span.html
+[`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
 [`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date
 [`LocalTime`]: https://graphql-scalars.dev/docs/scalars/local-time
 [`rust_decimal`]: https://docs.rs/rust_decimal

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -24,6 +24,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - Updated [GraphiQL] to [3.5.0 version](https://github.com/graphql/graphiql/blob/graphiql%403.5.0/packages/graphiql/CHANGELOG.md#350). ([#1274])
 
 [#1252]: /../../pull/1252
+[#1271]: /../../pull/1271
 [#1272]: /../../pull/1272
 [#1274]: /../../pull/1274
 
@@ -208,7 +209,6 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1237]: /../../pull/1237
 [#1239]: /../../pull/1239
 [#1246]: /../../pull/1246
-[#1271]: /../../pull/1271
 [ba1ed85b]: /../../commit/ba1ed85b3c3dd77fbae7baf6bc4e693321a94083
 [CVE-2022-31173]: /../../security/advisories/GHSA-4rx6-g5vg-5f3j
 

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -15,6 +15,10 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 
 - Upgraded [`chrono-tz` crate] integration to [0.9 version](https://github.com/chronotope/chrono-tz/releases/tag/v0.9.0). ([#1252])
 
+### Added
+
+- [`jiff` crate] integration behind `jiff` [Cargo feature]. ([#1271])
+
 ### Changed
 
 - Updated [GraphiQL] to [3.4.0 version](https://github.com/graphql/graphiql/blob/graphiql%403.4.0/packages/graphiql/CHANGELOG.md#340). ([#1269])
@@ -203,6 +207,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1237]: /../../pull/1237
 [#1239]: /../../pull/1239
 [#1246]: /../../pull/1246
+[#1271]: /../../pull/1271
 [ba1ed85b]: /../../commit/ba1ed85b3c3dd77fbae7baf6bc4e693321a94083
 [CVE-2022-31173]: /../../security/advisories/GHSA-4rx6-g5vg-5f3j
 
@@ -221,6 +226,7 @@ See [old CHANGELOG](/../../blob/juniper-v0.15.12/juniper/CHANGELOG.md).
 [`bson` crate]: https://docs.rs/bson
 [`chrono` crate]: https://docs.rs/chrono
 [`chrono-tz` crate]: https://docs.rs/chrono-tz
+[`jiff` crate]: https://docs.rs/jiff
 [`time` crate]: https://docs.rs/time
 [Cargo feature]: https://doc.rust-lang.org/cargo/reference/features.html
 [`graphql-transport-ws` GraphQL over WebSocket Protocol]: https://github.com/enisdenjo/graphql-ws/v5.14.0/PROTOCOL.md 

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -33,6 +33,7 @@ chrono = ["dep:chrono"]
 chrono-clock = ["chrono", "chrono/clock"]
 chrono-tz = ["dep:chrono-tz", "dep:regex"]
 expose-test-schema = ["dep:anyhow", "dep:serde_json"]
+jiff = ["dep:jiff"]
 js = ["chrono?/wasmbind", "time?/wasm-bindgen", "uuid?/js"]
 rust_decimal = ["dep:rust_decimal"]
 schema-language = ["dep:graphql-parser", "dep:void"]
@@ -52,6 +53,7 @@ fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
+jiff = { version = "0.1.4", optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -53,7 +53,7 @@ fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-jiff = { version = "0.1.5", optional = true }
+jiff = { version = "0.1.5", features = ["alloc"], default-features = false, optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -53,7 +53,7 @@ fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-jiff = { version = "0.1.4", optional = true }
+jiff = { version = "0.1.5", optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }

--- a/juniper/README.md
+++ b/juniper/README.md
@@ -48,6 +48,7 @@ As an exception to other [GraphQL] libraries for other languages, [Juniper] buil
 - [`bigdecimal`]
 - [`bson`]
 - [`chrono`], [`chrono-tz`]
+- [`jiff`]
 - [`rust_decimal`]
 - [`time`]
 - [`url`]
@@ -85,6 +86,7 @@ This project is licensed under [BSD 2-Clause License](https://github.com/graphql
 [`bson`]: https://docs.rs/bson
 [`chrono`]: https://docs.rs/chrono
 [`chrono-tz`]: https://docs.rs/chrono-tz
+[`jiff`]: https://docs.rs/jiff
 [`juniper_actix`]: https://docs.rs/juniper_actix
 [`juniper_axum`]: https://docs.rs/juniper_axum
 [`juniper_hyper`]: https://docs.rs/juniper_hyper

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -195,7 +195,7 @@ mod local_date_time {
 }
 
 #[cfg(test)]
-mod date_test {
+mod local_date_test {
     use crate::{graphql_input_value, FromInputValue as _, InputValue, ToInputValue as _};
 
     use super::LocalDate;
@@ -203,8 +203,8 @@ mod date_test {
     #[test]
     fn parses_correct_input() {
         for (raw, expected) in [
-            ("1996-12-19", LocalDate::new(1996, 12, 19)),
-            ("1564-01-30", LocalDate::new(1564, 01, 30)),
+            ("1996-12-19", LocalDate::constant(1996, 12, 19)),
+            ("1564-01-30", LocalDate::constant(1564, 01, 30)),
         ] {
             let input: InputValue = graphql_input_value!((raw));
             let parsed = LocalDate::from_input_value(&input);
@@ -214,7 +214,7 @@ mod date_test {
                 "failed to parse `{raw}`: {:?}",
                 parsed.unwrap_err(),
             );
-            assert_eq!(parsed.unwrap(), expected.unwrap(), "input: {raw}");
+            assert_eq!(parsed.unwrap(), expected, "input: {raw}");
         }
     }
 
@@ -245,19 +245,18 @@ mod date_test {
     fn formats_correctly() {
         for (val, expected) in [
             (
-                LocalDate::new(1996, 12, 19),
+                LocalDate::constant(1996, 12, 19),
                 graphql_input_value!("1996-12-19"),
             ),
             (
-                LocalDate::new(1564, 01, 30),
+                LocalDate::constant(1564, 01, 30),
                 graphql_input_value!("1564-01-30"),
             ),
             (
-                LocalDate::new(2020, 01, 01),
+                LocalDate::constant(2020, 01, 01),
                 graphql_input_value!("2020-01-01"),
             ),
         ] {
-            let val = val.unwrap();
             let actual: InputValue = val.to_input_value();
 
             assert_eq!(actual, expected, "on value: {val}");
@@ -274,12 +273,12 @@ mod local_time_test {
     #[test]
     fn parses_correct_input() {
         for (raw, expected) in [
-            ("14:23:43", LocalTime::new(14, 23, 43, 000_000_000)),
-            ("14:00:00", LocalTime::new(14, 00, 00, 000_000_000)),
-            ("14:00", LocalTime::new(14, 00, 00, 000_000_000)),
-            ("14:32", LocalTime::new(14, 32, 00, 000_000_000)),
-            ("14:00:00.000", LocalTime::new(14, 00, 00, 000_000_000)),
-            ("14:23:43.345", LocalTime::new(14, 23, 43, 345_000_000)),
+            ("14:23:43", LocalTime::constant(14, 23, 43, 000_000_000)),
+            ("14:00:00", LocalTime::constant(14, 00, 00, 000_000_000)),
+            ("14:00", LocalTime::constant(14, 00, 00, 000_000_000)),
+            ("14:32", LocalTime::constant(14, 32, 00, 000_000_000)),
+            ("14:00:00.000", LocalTime::constant(14, 00, 00, 000_000_000)),
+            ("14:23:43.345", LocalTime::constant(14, 23, 43, 345_000_000)),
         ] {
             let input: InputValue = graphql_input_value!((raw));
             let parsed = LocalTime::from_input_value(&input);
@@ -289,7 +288,7 @@ mod local_time_test {
                 "failed to parse `{raw}`: {:?}",
                 parsed.unwrap_err(),
             );
-            assert_eq!(parsed.unwrap(), expected.unwrap(), "input: {raw}");
+            assert_eq!(parsed.unwrap(), expected, "input: {raw}");
         }
     }
 
@@ -324,17 +323,22 @@ mod local_time_test {
     fn formats_correctly() {
         for (val, expected) in [
             (
-                LocalTime::new(1, 2, 3, 4_005_000),
+                LocalTime::constant(1, 2, 3, 4_005_000),
                 graphql_input_value!("01:02:03.004"),
             ),
-            (LocalTime::new(0, 0, 0, 0), graphql_input_value!("00:00:00")),
             (
-                LocalTime::new(12, 0, 0, 0),
+                LocalTime::constant(0, 0, 0, 0),
+                graphql_input_value!("00:00:00"),
+            ),
+            (
+                LocalTime::constant(12, 0, 0, 0),
                 graphql_input_value!("12:00:00"),
             ),
-            (LocalTime::new(1, 2, 3, 0), graphql_input_value!("01:02:03")),
+            (
+                LocalTime::constant(1, 2, 3, 0),
+                graphql_input_value!("01:02:03"),
+            ),
         ] {
-            let val = val.unwrap();
             let actual: InputValue = val.to_input_value();
 
             assert_eq!(actual, expected, "on value: {val}");
@@ -353,11 +357,11 @@ mod local_date_time_test {
         for (raw, expected) in [
             (
                 "1996-12-19 14:23:43",
-                LocalDateTime::new(1996, 12, 19, 14, 23, 43, 0).unwrap(),
+                LocalDateTime::constant(1996, 12, 19, 14, 23, 43, 0),
             ),
             (
                 "1564-01-30 14:00:00",
-                LocalDateTime::new(1564, 1, 30, 14, 00, 00, 0).unwrap(),
+                LocalDateTime::constant(1564, 1, 30, 14, 00, 00, 0),
             ),
         ] {
             let input: InputValue = graphql_input_value!((raw));
@@ -405,11 +409,11 @@ mod local_date_time_test {
     fn formats_correctly() {
         for (val, expected) in [
             (
-                LocalDateTime::new(1996, 12, 19, 0, 0, 0, 0).unwrap(),
+                LocalDateTime::constant(1996, 12, 19, 0, 0, 0, 0),
                 graphql_input_value!("1996-12-19 00:00:00"),
             ),
             (
-                LocalDateTime::new(1564, 1, 30, 14, 0, 0, 0).unwrap(),
+                LocalDateTime::constant(1564, 1, 30, 14, 0, 0, 0),
                 graphql_input_value!("1564-01-30 14:00:00"),
             ),
         ] {

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -126,10 +126,7 @@ mod local_time {
             if v.subsec_nanosecond() == 0 {
                 v.strftime(FORMAT_NO_MILLIS)
             } else {
-                // `LocalTime` scalar only allows precision up to milliseconds.
-                (*v).round(jiff::Unit::Millisecond)
-                    .unwrap_or_else(|e| panic!("failed to format `LocalTime`: {e}"))
-                    .strftime(FORMAT)
+                v.strftime(FORMAT)
             }
             .to_string(),
         )

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -7,8 +7,14 @@
 //! | [`civil::Date`]     | `yyyy-MM-dd`          | [`LocalDate`][s1]     |
 //! | [`civil::Time`]     | `HH:mm[:ss[.SSS]]`    | [`LocalTime`][s2]     |
 //! | [`civil::DateTime`] | `yyyy-MM-ddTHH:mm:ss` | [`LocalDateTime`][s3] |
-//! | [`Zoned`]           | [RFC 3339] string     | [`DateTime`][s4]      |
 //! | [`Timestamp`]       | [RFC 3339] string     | [`DateTime`][s4]      |
+//!
+//! # Unsupported types
+//!
+//! [`Zoned`] is not supported because the GraphQL scalar [`DateTime`][s4] only supports time zone
+//! offsets but no IANA time zone names (as in `2024-08-10T23:14:00-04:00[America/New_York]`, cf.
+//! [RFC 9557]). Serializing such values would incur a loss of information with unexpected and
+//! subtle consequences (a fixed offset would only _seem_ to work in most cases).
 //!
 //! [`civil::Date`]: jiff::civil::Date
 //! [`civil::Time`]: jiff::civil::Time
@@ -16,6 +22,7 @@
 //! [`Zoned`]: jiff::Zoned
 //! [`Timestamp`]: jiff::Timestamp
 //! [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+//! [RFC 9557]: https://datatracker.ietf.org/doc/html/rfc9557#section-4.1
 //! [s1]: https://graphql-scalars.dev/docs/scalars/local-date
 //! [s2]: https://graphql-scalars.dev/docs/scalars/local-time
 //! [s3]: https://graphql-scalars.dev/docs/scalars/local-date-time

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -18,14 +18,14 @@
 //! subtle consequences (a fixed offset would only _seem_ to work in most cases).
 //!
 //! [`civil::Date`]: jiff::civil::Date
-//! [`civil::Time`]: jiff::civil::Time
 //! [`civil::DateTime`]: jiff::civil::DateTime
+//! [`civil::Time`]: jiff::civil::Time
 //! [`Span`]: jiff::Span
 //! [`Timestamp`]: jiff::Timestamp
 //! [`Zoned`]: jiff::Zoned
+//! [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601#Durations
 //! [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
 //! [RFC 9557]: https://datatracker.ietf.org/doc/html/rfc9557#section-4.1
-//! [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601#Durations
 //! [s1]: https://graphql-scalars.dev/docs/scalars/local-date
 //! [s2]: https://graphql-scalars.dev/docs/scalars/local-time
 //! [s3]: https://graphql-scalars.dev/docs/scalars/local-date-time
@@ -34,12 +34,11 @@
 
 use crate::{graphql_scalar, InputValue, ScalarValue, Value};
 
-/// A representation of a civil date in the Gregorian calendar.
+/// Representation of a civil date in the Gregorian calendar.
 ///
-/// A `Date` value corresponds to a triple of year, month and day. Every `Date`
-/// value is guaranteed to be a valid Gregorian calendar date. For example,
-/// both `2023-02-29` and `2023-11-31` are invalid and cannot be represented by
-/// a `Date`.
+/// Corresponds to a triple of year, month and day. Every value is guaranteed to be a valid
+/// Gregorian calendar date. For example, both `2023-02-29` and `2023-11-31` are invalid and cannot
+/// be represented.
 ///
 /// [`LocalDate` scalar][1] compliant.
 ///
@@ -81,11 +80,11 @@ mod local_date {
     }
 }
 
-/// A representation of civil "wall clock" time.
+/// Representation of a civil "wall clock" time.
 ///
-/// Conceptually, a `Time` value corresponds to the typical hours and minutes
-/// that you might see on a clock. This type also contains the second and
-/// fractional subsecond (to nanosecond precision) associated with a time.
+/// Conceptually, corresponds to the typical hours and minutes that you might see on a clock. This
+/// type also contains the second and fractional subsecond (to nanosecond precision) associated with
+/// a time.
 ///
 /// [`LocalTime` scalar][1] compliant.
 ///
@@ -150,15 +149,13 @@ mod local_time {
     }
 }
 
-/// A representation of a civil datetime in the Gregorian calendar.
+/// Representation of a civil datetime in the Gregorian calendar.
 ///
-/// A `DateTime` value corresponds to a pair of a [`Date`] and a [`Time`].
-/// That is, a datetime contains a year, month, day, hour, minute, second and
-/// the fractional number of nanoseconds.
+/// Corresponds to a pair of a `LocalDate` and a `LocalTime`. That is, a datetime contains a year,
+/// month, day, hour, minute, second and the fractional number of nanoseconds.
 ///
-/// A `DateTime` value is guaranteed to contain a valid date and time. For
-/// example, neither `2023-02-29T00:00:00` nor `2015-06-30T23:59:60` are
-/// valid `DateTime` values.
+/// Value is guaranteed to contain a valid date and time. For example, neither `2023-02-29T00:00:00`
+/// nor `2015-06-30T23:59:60` are valid.
 ///
 /// [`LocalDateTime` scalar][1] compliant.
 ///
@@ -201,10 +198,9 @@ mod local_date_time {
     }
 }
 
-/// An instant in time represented as the number of nanoseconds since the Unix
-/// epoch.
+/// Instant in time represented as the number of nanoseconds since the Unix epoch.
 ///
-/// A timestamp is always in UTC.
+/// Always in UTC.
 ///
 /// [`DateTime` scalar][1] compliant.
 ///
@@ -246,10 +242,10 @@ mod date_time {
     }
 }
 
-/// A span of time represented via a mixture of calendar and clock units.
+/// Span of time represented via a mixture of calendar and clock units.
 ///
-/// A span represents a duration of time in units of years, months, weeks,
-/// days, hours, minutes, seconds, milliseconds, microseconds and nanoseconds.
+/// Represents a duration of time in units of years, months, weeks, days, hours, minutes, seconds,
+/// milliseconds, microseconds and nanoseconds.
 ///
 /// [`Duration` scalar][1] compliant.
 ///

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -1,0 +1,140 @@
+//! GraphQL support for [`jiff`] crate types.
+//!
+//! # Supported types
+//!
+//! | Rust type           | Format                | GraphQL scalar        |
+//! |---------------------|-----------------------|-----------------------|
+//! | [`civil::Date`]     | `yyyy-MM-dd`          | [`LocalDate`][s1]     |
+//! | [`civil::Time`]     | `HH:mm[:ss[.SSS]]`    | [`LocalTime`][s2]     |
+//! | [`civil::DateTime`] | `yyyy-MM-ddTHH:mm:ss` | [`LocalDateTime`][s3] |
+//! | [`Zoned`]           | [RFC 3339] string     | [`DateTime`][s4]      |
+//! | [`Timestamp`]       | [RFC 3339] string     | [`DateTime`][s4]      |
+//!
+//! [`civil::Date`]: jiff::civil::Date
+//! [`civil::Time`]: jiff::civil::Time
+//! [`civil::DateTime`]: jiff::civil::DateTime
+//! [`Zoned`]: jiff::Zoned
+//! [`Timestamp`]: jiff::Timestamp
+//! [RFC 3339]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+//! [s1]: https://graphql-scalars.dev/docs/scalars/local-date
+//! [s2]: https://graphql-scalars.dev/docs/scalars/local-time
+//! [s3]: https://graphql-scalars.dev/docs/scalars/local-date-time
+//! [s4]: https://graphql-scalars.dev/docs/scalars/date-time
+
+use crate::{graphql_scalar, InputValue, ScalarValue, Value};
+
+/// A representation of a civil date in the Gregorian calendar.
+///
+/// A `Date` value corresponds to a triple of year, month and day. Every `Date`
+/// value is guaranteed to be a valid Gregorian calendar date. For example,
+/// both `2023-02-29` and `2023-11-31` are invalid and cannot be represented by
+/// a `Date`.
+///
+/// [`LocalDate` scalar][1] compliant.
+///
+/// See also [`jiff::civil::Date`][2] for details.
+///
+/// [1]: https://graphql-scalars.dev/docs/scalars/local-date
+/// [2]: https://docs.rs/jiff/latest/jiff/civil/struct.Date.html
+#[graphql_scalar(
+    with = local_date,
+    parse_token(String),
+    specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-date",
+)]
+pub type LocalDate = jiff::civil::Date;
+
+mod local_date {
+    use super::*;
+
+    /// Format of a [`LocalDate` scalar][1].
+    ///
+    /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
+    const FORMAT: &str = "%Y-%m-%d";
+
+    pub(super) fn to_output<S>(v: &LocalDate) -> Value<S>
+    where
+        S: ScalarValue,
+    {
+        Value::scalar(v.strftime(FORMAT).to_string())
+    }
+
+    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalDate, String>
+    where
+        S: ScalarValue,
+    {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            .and_then(|s| {
+                LocalDate::strptime(FORMAT, s).map_err(|e| format!("Invalid `LocalDate`: {e}"))
+            })
+    }
+}
+
+/// A representation of civil "wall clock" time.
+///
+/// Conceptually, a `Time` value corresponds to the typical hours and minutes
+/// that you might see on a clock. This type also contains the second and
+/// fractional subsecond (to nanosecond precision) associated with a time.
+///
+/// [`LocalTime` scalar][1] compliant.
+///
+/// See also [`jiff::civil::Time`][2] for details.
+///
+/// [1]: https://graphql-scalars.dev/docs/scalars/local-time
+/// [2]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
+#[graphql_scalar(
+    with = local_time,
+    parse_token(String),
+    specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-time",
+)]
+pub type LocalTime = jiff::civil::Time;
+
+mod local_time {
+    use super::*;
+
+    /// Full format of a [`LocalTime` scalar][1].
+    ///
+    /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
+    const FORMAT: &str = "%H:%M:%S%.3f";
+
+    /// Format of a [`LocalTime` scalar][1] without milliseconds.
+    ///
+    /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
+    const FORMAT_NO_MILLIS: &str = "%H:%M:%S";
+
+    /// Format of a [`LocalTime` scalar][1] without seconds.
+    ///
+    /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
+    const FORMAT_NO_SECS: &str = "%H:%M";
+
+    pub(super) fn to_output<S>(v: &LocalTime) -> Value<S>
+    where
+        S: ScalarValue,
+    {
+        Value::scalar(
+            if v.subsec_nanosecond() == 0 {
+                v.strftime(FORMAT_NO_MILLIS)
+            } else {
+                v.strftime(FORMAT)
+            }
+            .to_string(),
+        )
+    }
+
+    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalTime, String>
+    where
+        S: ScalarValue,
+    {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            .and_then(|s| {
+                // First, try to parse the most used format.
+                // At the end, try to parse the full format for the parsing
+                // error to be most informative.
+                LocalTime::strptime(FORMAT_NO_MILLIS, s)
+                    .or_else(|_| LocalTime::strptime(FORMAT_NO_SECS, s))
+                    .or_else(|_| LocalTime::strptime(FORMAT, s))
+                    .map_err(|e| format!("Invalid `LocalTime`: {e}"))
+            })
+    }
+}

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -127,8 +127,7 @@ mod local_time {
                 v.strftime(FORMAT_NO_MILLIS)
             } else {
                 // `LocalTime` scalar only allows precision up to milliseconds.
-                v.clone()
-                    .round(jiff::Unit::Millisecond)
+                (*v).round(jiff::Unit::Millisecond)
                     .unwrap_or_else(|e| panic!("failed to format `LocalTime`: {e}"))
                     .strftime(FORMAT)
             }

--- a/juniper/src/integrations/mod.rs
+++ b/juniper/src/integrations/mod.rs
@@ -10,6 +10,8 @@ pub mod bson;
 pub mod chrono;
 #[cfg(feature = "chrono-tz")]
 pub mod chrono_tz;
+#[cfg(feature = "jiff")]
+pub mod jiff;
 #[cfg(feature = "rust_decimal")]
 pub mod rust_decimal;
 #[doc(hidden)]


### PR DESCRIPTION
## Description

This adds [Jiff](https://crates.io/crates/jiff) integration, behind feature flag `jiff`, for the following date/time types:

- [`civil::Date`](https://docs.rs/jiff/latest/jiff/civil/struct.Date.html) to GraphQL scalar [`LocalDate`](https://the-guild.dev/graphql/scalars/docs/scalars/local-date)
- [`civil::Time`](https://docs.rs/jiff/latest/jiff/civil/struct.Time.html) to GraphQL scalar [`LocalTime`](https://the-guild.dev/graphql/scalars/docs/scalars/local-time)
- [`civil::DateTime`](https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html) to GraphQL scalar [`LocalDateTime`](https://the-guild.dev/graphql/scalars/docs/scalars/local-date-time)
- [`Timestamp`](https://docs.rs/jiff/latest/jiff/struct.Timestamp.html) to GraphQL scalar [`DateTime`](https://the-guild.dev/graphql/scalars/docs/scalars/date-time)
- [`Span`](https://docs.rs/jiff/latest/jiff/struct.Span.html) to GraphQL scalar [`Duration`](https://the-guild.dev/graphql/scalars/docs/scalars/duration)

This does not add integration for [`Zoned`](https://docs.rs/jiff/latest/jiff/struct.Zoned.html) because there is no matching GraphQL scalar yet. See https://github.com/graphql-rust/juniper/issues/1270#issuecomment-2266685112 and related comments for details.

Closes #1270