### PR TITLE
Fix content-header parsing in juniper_axum

### DIFF
--- a/juniper_axum/CHANGELOG.md
+++ b/juniper_axum/CHANGELOG.md
@@ -16,6 +16,10 @@ All user visible changes to `juniper_axum` crate will be documented in this file
 
 - Building on `wasm32-unknown-unknown` and `wasm32-wasi` targets. ([#1283], [#1282])
 
+### Fixed
+
+- `Content-Type` header reading full value instead of just the media type. ([#1288])
+
 [#1272]: /../../pull/1272
 [#1282]: /../../issues/1282
 [#1283]: /../../pull/1283

--- a/juniper_axum/src/extract.rs
+++ b/juniper_axum/src/extract.rs
@@ -249,9 +249,41 @@ mod juniper_request_tests {
     }
 
     #[tokio::test]
+    async fn from_json_post_request_with_charset() {
+        let req = Request::post("/")
+            .header("content-type", "application/json; charset=utf-8")
+            .body(Body::from(r#"{"query": "{ add(a: 2, b: 3) }"}"#))
+            .unwrap_or_else(|e| panic!("cannot build `Request`: {e}"));
+
+        let expected = JuniperRequest(GraphQLBatchRequest::Single(GraphQLRequest::new(
+            "{ add(a: 2, b: 3) }".to_string(),
+            None,
+            None,
+        )));
+
+        assert_eq!(do_from_request(req).await, expected);
+    }
+
+    #[tokio::test]
     async fn from_graphql_post_request() {
         let req = Request::post("/")
             .header("content-type", "application/graphql")
+            .body(Body::from(r#"{ add(a: 2, b: 3) }"#))
+            .unwrap_or_else(|e| panic!("cannot build `Request`: {e}"));
+
+        let expected = JuniperRequest(GraphQLBatchRequest::Single(GraphQLRequest::new(
+            "{ add(a: 2, b: 3) }".to_string(),
+            None,
+            None,
+        )));
+
+        assert_eq!(do_from_request(req).await, expected);
+    }
+
+    #[tokio::test]
+    async fn from_graphql_post_request_with_charset() {
+        let req = Request::post("/")
+            .header("content-type", "application/graphql; charset=utf-8")
             .body(Body::from(r#"{ add(a: 2, b: 3) }"#))
             .unwrap_or_else(|e| panic!("cannot build `Request`: {e}"));
 


### PR DESCRIPTION
Check media type using `starts_with` instead of full string matching.

Fixes #1288