### PR TITLE
Fix error propagation in fragments spreading (#1287)

### DIFF
--- a/tests/integration/tests/issue_1287.rs
+++ b/tests/integration/tests/issue_1287.rs
@@ -1,0 +1,71 @@
+//! Checks that error is propagated from a fragment the same way as without it.
+//! See [#1287](https://github.com/graphql-rust/juniper/issues/1287) for details.
+
+use juniper::{EmptyMutation, EmptySubscription, Variables, graphql_object};
+
+struct MyObject;
+
+#[graphql_object]
+impl MyObject {
+    fn erroring_field() -> Result<i32, &'static str> {
+        Err("This field always errors")
+    }
+}
+
+struct Query;
+
+#[graphql_object]
+impl Query {
+    fn my_object() -> MyObject {
+        MyObject {}
+    }
+
+    fn just_a_field() -> i32 {
+        3
+    }
+}
+
+type Schema = juniper::RootNode<'static, Query, EmptyMutation, EmptySubscription>;
+
+#[tokio::test]
+async fn error_propagates_same_way() {
+    // language=GraphQL
+    let without_fragment = r"{ 
+        myObject { erroringField } 
+        justAField 
+    }";
+    // language=GraphQL
+    let with_fragment = r"
+        query { 
+            myObject { 
+                ...MyObjectFragment 
+            } 
+            justAField
+        }
+        
+        fragment MyObjectFragment on MyObject { 
+            erroringField 
+        }
+    ";
+
+    let (expected, _) = juniper::execute(
+        without_fragment,
+        None,
+        &Schema::new(Query, EmptyMutation::new(), EmptySubscription::new()),
+        &Variables::new(),
+        &(),
+    )
+    .await
+    .unwrap();
+    let (actual, _) = juniper::execute(
+        with_fragment,
+        None,
+        &Schema::new(Query, EmptyMutation::new(), EmptySubscription::new()),
+        &Variables::new(),
+        &(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Resolves #1287


##  Synopsis

See https://github.com/graphql-rust/juniper/issues/1287#issue-2567533822:
> Relevant excerpt from the GraphQL spec about how to handle field errors on non-nullable fields.
> 
> > Since Non-Null type fields cannot be null, field errors are propagated to be handled by the parent field. If the parent field may be null then it resolves to null, otherwise if it is a Non-Null type, the field error is further propagated to its parent field.
> 
> Juniper follows this behavior when the query doesn't have any fragments, but if the field error only occurs in a fragment, "null" won't propagate to the closest nullable ancestor field, but instead seems to just make the fields in the fragment null, while not affecting fields outside of the fragment.


## Solution

Make fragment and non-fragment behave similarly.