### PR TITLE
Update `axum` from 0.7 to 0.8 version (breaking)

### DIFF
--- a/juniper_axum/Cargo.toml
+++ b/juniper_axum/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 subscriptions = ["axum/ws", "juniper_graphql_ws/graphql-ws", "dep:futures"]
 
 [dependencies]
-axum = { version = "0.7", features = ["json", "query"], default-features = false }
+axum = { version = "0.8", features = ["json", "query"], default-features = false }
 futures = { version = "0.3.22", optional = true }
 juniper = { version = "0.16", path = "../juniper", default-features = false }
 juniper_graphql_ws = { version = "0.4.0", path = "../juniper_graphql_ws", features = ["graphql-transport-ws"] }
@@ -38,7 +38,7 @@ bytes = "1.2"
 
 [dev-dependencies]
 anyhow = "1.0"
-axum = { version = "0.7", features = ["http1", "macros", "tokio"] }
+axum = { version = "0.8", features = ["http1", "macros", "tokio"] }
 futures = "0.3.22"
 juniper = { version = "0.16", path = "../juniper", features = ["expose-test-schema"] }
 tokio = { version = "1.20", features = ["macros", "net", "rt-multi-thread", "time"] }

--- a/juniper_axum/src/extract.rs
+++ b/juniper_axum/src/extract.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 use axum::{
-    async_trait,
     body::Body,
     extract::{FromRequest, FromRequestParts, Query},
     http::{header, HeaderValue, Method, Request, StatusCode},
@@ -70,7 +69,6 @@ pub struct JuniperRequest<S = DefaultScalarValue>(pub GraphQLBatchRequest<S>)
 where
     S: ScalarValue;
 
-#[async_trait]
 impl<S, State> FromRequest<State> for JuniperRequest<S>
 where
     S: ScalarValue,

--- a/juniper_axum/src/subscriptions.rs
+++ b/juniper_axum/src/subscriptions.rs
@@ -488,7 +488,7 @@ where
             Ok(match output {
                 graphql_transport_ws::Output::Message(msg) => {
                     serde_json::to_string(&msg)
-                        .map(ws::Message::Text)
+                        .map(|s| ws::Message::Text(s.into()))
                         .unwrap_or_else(|e| {
                             ws::Message::Close(Some(ws::CloseFrame {
                                 code: 1011, // CloseCode::Error
@@ -618,7 +618,7 @@ where
     let output = s_rx
         .map(|msg| {
             Ok(serde_json::to_string(&msg)
-                .map(ws::Message::Text)
+                .map(|s| ws::Message::Text(s.into()))
                 .unwrap_or_else(|e| {
                     ws::Message::Close(Some(ws::CloseFrame {
                         code: 1011, // CloseCode::Error


### PR DESCRIPTION
Thanks for the project!

Axum just released 0.8 and changed a couple of things, and I tried upgrading and there are a couple places in `juniper_axum` that need changing (the type of WS message and remove `::async_trait`). This will be a breaking change to your user as the type for ["extract::ws::WebSocket"] is incompatible.
