### PR TITLE
Introducing Juniper Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![codecov](https://codecov.io/gh/graphql-rust/juniper/branch/master/graph/badge.svg)](https://codecov.io/gh/graphql-rust/juniper)
 [![Crates.io](https://img.shields.io/crates/v/juniper.svg?maxAge=2592000)](https://crates.io/crates/juniper)
 [![Gitter chat](https://badges.gitter.im/juniper-graphql/gitter.svg)](https://gitter.im/juniper-graphql/Lobby)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Juniper%20Guru-006BFF)](https://gurubase.io/g/juniper)
 
 ---
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Juniper Guru](https://gurubase.io/g/juniper) to Gurubase. Juniper Guru uses the data from this repo and data from the [docs](https://graphql-rust.github.io/juniper) to answer questions by leveraging the LLM.

In this PR, I showcased the "Juniper Guru", which highlights that Juniper now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Juniper Guru in Gurubase, just let me know that's totally fine.
