### PR TITLE
Remove `DynType` and resculpt `ast::Type`

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -52,7 +52,6 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
         - Made `name` and `description` fields using `ArcStr`.
     - `SchemaType`: 
         - Removed lifetime parameters.
-        - Made `is_subtype()` method accepting `DynType` instead of `Type`.
     - `RootNode`:
         - Removed lifetime parameters.
     - `Registry`:

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Type literal in a syntax tree.
 ///
 /// This enum carries no semantic information and might refer to types that do not exist.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Type<N = ArcStr> {
     /// `null`able named type, e.g. `String`.
     Named(N),
@@ -30,6 +30,22 @@ pub enum Type<N = ArcStr> {
     ///
     /// The list itself is non-`null`, the containing [`Type`] might be `null`able.
     NonNullList(Box<Type<N>>, Option<usize>),
+}
+
+impl<N> Eq for Type<N> where Self: PartialEq {}
+
+impl<N1: AsRef<str>, N2: AsRef<str>> PartialEq<Type<N2>> for Type<N1> {
+    fn eq(&self, other: &Type<N2>) -> bool {
+        match (self, other) {
+            (Self::Named(n1), Type::Named(n2)) => n1.as_ref() == n2.as_ref(),
+            (Self::List(lhs, s1), Type::List(rhs, s2)) => s1 == s2 && lhs.as_ref() == rhs.as_ref(),
+            (Self::NonNullNamed(n1), Type::NonNullNamed(n2)) => n1.as_ref() == n2.as_ref(),
+            (Self::NonNullList(lhs, s1), Type::NonNullList(rhs, s2)) => {
+                s1 == s2 && lhs.as_ref() == rhs.as_ref()
+            }
+            _ => false,
+        }
+    }
 }
 
 impl<N: fmt::Display> fmt::Display for Type<N> {

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -473,23 +473,27 @@ impl<S> SchemaType<S> {
     }
 
     /// If the type is a subtype of another type.
-    pub fn is_subtype<'b>(&self, sub_type: &DynType<'b>, super_type: &DynType<'b>) -> bool {
-        use DynType::*;
+    pub fn is_subtype(
+        &self,
+        sub_type: &Type<impl AsRef<str>>,
+        super_type: &Type<impl AsRef<str>>,
+    ) -> bool {
+        use Type::*;
 
-        if super_type.equals(sub_type) {
+        if super_type == sub_type {
             return true;
         }
 
         match (super_type, sub_type) {
-            (&NonNullNamed(ref super_name), &NonNullNamed(ref sub_name))
-            | (&Named(ref super_name), &Named(ref sub_name))
-            | (&Named(ref super_name), &NonNullNamed(ref sub_name)) => {
+            (NonNullNamed(super_name), NonNullNamed(sub_name))
+            | (Named(super_name), Named(sub_name))
+            | (Named(super_name), NonNullNamed(sub_name)) => {
                 self.is_named_subtype(sub_name.as_ref(), super_name.as_ref())
             }
-            (&NonNullList(super_inner, _), &NonNullList(sub_inner, _))
-            | (&List(super_inner, _), &List(sub_inner, _))
-            | (&List(super_inner, _), &NonNullList(sub_inner, _)) => {
-                self.is_subtype(&sub_inner.as_dyn_type(), &super_inner.as_dyn_type())
+            (NonNullList(super_inner, _), NonNullList(sub_inner, _))
+            | (List(super_inner, _), List(sub_inner, _))
+            | (List(super_inner, _), NonNullList(sub_inner, _)) => {
+                self.is_subtype(sub_inner, super_inner)
             }
             _ => false,
         }

--- a/juniper/src/schema/model.rs
+++ b/juniper/src/schema/model.rs
@@ -397,16 +397,13 @@ impl<S> SchemaType<S> {
             Type::List(inner, expected_size) => {
                 TypeType::List(Box::new(self.make_type(inner)), *expected_size)
             }
-            Type::Named(n) => self
-                .type_by_name(n.as_ref())
-                .expect("Type not found in schema"),
+            Type::Named(n) => self.type_by_name(n).expect("Type not found in schema"),
             Type::NonNullList(inner, expected_size) => TypeType::NonNull(Box::new(TypeType::List(
                 Box::new(self.make_type(inner)),
                 *expected_size,
             ))),
             Type::NonNullNamed(n) => TypeType::NonNull(Box::new(
-                self.type_by_name(n.as_ref())
-                    .expect("Type not found in schema"),
+                self.type_by_name(n).expect("Type not found in schema"),
             )),
         }
     }

--- a/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/juniper/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -570,8 +570,8 @@ impl<'a, S: Debug> OverlappingFieldsCanBeMerged<'a, S> {
             }
             (Type::Named(n1), Type::Named(n2))
             | (Type::NonNullNamed(n1), Type::NonNullNamed(n2)) => {
-                let ct1 = ctx.schema.concrete_type_by_name(n1.as_ref());
-                let ct2 = ctx.schema.concrete_type_by_name(n2.as_ref());
+                let ct1 = ctx.schema.concrete_type_by_name(n1);
+                let ct2 = ctx.schema.concrete_type_by_name(n2);
 
                 if ct1.map(MetaType::is_leaf).unwrap_or(false)
                     || ct2.map(MetaType::is_leaf).unwrap_or(false)

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -92,10 +92,7 @@ impl<'a, S: fmt::Debug> VariableInAllowedPosition<'a, S> {
                         (_, ty) => ty.clone(),
                     };
 
-                    if !ctx
-                        .schema
-                        .is_subtype(&expected_type, var_type)
-                    {
+                    if !ctx.schema.is_subtype(&expected_type, var_type) {
                         ctx.report_error(
                             &error_message(var_name.item, expected_type, var_type),
                             &[var_def_name.span.start, var_name.span.start],

--- a/juniper/src/validation/rules/variables_in_allowed_position.rs
+++ b/juniper/src/validation/rules/variables_in_allowed_position.rs
@@ -94,7 +94,7 @@ impl<'a, S: fmt::Debug> VariableInAllowedPosition<'a, S> {
 
                     if !ctx
                         .schema
-                        .is_subtype(&expected_type.as_dyn_type(), var_type)
+                        .is_subtype(&expected_type, var_type)
                     {
                         ctx.report_error(
                             &error_message(var_name.item, expected_type, var_type),


### PR DESCRIPTION
Follows #1247


## Synopsis

In #1247 the `ast::Type` was made generic over the string type used for name.
```rust
pub enum Type<N = ArcStr> {
    Named(N),
    List(Box<Type<N>>, Option<usize>),
    NonNullNamed(N),
    NonNullList(Box<Type<N>>, Option<usize>),
}
```

In the codebase, there are numerous places where it's required to convert both `ast::Type<ArcStr>` and `ast::Type<&str>` to some singular representation stored in `ValidatorContext` or similar places.

However, the current `ast::Type` enum representation using `Box`es introduces a problem that it's not possible to cheaply receive a borrowed version of `ast::Type<ArcStr>` as `ast::Type<&str>` without re-allocating all those `Box`es. Furthermore, using `Box`es involves redundant re-allocations on `Clone`ing even when `&str` is used.

Thus, @audunhalland came up with a temporary `DynType` solution to solve this problem:
```rust
pub enum DynType<'a> {
    Named(&'a str),
    List(&'a dyn AsDynType, Option<usize>),
    NonNullNamed(&'a str),
    NonNullList(&'a dyn AsDynType, Option<usize>),
}

pub trait AsDynType: fmt::Debug {
    fn as_dyn_type(&self) -> DynType<'_>;
}
impl AsDynType for ast::Type<ArcStr> { }
impl AsDynType for ast::Type<&str> {}
```

The problem with this solution, that it duplicates `ast::Type` inner logic and pollutes some potentially public APIs.


## Solution

As @audunhalland kindly suggested in TODO comment:
```rust
// TODO: Ideally this type should not exist, but the reason it currently does is that `Type` has a
//       recursive design to allow arbitrary number of list wrappings.
//       The list layout could instead be modelled as a modifier so that type becomes a tuple of
//       (name, modifier).
//       If `Type` is modelled like this it becomes easier to project it as a borrowed version of
//       itself, i.e. [Type<ArcStr>] vs [Type<&str>].
```
This PR resculpts `ast::Type` in this manner:
```rust
pub enum TypeModifier {
    NonNull,
    List(Option<usize>),
}

pub(crate) type BorrowedType<'a> = Type<&'a str, &'a [TypeModifier]>;

#[derive(Clone, Debug)]
pub struct Type<N = ArcStr, M = Box<[TypeModifier]>> {
    name: N,
    modifiers: M,
}
```



## Checklist

- [ ] Docs are updated
- [ ] Tests are updated
- [ ] `README.md` updated



