### PR TITLE
Add Jiff date/time types `Zoned`/`TimeZone`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           - { feature: chrono-tz, crate: juniper }
           - { feature: expose-test-schema, crate: juniper }
           - { feature: jiff, crate: juniper }
+          - { feature: jiff-tz, crate: juniper }
           - { feature: rust_decimal, crate: juniper }
           - { feature: schema-language, crate: juniper }
           - { feature: time, crate: juniper }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
           - { feature: chrono-tz, crate: juniper }
           - { feature: expose-test-schema, crate: juniper }
           - { feature: jiff, crate: juniper }
-          - { feature: jiff-tz, crate: juniper }
           - { feature: rust_decimal, crate: juniper }
           - { feature: schema-language, crate: juniper }
           - { feature: time, crate: juniper }

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -401,6 +401,7 @@ mod date_scalar {
 | [`jiff::civil::DateTime`]   | `LocalDateTime`  | [`jiff`]         |
 | [`jiff::Timestamp`]         | [`DateTime`]     | [`jiff`]         |
 | [`jiff::Span`]              | [`Duration`]     | [`jiff`]         |
+| [`jiff::Zoned`]             | `ZonedDateTime`  | `jiff-tz`        |
 | [`time::Date`]              | [`Date`]         | [`time`]         |
 | [`time::Time`]              | [`LocalTime`]    | [`time`]         |
 | [`time::PrimitiveDateTime`] | `LocalDateTime`  | [`time`]         |
@@ -435,6 +436,7 @@ mod date_scalar {
 [`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::Span`]: https://docs.rs/jiff/latest/jiff/struct.Span.html
 [`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`jiff::Zoned`]: https://docs.rs/jiff/latest/jiff/struct.Zoned.html
 [`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date
 [`LocalTime`]: https://graphql-scalars.dev/docs/scalars/local-time
 [`rust_decimal`]: https://docs.rs/rust_decimal

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -427,6 +427,7 @@ mod date_scalar {
 [`chrono::NaiveTime`]: https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html
 [`chrono-tz`]: https://docs.rs/chrono-tz
 [`chrono_tz::Tz`]: https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html
+[`rust_decimal::Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`DateTime`]: https://graphql-scalars.dev/docs/scalars/date-time
 [`Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`Duration`]: https://graphql-scalars.dev/docs/scalars/duration

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -385,33 +385,33 @@ mod date_scalar {
 
 [Juniper] provides out-of-the-box [GraphQL scalar][0] implementations for some very common [Rust] crates. The types from these crates will be usable in your schemas automatically after enabling the correspondent self-titled [Cargo feature].
 
-| [Rust] type                 | [GraphQL] scalar      | [Cargo feature]  | Notes |
-|-----------------------------|-----------------------|------------------|-------|
-| [`bigdecimal::BigDecimal`]  | `BigDecimal`          | [`bigdecimal`]   |       |
-| [`bson::oid::ObjectId`]     | [`ObjectID`]          | [`bson`]         |       |
-| [`bson::DateTime`]          | [`DateTime`]          | [`bson`]         |       |
-| [`chrono::NaiveDate`]       | [`LocalDate`]         | [`chrono`]       |       |
-| [`chrono::NaiveTime`]       | [`LocalTime`]         | [`chrono`]       |       |
-| [`chrono::NaiveDateTime`]   | [`LocalDateTime`]     | [`chrono`]       |       |
-| [`chrono::DateTime`]        | [`DateTime`]          | [`chrono`]       |       |
-| [`chrono_tz::Tz`]           | [`TimeZone`]          | [`chrono-tz`]    |       |
-| [`rust_decimal::Decimal`]   | `Decimal`             | [`rust_decimal`] |       |
-| [`jiff::civil::Date`]       | [`LocalDate`]         | [`jiff`]         |       |
-| [`jiff::civil::Time`]       | [`LocalTime`]         | [`jiff`]         |       |
-| [`jiff::civil::DateTime`]   | [`LocalDateTime`]     | [`jiff`]         |       |
-| [`jiff::Timestamp`]         | [`DateTime`]          | [`jiff`]         |       |
-| [`jiff::Zoned`]             | `ZonedDateTime`       | [`jiff`]         |       |
-| [`jiff::tz::TimeZone`]      | `TimeZoneOrUtcOffset` | [`jiff`]         |       |
-| [`jiff::tz::TimeZone`]      | [`TimeZone`]          | [`jiff`]         | [^n1] |
-| [`jiff::tz::Offset`]        | [`UtcOffset`]         | [`jiff`]         |       |
-| [`jiff::Span`]              | [`Duration`]          | [`jiff`]         |       |
-| [`time::Date`]              | [`LocalDate`]         | [`time`]         |       |
-| [`time::Time`]              | [`LocalTime`]         | [`time`]         |       |
-| [`time::PrimitiveDateTime`] | [`LocalDateTime`]     | [`time`]         |       |
-| [`time::OffsetDateTime`]    | [`DateTime`]          | [`time`]         |       |
-| [`time::UtcOffset`]         | [`UtcOffset`]         | [`time`]         |       |
-| [`url::Url`]                | [`URL`]               | [`url`]          |       |
-| [`uuid::Uuid`]              | [`UUID`]              | [`uuid`]         |       |
+| [Rust] type                 | [GraphQL] scalar      | [Cargo feature]  |
+|-----------------------------|-----------------------|------------------|
+| [`bigdecimal::BigDecimal`]  | `BigDecimal`          | [`bigdecimal`]   |
+| [`bson::oid::ObjectId`]     | [`ObjectID`]          | [`bson`]         |
+| [`bson::DateTime`]          | [`DateTime`]          | [`bson`]         |
+| [`chrono::NaiveDate`]       | [`LocalDate`]         | [`chrono`]       |
+| [`chrono::NaiveTime`]       | [`LocalTime`]         | [`chrono`]       |
+| [`chrono::NaiveDateTime`]   | [`LocalDateTime`]     | [`chrono`]       |
+| [`chrono::DateTime`]        | [`DateTime`]          | [`chrono`]       |
+| [`chrono_tz::Tz`]           | [`TimeZone`]          | [`chrono-tz`]    |
+| [`rust_decimal::Decimal`]   | `Decimal`             | [`rust_decimal`] |
+| [`jiff::civil::Date`]       | [`LocalDate`]         | [`jiff`]         |
+| [`jiff::civil::Time`]       | [`LocalTime`]         | [`jiff`]         |
+| [`jiff::civil::DateTime`]   | [`LocalDateTime`]     | [`jiff`]         |
+| [`jiff::Timestamp`]         | [`DateTime`]          | [`jiff`]         |
+| [`jiff::Zoned`]             | `ZonedDateTime`       | [`jiff`]         |
+| [`jiff::tz::TimeZone`]      | `TimeZoneOrUtcOffset` | [`jiff`]         |
+| [`jiff::tz::TimeZone`]      | [`TimeZone`] [^n1]    | [`jiff`]         |
+| [`jiff::tz::Offset`]        | [`UtcOffset`]         | [`jiff`]         |
+| [`jiff::Span`]              | [`Duration`]          | [`jiff`]         |
+| [`time::Date`]              | [`LocalDate`]         | [`time`]         |
+| [`time::Time`]              | [`LocalTime`]         | [`time`]         |
+| [`time::PrimitiveDateTime`] | [`LocalDateTime`]     | [`time`]         |
+| [`time::OffsetDateTime`]    | [`DateTime`]          | [`time`]         |
+| [`time::UtcOffset`]         | [`UtcOffset`]         | [`time`]         |
+| [`url::Url`]                | [`URL`]               | [`url`]          |
+| [`uuid::Uuid`]              | [`UUID`]              | [`uuid`]         |
 
 [^n1]: Conversion supported via newtype.
 

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -413,7 +413,7 @@ mod date_scalar {
 | [`url::Url`]                | [`URL`]               | [`url`]          |
 | [`uuid::Uuid`]              | [`UUID`]              | [`uuid`]         |
 
-[^n1]: Conversion supported via newtype.
+[^n1]: Conversion supported via newtype [`integrations::jiff::TimeZone`][10].
 
 
 
@@ -482,3 +482,4 @@ mod date_scalar {
 [7]: https://spec.graphql.org/October2021#sec-Value-Resolution
 [8]: https://docs.rs/juniper/0.16.1/juniper/derive.GraphQLScalar.html
 [9]: https://docs.rs/juniper/0.16.1/juniper/attr.graphql_scalar.html
+[10]: https://docs.rs/juniper/0.16.1/juniper/integrations/jiff/struct.TimeZone.html

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -402,6 +402,7 @@ mod date_scalar {
 | [`jiff::Timestamp`]         | [`DateTime`]      | [`jiff`]         |
 | [`jiff::Zoned`]             | `ZonedDateTime`   | [`jiff`]         |
 | [`jiff::tz::TimeZone`]      | [`TimeZone`]      | [`jiff`]         |
+| [`jiff::tz::Offset`]        | [`UtcOffset`]     | [`jiff`]         |
 | [`jiff::Span`]              | [`Duration`]      | [`jiff`]         |
 | [`time::Date`]              | [`LocalDate`]     | [`time`]         |
 | [`time::Time`]              | [`LocalTime`]     | [`time`]         |
@@ -436,6 +437,7 @@ mod date_scalar {
 [`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::Span`]: https://docs.rs/jiff/latest/jiff/struct.Span.html
 [`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`jiff::tz::Offset`]: https://docs.rs/jiff/latest/jiff/tz/struct.Offset.html
 [`jiff::tz::TimeZone`]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
 [`jiff::Zoned`]: https://docs.rs/jiff/latest/jiff/struct.Zoned.html
 [`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -400,8 +400,9 @@ mod date_scalar {
 | [`jiff::civil::Time`]       | [`LocalTime`]     | [`jiff`]         |
 | [`jiff::civil::DateTime`]   | [`LocalDateTime`] | [`jiff`]         |
 | [`jiff::Timestamp`]         | [`DateTime`]      | [`jiff`]         |
+| [`jiff::Zoned`]             | `ZonedDateTime`   | [`jiff`]         |
+| [`jiff::tz::TimeZone`]      | [`TimeZone`]      | [`jiff`]         |
 | [`jiff::Span`]              | [`Duration`]      | [`jiff`]         |
-| [`jiff::Zoned`]             | `ZonedDateTime`   | `jiff-tz`        |
 | [`time::Date`]              | [`LocalDate`]     | [`time`]         |
 | [`time::Time`]              | [`LocalTime`]     | [`time`]         |
 | [`time::PrimitiveDateTime`] | [`LocalDateTime`] | [`time`]         |
@@ -435,6 +436,7 @@ mod date_scalar {
 [`jiff::civil::Time`]: https://docs.rs/jiff/latest/jiff/civil/struct.Time.html
 [`jiff::Span`]: https://docs.rs/jiff/latest/jiff/struct.Span.html
 [`jiff::Timestamp`]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
+[`jiff::tz::TimeZone`]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
 [`jiff::Zoned`]: https://docs.rs/jiff/latest/jiff/struct.Zoned.html
 [`LocalDate`]: https://graphql-scalars.dev/docs/scalars/local-date
 [`LocalDateTime`]: https://graphql-scalars.dev/docs/scalars/local-date-time

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -430,7 +430,6 @@ mod date_scalar {
 [`chrono::NaiveTime`]: https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html
 [`chrono-tz`]: https://docs.rs/chrono-tz
 [`chrono_tz::Tz`]: https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html
-[`rust_decimal::Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`DateTime`]: https://graphql-scalars.dev/docs/scalars/date-time
 [`Duration`]: https://graphql-scalars.dev/docs/scalars/duration
 [`ID`]: https://spec.graphql.org/October2021#sec-ID
@@ -448,6 +447,7 @@ mod date_scalar {
 [`LocalTime`]: https://graphql-scalars.dev/docs/scalars/local-time
 [`ObjectID`]: https://the-guild.dev/graphql/scalars/docs/scalars/object-id
 [`rust_decimal`]: https://docs.rs/rust_decimal
+[`rust_decimal::Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`ScalarValue`]: https://docs.rs/juniper/0.16.1/juniper/trait.ScalarValue.html
 [`serde`]: https://docs.rs/serde
 [`time`]: https://docs.rs/time

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -385,32 +385,35 @@ mod date_scalar {
 
 [Juniper] provides out-of-the-box [GraphQL scalar][0] implementations for some very common [Rust] crates. The types from these crates will be usable in your schemas automatically after enabling the correspondent self-titled [Cargo feature].
 
-| [Rust] type                 | [GraphQL] scalar  | [Cargo feature]  |
-|-----------------------------|-------------------|------------------|
-| [`bigdecimal::BigDecimal`]  | `BigDecimal`      | [`bigdecimal`]   |
-| [`bson::oid::ObjectId`]     | [`ObjectID`]      | [`bson`]         |
-| [`bson::DateTime`]          | [`DateTime`]      | [`bson`]         |
-| [`chrono::NaiveDate`]       | [`LocalDate`]     | [`chrono`]       |
-| [`chrono::NaiveTime`]       | [`LocalTime`]     | [`chrono`]       |
-| [`chrono::NaiveDateTime`]   | [`LocalDateTime`] | [`chrono`]       |
-| [`chrono::DateTime`]        | [`DateTime`]      | [`chrono`]       |
-| [`chrono_tz::Tz`]           | [`TimeZone`]      | [`chrono-tz`]    |
-| [`rust_decimal::Decimal`]   | `Decimal`         | [`rust_decimal`] |
-| [`jiff::civil::Date`]       | [`LocalDate`]     | [`jiff`]         |
-| [`jiff::civil::Time`]       | [`LocalTime`]     | [`jiff`]         |
-| [`jiff::civil::DateTime`]   | [`LocalDateTime`] | [`jiff`]         |
-| [`jiff::Timestamp`]         | [`DateTime`]      | [`jiff`]         |
-| [`jiff::Zoned`]             | `ZonedDateTime`   | [`jiff`]         |
-| [`jiff::tz::TimeZone`]      | [`TimeZone`]      | [`jiff`]         |
-| [`jiff::tz::Offset`]        | [`UtcOffset`]     | [`jiff`]         |
-| [`jiff::Span`]              | [`Duration`]      | [`jiff`]         |
-| [`time::Date`]              | [`LocalDate`]     | [`time`]         |
-| [`time::Time`]              | [`LocalTime`]     | [`time`]         |
-| [`time::PrimitiveDateTime`] | [`LocalDateTime`] | [`time`]         |
-| [`time::OffsetDateTime`]    | [`DateTime`]      | [`time`]         |
-| [`time::UtcOffset`]         | [`UtcOffset`]     | [`time`]         |
-| [`url::Url`]                | [`URL`]           | [`url`]          |
-| [`uuid::Uuid`]              | [`UUID`]          | [`uuid`]         |
+| [Rust] type                 | [GraphQL] scalar      | [Cargo feature]  | Notes |
+|-----------------------------|-----------------------|------------------|-------|
+| [`bigdecimal::BigDecimal`]  | `BigDecimal`          | [`bigdecimal`]   |       |
+| [`bson::oid::ObjectId`]     | [`ObjectID`]          | [`bson`]         |       |
+| [`bson::DateTime`]          | [`DateTime`]          | [`bson`]         |       |
+| [`chrono::NaiveDate`]       | [`LocalDate`]         | [`chrono`]       |       |
+| [`chrono::NaiveTime`]       | [`LocalTime`]         | [`chrono`]       |       |
+| [`chrono::NaiveDateTime`]   | [`LocalDateTime`]     | [`chrono`]       |       |
+| [`chrono::DateTime`]        | [`DateTime`]          | [`chrono`]       |       |
+| [`chrono_tz::Tz`]           | [`TimeZone`]          | [`chrono-tz`]    |       |
+| [`rust_decimal::Decimal`]   | `Decimal`             | [`rust_decimal`] |       |
+| [`jiff::civil::Date`]       | [`LocalDate`]         | [`jiff`]         |       |
+| [`jiff::civil::Time`]       | [`LocalTime`]         | [`jiff`]         |       |
+| [`jiff::civil::DateTime`]   | [`LocalDateTime`]     | [`jiff`]         |       |
+| [`jiff::Timestamp`]         | [`DateTime`]          | [`jiff`]         |       |
+| [`jiff::Zoned`]             | `ZonedDateTime`       | [`jiff`]         |       |
+| [`jiff::tz::TimeZone`]      | `TimeZoneOrUtcOffset` | [`jiff`]         |       |
+| [`jiff::tz::TimeZone`]      | [`TimeZone`]          | [`jiff`]         | [^n1] |
+| [`jiff::tz::Offset`]        | [`UtcOffset`]         | [`jiff`]         |       |
+| [`jiff::Span`]              | [`Duration`]          | [`jiff`]         |       |
+| [`time::Date`]              | [`LocalDate`]         | [`time`]         |       |
+| [`time::Time`]              | [`LocalTime`]         | [`time`]         |       |
+| [`time::PrimitiveDateTime`] | [`LocalDateTime`]     | [`time`]         |       |
+| [`time::OffsetDateTime`]    | [`DateTime`]          | [`time`]         |       |
+| [`time::UtcOffset`]         | [`UtcOffset`]         | [`time`]         |       |
+| [`url::Url`]                | [`URL`]               | [`url`]          |       |
+| [`uuid::Uuid`]              | [`UUID`]              | [`uuid`]         |       |
+
+[^n1]: Conversion supported via newtype.
 
 
 

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -432,7 +432,6 @@ mod date_scalar {
 [`chrono_tz::Tz`]: https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html
 [`rust_decimal::Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`DateTime`]: https://graphql-scalars.dev/docs/scalars/date-time
-[`Decimal`]: https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html
 [`Duration`]: https://graphql-scalars.dev/docs/scalars/duration
 [`ID`]: https://spec.graphql.org/October2021#sec-ID
 [`jiff`]: https://docs.rs/jiff

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -39,9 +39,10 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
     - `jiff::civil::Time` as `LocalTime` scalar.
     - `jiff::civil::DateTime` as `LocalDateTime` scalar. ([#1275])
     - `jiff::Timestamp` as `DateTime` scalar.
-    - `jiff::Span` as `Duration` scalar.
     - `jiff::Zoned` as `ZonedDateTime` scalar.
-    - `jiff::tz::TimeZone` as `TimeZone` scalar.
+    - `jiff::tz::TimeZone` as `TimeZoneOrUtcOffset` scalar.
+    - `jiff::tz::Offset` as `UtcOffset` scalar.
+    - `jiff::Span` as `Duration` scalar.
 
 ### Changed
 

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -17,7 +17,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 
 ### Added
 
-- [`jiff` crate] integration behind `jiff` [Cargo feature]. ([#1271])
+- [`jiff` crate] integration behind `jiff`/`jiff-tz` [Cargo feature]. ([#1271])
 
 ### Changed
 

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -34,7 +34,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 
 ### Added
 
-- [`jiff` crate] integration behind `jiff`/`jiff-tz` [Cargo feature]: ([#1271], [#1278], [#1270])
+- [`jiff` crate] integration behind `jiff` [Cargo feature]: ([#1271], [#1278], [#1270])
     - `jiff::civil::Date` as `LocalDate` scalar.
     - `jiff::civil::Time` as `LocalTime` scalar.
     - `jiff::civil::DateTime` as `LocalDateTime` scalar. ([#1275])
@@ -50,11 +50,11 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1252]: /../../pull/1252
 [#1270]: /../../issues/1270
 [#1271]: /../../pull/1271
-[#1278]: /../../pull/1278
 [#1272]: /../../pull/1272
 [#1274]: /../../pull/1274
 [#1275]: /../../pull/1275
 [#1277]: /../../pull/1277
+[#1278]: /../../pull/1278
 
 
 

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -34,6 +34,7 @@ chrono-clock = ["chrono", "chrono/clock"]
 chrono-tz = ["dep:chrono-tz", "dep:regex"]
 expose-test-schema = ["dep:anyhow", "dep:serde_json"]
 jiff = ["dep:jiff"]
+jiff-tz = ["jiff", "jiff/std"]
 js = ["chrono?/wasmbind", "time?/wasm-bindgen", "uuid?/js"]
 rust_decimal = ["dep:rust_decimal"]
 schema-language = ["dep:graphql-parser", "dep:void"]
@@ -78,6 +79,7 @@ void = { version = "1.0.2", optional = true }
 [dev-dependencies]
 bencher = "0.1.2"
 chrono = { version = "0.4.30", features = ["alloc"], default-features = false }
+jiff = { version = "0.1.5", features = ["tzdb-bundle-always"], default-features = false }
 pretty_assertions = "1.0.0"
 serde_json = "1.0.18"
 serial_test = "3.0"

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -53,7 +53,7 @@ fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-jiff = { version = "0.1.5", features = ["alloc", "std"], default-features = false, optional = true }
+jiff = { version = "0.1.5", features = ["std"], default-features = false, optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -34,7 +34,6 @@ chrono-clock = ["chrono", "chrono/clock"]
 chrono-tz = ["dep:chrono-tz", "dep:regex"]
 expose-test-schema = ["dep:anyhow", "dep:serde_json"]
 jiff = ["dep:jiff"]
-jiff-tz = ["jiff", "jiff/std"]
 js = ["chrono?/wasmbind", "time?/wasm-bindgen", "uuid?/js"]
 rust_decimal = ["dep:rust_decimal"]
 schema-language = ["dep:graphql-parser", "dep:void"]
@@ -54,7 +53,7 @@ fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }
 indexmap = { version = "2.0", features = ["serde"] }
-jiff = { version = "0.1.5", features = ["alloc"], default-features = false, optional = true }
+jiff = { version = "0.1.5", features = ["alloc", "std"], default-features = false, optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -341,7 +341,7 @@ pub enum TimeZoneError {
     InvalidInput(jiff::Error),
     /// GraphQL scalar [`TimeZone`] requires `tz::TimeZone` with IANA name.
     MissingIanaName(jiff::tz::TimeZone),
-    /// GraphQL scalar [`UTCOffset`] expects `tz::TimeZone` without IANA name.
+    /// GraphQL scalar [`UtcOffset`] expects `tz::TimeZone` without IANA name.
     UnexpectedIanaName(jiff::tz::TimeZone),
 }
 
@@ -465,9 +465,9 @@ mod time_zone {
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/utc-offset",
 )]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UTCOffset(jiff::tz::TimeZone);
+pub struct UtcOffset(jiff::tz::TimeZone);
 
-impl TryFrom<jiff::tz::TimeZone> for UTCOffset {
+impl TryFrom<jiff::tz::TimeZone> for UtcOffset {
     type Error = TimeZoneError;
 
     fn try_from(value: jiff::tz::TimeZone) -> Result<Self, Self::Error> {
@@ -482,7 +482,7 @@ impl TryFrom<jiff::tz::TimeZone> for UTCOffset {
     }
 }
 
-impl str::FromStr for UTCOffset {
+impl str::FromStr for UtcOffset {
     type Err = TimeZoneError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -491,8 +491,8 @@ impl str::FromStr for UTCOffset {
     }
 }
 
-impl From<UTCOffset> for jiff::tz::TimeZone {
-    fn from(value: UTCOffset) -> Self {
+impl From<UtcOffset> for jiff::tz::TimeZone {
+    fn from(value: UtcOffset) -> Self {
         value.0
     }
 }
@@ -502,12 +502,12 @@ mod utc_offset {
 
     use super::*;
 
-    /// Format of a [`UTCOffset` scalar][1].
+    /// Format of a [`UtcOffset` scalar][1].
     ///
     /// [1]: https://graphql-scalars.dev/docs/scalars/utc-offset
     const FORMAT: &str = "%:z";
 
-    pub(super) fn to_output<S>(v: &UTCOffset) -> Value<S>
+    pub(super) fn to_output<S>(v: &UtcOffset) -> Value<S>
     where
         S: ScalarValue,
     {
@@ -523,18 +523,18 @@ mod utc_offset {
         )
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<UTCOffset, String>
+    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<UtcOffset, String>
     where
         S: ScalarValue,
     {
         v.as_string_value()
             .ok_or_else(|| format!("Expected `String`, found: {v}"))
             .and_then(|s| {
-                jiff::Zoned::strptime(FORMAT, s).map_err(|e| format!("Invalid `UTCOffset`: {e}"))
+                jiff::Zoned::strptime(FORMAT, s).map_err(|e| format!("Invalid `UtcOffset`: {e}"))
             })
             .and_then(|z| {
-                UTCOffset::try_from(z.time_zone().clone())
-                    .map_err(|e| format!("Invalid `UTCOffset`: {e}"))
+                UtcOffset::try_from(z.time_zone().clone())
+                    .map_err(|e| format!("Invalid `UtcOffset`: {e}"))
             })
     }
 }
@@ -1297,26 +1297,26 @@ mod utc_offset_test {
 
     use crate::{graphql_input_value, FromInputValue as _, InputValue, ToInputValue as _};
 
-    use super::UTCOffset;
+    use super::UtcOffset;
 
     #[test]
     fn parses_correct_input() {
         for (raw, expected) in [
             (
                 "+00:00",
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(0))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(0))).unwrap(),
             ),
             (
                 "+03:00",
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(3))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(3))).unwrap(),
             ),
             (
                 "-09:00",
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(-9))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(-9))).unwrap(),
             ),
         ] {
             let input: InputValue = graphql_input_value!((raw));
-            let parsed = UTCOffset::from_input_value(&input);
+            let parsed = UtcOffset::from_input_value(&input);
 
             assert!(
                 parsed.is_ok(),
@@ -1342,7 +1342,7 @@ mod utc_offset_test {
             graphql_input_value!(false),
         ] {
             let input: InputValue = input;
-            let parsed = UTCOffset::from_input_value(&input);
+            let parsed = UtcOffset::from_input_value(&input);
 
             assert!(parsed.is_err(), "allows input: {input:?}");
         }
@@ -1352,19 +1352,19 @@ mod utc_offset_test {
     fn formats_correctly() {
         for (val, expected) in [
             (
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(0))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(0))).unwrap(),
                 graphql_input_value!("+00:00"),
             ),
             (
-                UTCOffset::try_from(tz::TimeZone::UTC).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::UTC).unwrap(),
                 graphql_input_value!("+00:00"),
             ),
             (
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(2))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(2))).unwrap(),
                 graphql_input_value!("+02:00"),
             ),
             (
-                UTCOffset::try_from(tz::TimeZone::fixed(tz::offset(-11))).unwrap(),
+                UtcOffset::try_from(tz::TimeZone::fixed(tz::offset(-11))).unwrap(),
                 graphql_input_value!("-11:00"),
             ),
         ] {
@@ -1386,7 +1386,7 @@ mod integration_test {
     };
 
     use super::{
-        DateTime, Duration, LocalDate, LocalDateTime, LocalTime, TimeZone, UTCOffset, ZonedDateTime,
+        DateTime, Duration, LocalDate, LocalDateTime, LocalTime, TimeZone, UtcOffset, ZonedDateTime,
     };
 
     #[tokio::test]
@@ -1424,7 +1424,7 @@ mod integration_test {
                 tz::TimeZone::get("Asia/Tokyo").unwrap().try_into().unwrap()
             }
 
-            fn utc_offset() -> UTCOffset {
+            fn utc_offset() -> UtcOffset {
                 tz::TimeZone::fixed(tz::offset(10)).try_into().unwrap()
             }
 

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -9,12 +9,12 @@
 //! | [`civil::DateTime`]  | `yyyy-MM-ddTHH:mm:ss` | [`LocalDateTime`][s3] |
 //! | [`Timestamp`]        | [RFC 3339] string     | [`DateTime`][s4]      |
 //! | [`Zoned`][^1]        | [RFC 9557] string     | `ZonedDateTime`       |
-//! | [`tz::TimeZone`][^1] | [IANA database][1]    | [`TimeZone`][s6]      |
-//! | [`Span`]             | [ISO 8601] duration   | [`Duration`][s5]      |
+//! | [`tz::TimeZone`][^1] | [IANA database][1]    | [`TimeZone`][s5]      |
+//! | [`Span`]             | [ISO 8601] duration   | [`Duration`][s6]      |
 //!
-//! [^1]: For these, feature flag `jiff-tz` must be enabled and crate [`jiff`] must be installed
-//! with a feature flag that provides access to the Time Zone Database (e.g. by using the crate's
-//! default feature flags). See [`jiff` time zone features][tz] for details.
+//! [^1]: For these, crate [`jiff`] must be installed with a feature flag that provides access to
+//! the Time Zone Database (e.g. by using the crate's default feature flags). See [`jiff` time zone
+//! features][tz] for details.
 //!
 //! [`civil::Date`]: jiff::civil::Date
 //! [`civil::DateTime`]: jiff::civil::DateTime
@@ -30,8 +30,8 @@
 //! [s2]: https://graphql-scalars.dev/docs/scalars/local-time
 //! [s3]: https://graphql-scalars.dev/docs/scalars/local-date-time
 //! [s4]: https://graphql-scalars.dev/docs/scalars/date-time
-//! [s5]: https://graphql-scalars.dev/docs/scalars/duration
-//! [s6]: https://graphql-scalars.dev/docs/scalars/time-zone
+//! [s5]: https://graphql-scalars.dev/docs/scalars/time-zone
+//! [s6]: https://graphql-scalars.dev/docs/scalars/duration
 //! [tz]: https://docs.rs/jiff/latest/jiff/index.html#time-zone-features
 //! [1]: http://www.iana.org/time-zones
 
@@ -262,14 +262,12 @@ mod date_time {
 /// [3]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
 /// [4]: https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html
 /// [5]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
-#[cfg(feature = "jiff-tz")]
 #[graphql_scalar(
     with = zoned_date_time,
     parse_token(String),
 )]
 pub type ZonedDateTime = jiff::Zoned;
 
-#[cfg(feature = "jiff-tz")]
 mod zoned_date_time {
     use std::str::FromStr as _;
 
@@ -346,7 +344,6 @@ mod duration {
 ///
 /// [1]: http://www.iana.org/time-zones
 /// [2]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
-#[cfg(feature = "jiff-tz")]
 #[graphql_scalar(
     with = time_zone,
     parse_token(String),
@@ -354,7 +351,6 @@ mod duration {
 )]
 pub type TimeZone = jiff::tz::TimeZone;
 
-#[cfg(feature = "jiff-tz")]
 mod time_zone {
     use super::*;
 
@@ -737,7 +733,6 @@ mod date_time_test {
     }
 }
 
-#[cfg(feature = "jiff-tz")]
 #[cfg(test)]
 mod zoned_date_time_test {
     use jiff::{civil, tz, tz::TimeZone};
@@ -1019,7 +1014,6 @@ mod duration_test {
     }
 }
 
-#[cfg(feature = "jiff-tz")]
 #[cfg(test)]
 mod time_zone_test {
     use jiff::tz;

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -440,7 +440,7 @@ impl Error for TimeZoneError {
 
 /// Representation of time zone.
 ///
-/// Is a set of rules for determining the civil time, via an offset from UTC, in a particular
+/// A set of rules for determining the civil time, via an offset from UTC, in a particular
 /// geographic region. In many cases, the offset in a particular time zone can vary over the course
 /// of a year through transitions into and out of daylight saving time.
 ///

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -395,7 +395,7 @@ mod time_zone_or_utc_offset {
             .ok_or_else(|| format!("Expected `String`, found: {v}"))
             .and_then(|s| {
                 TimeZoneOrUtcOffset::get(s)
-                    .map_err(TimeZoneError::InvalidInput)
+                    .map_err(TimeZoneError::InvalidTimeZone)
                     .or_else(|_| utc_offset::utc_offset_from_str(s).map(TimeZoneOrUtcOffset::fixed))
                     .map_err(|e| format!("Invalid `TimeZoneOrUtcOffset`: {e}"))
             })
@@ -405,8 +405,8 @@ mod time_zone_or_utc_offset {
 /// Error while handling [`TimeZone`] value.
 #[derive(Clone)]
 pub enum TimeZoneError {
-    /// Input could not be parsed by [`tz::TimeZone::get`](jiff::tz::TimeZone::get).
-    InvalidInput(jiff::Error),
+    /// Identifier could not be parsed by [`tz::TimeZone::get`](jiff::tz::TimeZone::get).
+    InvalidTimeZone(jiff::Error),
     /// GraphQL scalar [`TimeZone`] requires `tz::TimeZone` with IANA name.
     MissingIanaName(jiff::tz::TimeZone),
 }
@@ -414,7 +414,7 @@ pub enum TimeZoneError {
 impl fmt::Debug for TimeZoneError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidInput(err) => write!(f, "TimeZoneError::InvalidInput({err:?})"),
+            Self::InvalidTimeZone(err) => write!(f, "TimeZoneError::InvalidTimeZone({err:?})"),
             Self::MissingIanaName(_value) => write!(f, "TimeZoneError::MissingIanaName(..)"),
         }
     }
@@ -423,7 +423,7 @@ impl fmt::Debug for TimeZoneError {
 impl fmt::Display for TimeZoneError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidInput(err) => err.fmt(f),
+            Self::InvalidTimeZone(err) => err.fmt(f),
             Self::MissingIanaName(_value) => write!(f, "missing IANA name"),
         }
     }
@@ -432,7 +432,7 @@ impl fmt::Display for TimeZoneError {
 impl Error for TimeZoneError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::InvalidInput(err) => Some(err),
+            Self::InvalidTimeZone(err) => Some(err),
             Self::MissingIanaName(_) => None,
         }
     }
@@ -473,7 +473,7 @@ impl str::FromStr for TimeZone {
     type Err = TimeZoneError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let value = jiff::tz::TimeZone::get(value).map_err(TimeZoneError::InvalidInput)?;
+        let value = jiff::tz::TimeZone::get(value).map_err(TimeZoneError::InvalidTimeZone)?;
         value.try_into()
     }
 }

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -1120,7 +1120,7 @@ mod time_zone_test {
 
 #[cfg(test)]
 mod integration_test {
-    use jiff::{civil, tz::TimeZone, ToSpan as _};
+    use jiff::{civil, tz, ToSpan as _};
 
     use crate::{
         execute, graphql_object, graphql_value, graphql_vars,
@@ -1128,7 +1128,7 @@ mod integration_test {
         types::scalars::{EmptyMutation, EmptySubscription},
     };
 
-    use super::{DateTime, Duration, LocalDate, LocalDateTime, LocalTime};
+    use super::{DateTime, Duration, LocalDate, LocalDateTime, LocalTime, TimeZone, ZonedDateTime};
 
     #[tokio::test]
     async fn serializes() {
@@ -1150,9 +1150,19 @@ mod integration_test {
 
             fn date_time() -> DateTime {
                 civil::DateTime::constant(2014, 11, 28, 12, 0, 9, 50_000_000)
-                    .to_zoned(TimeZone::UTC)
+                    .to_zoned(tz::TimeZone::UTC)
                     .unwrap()
                     .timestamp()
+            }
+
+            fn zoned_date_time() -> ZonedDateTime {
+                civil::DateTime::constant(2014, 11, 28, 12, 0, 9, 50_000_000)
+                    .to_zoned(tz::TimeZone::get("America/New_York").unwrap())
+                    .unwrap()
+            }
+
+            fn time_zone() -> TimeZone {
+                tz::TimeZone::get("Asia/Tokyo").unwrap()
             }
 
             fn duration() -> Duration {
@@ -1171,6 +1181,8 @@ mod integration_test {
             localTime
             localDateTime
             dateTime,
+            zonedDateTime,
+            timeZone,
             duration,
         }"#;
 
@@ -1188,6 +1200,8 @@ mod integration_test {
                     "localTime": "16:07:08",
                     "localDateTime": "2016-07-08T09:10:11",
                     "dateTime": "2014-11-28T12:00:09.05Z",
+                    "zonedDateTime": "2014-11-28T12:00:09.05-05:00[America/New_York]",
+                    "timeZone": "Asia/Tokyo",
                     "duration": "P1y1m1dT1h1m1.1s",
                 }),
                 vec![],


### PR DESCRIPTION
## Description

This is a follow-up to #1271 and adds integration for the following [Jiff](https://crates.io/crates/jiff) date/time types:

- [`Zoned`](https://docs.rs/jiff/latest/jiff/struct.Zoned.html) to GraphQL scalar `ZonedDateTime`[^1]
- [`tz::TimeZone`](https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html) to GraphQL scalar `TimeZoneOrUtcOffset`[^2], and to GraphQL scalar [`TimeZone`](https://the-guild.dev/graphql/scalars/docs/scalars/time-zone) with a newtype
- [`tz::Offset`](https://docs.rs/jiff/latest/jiff/tz/struct.Offset.html) to GraphQL scalar [`UtcOffset`](https://the-guild.dev/graphql/scalars/docs/scalars/utc-offset)

[^1]: This GraphQL scalar is not documented at https://graphql-scalars.dev but we can introduce it here as laid out in https://github.com/graphql-rust/juniper/issues/1270#issuecomment-2291041828.

[^2]: This GraphQL scalar does not exist yet either. It is the union of GraphQL scalars `TimeZone` and `UtcOffset`.

~The new types are hidden behind feature flag `jiff-tz` because they require enabling the `std` feature flag for the `jiff` crate (which is not necessary for the remaining Jiff date/time types introduced in #1271).~

In addition, the `jiff` crate itself must be installed either with the default feature flags or with explicit feature flags that make the Time Zone Database available as explained in [`jiff` time zone features](https://docs.rs/jiff/latest/jiff/index.html#time-zone-features).

Closes #1270