### PR TITLE
Strip `InputValue` from `from_input` for GraphQL scalars

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -67,6 +67,31 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - Switched `ParseError::UnexpectedToken` to `compact_str::CompactString` instead of `smartstring::SmartString`. ([20609366])
 - Replaced `Value`'s `From` implementations with `IntoValue` ones. ([#1324])
 - Replaced `InputValue`'s `From` implementations with `IntoInputValue` ones. ([#1324])
+- `Value` enum: ([#1327])
+    - Removed `as_float_value()`, `as_string_value()` and `as_scalar_value()` methods (use `as_scalar()` method and then `ScalarValue` methods instead).
+- `InputValue` enum: ([#1327])
+    - Removed `as_float_value()`, `as_int_value()`, `as_string_value()` and `as_scalar_value()` methods (use `as_scalar()` method and then `ScalarValue` methods instead).
+- `ScalarValue` trait: ([#1327])
+    - Switched from `From` conversions to `TryScalarValueTo` conversions.
+    - Made to require `TryScalarValueTo` conversions for `bool`, `f64`, `i32`, `String` and `&str` types (could be derived with `#[value(<conversion>)]` attributes of `#[derive(ScalarValue)]` macro).
+    - Made to require `TryInto<String>` conversion (could be derived with `derive_more::TryInto`).
+    - Made `is_type()` method required and to accept `Any` type.
+    - Renamed `as_bool()` method to as `try_to_bool()` and made it defined by default as `TryScalarValueTo<bool>` alias.
+    - Renamed `as_float()` method to as `try_to_float()` and made it defined by default as `TryScalarValueTo<f64>` alias.
+    - Renamed `as_int()` method to as `try_to_int()` and made it defined by default as `TryScalarValueTo<i32>` alias.
+    - Renamed `as_string()` method to as `try_to_string()` and made it defined by default as `TryScalarValueTo<String>` alias.
+    - Renamed `as_str()` method to as `try_as_str()` and made it defined by default as `TryScalarValueTo<&str>` alias.
+    - Renamed `into_string()` method to as `try_into_string()` and made it defined by default as `TryInto<String>` alias.
+- `#[derive(ScalarValue)]` macro: ([#1327])
+    - Renamed `#[value(as_bool)]` attribute as `#[value(to_bool)]`.
+    - Renamed `#[value(as_float)]` attribute as `#[value(to_float)]`.
+    - Renamed `#[value(as_int)]` attribute as `#[value(to_int)]`.
+    - Renamed `#[value(as_string)]` attribute as `#[value(to_string)]`.
+    - Removed `#[value(into_string)]` attribute.
+    - Removed `#[value(allow_missing_attributes)]` attribute (now attributes can always be omitted).
+    - `From` and `Display` implementations are not derived anymore (recommended way is to use [`derive_more` crate] for this).
+- `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
+    - Made provided `from_input()` function to accept `ScalarValue` (or anything `TryScalarValueTo`-convertible) directly instead of `InputValue`.
 
 ### Added
 
@@ -82,8 +107,15 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - `http::GraphQLResponse::into_result()` method. ([#1293])
 - `String` scalar implementation for `arcstr::ArcStr`. ([#1247])
 - `String` scalar implementation for `compact_str::CompactString`. ([20609366])
-- `ScalarValue::from_displayable()` method allowing to specialize `ScalarValue` conversion from custom string types. ([#1324], [#819])
 - `IntoValue` and `IntoInputValue` conversion traits allowing to work around orphan rules with custom `ScalarValue`. ([#1324])
+- `ScalarValue` trait: ([#1327])
+    - `from_displayable()` method allowing to specialize `ScalarValue` conversion from custom string types. ([#1324], [#819])
+    - `try_to::<T>()` method defined by default as `TryScalarValueTo<T>` alias.
+- `TryScalarValueTo` conversion trait aiding `ScalarValue` trait. ([#1327])
+- `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
+    - Support for specifying concrete types as input argument in provided `from_input()` function.
+    - Support for non-`Result` return type in provided `from_input()` function.
+    - `Scalar` transparent wrapper for aiding type inference in `from_input()` function when input argument is generic `ScalarValue`.
 
 ### Changed
 
@@ -110,6 +142,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1318]: /../../pull/1318
 [#1324]: /../../pull/1324
 [#1326]: /../../pull/1326
+[#1327]: /../../pull/1327
 [1b1fc618]: /../../commit/1b1fc61879ffdd640d741e187dc20678bf7ab295
 [20609366]: /../../commit/2060936635609b0186d46d8fbd06eb30fce660e3
 
@@ -313,6 +346,7 @@ See [old CHANGELOG](/../../blob/juniper-v0.15.12/juniper/CHANGELOG.md).
 [`bson` crate]: https://docs.rs/bson
 [`chrono` crate]: https://docs.rs/chrono
 [`chrono-tz` crate]: https://docs.rs/chrono-tz
+[`derive_more` crate]: https://docs.rs/derive_more
 [`jiff` crate]: https://docs.rs/jiff
 [`time` crate]: https://docs.rs/time
 [Cargo feature]: https://doc.rust-lang.org/cargo/reference/features.html

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -108,9 +108,9 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - `String` scalar implementation for `arcstr::ArcStr`. ([#1247])
 - `String` scalar implementation for `compact_str::CompactString`. ([20609366])
 - `IntoValue` and `IntoInputValue` conversion traits allowing to work around orphan rules with custom `ScalarValue`. ([#1324])
-- `ScalarValue` trait: ([#1327])
+- `ScalarValue` trait:
     - `from_displayable()` method allowing to specialize `ScalarValue` conversion from custom string types. ([#1324], [#819])
-    - `try_to::<T>()` method defined by default as `TryScalarValueTo<T>` alias.
+    - `try_to::<T>()` method defined by default as `TryScalarValueTo<T>` alias. ([#1327])
 - `TryScalarValueTo` conversion trait aiding `ScalarValue` trait. ([#1327])
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
     - Support for specifying concrete types as input argument in provided `from_input()` function.

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -76,12 +76,12 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
     - Made to require `TryScalarValueTo` conversions for `bool`, `f64`, `i32`, `String` and `&str` types (could be derived with `#[value(<conversion>)]` attributes of `#[derive(ScalarValue)]` macro).
     - Made to require `TryInto<String>` conversion (could be derived with `derive_more::TryInto`).
     - Made `is_type()` method required and to accept `Any` type.
-    - Renamed `as_bool()` method to as `try_to_bool()` and made it defined by default as `TryScalarValueTo<bool>` alias.
-    - Renamed `as_float()` method to as `try_to_float()` and made it defined by default as `TryScalarValueTo<f64>` alias.
-    - Renamed `as_int()` method to as `try_to_int()` and made it defined by default as `TryScalarValueTo<i32>` alias.
-    - Renamed `as_string()` method to as `try_to_string()` and made it defined by default as `TryScalarValueTo<String>` alias.
-    - Renamed `as_str()` method to as `try_as_str()` and made it defined by default as `TryScalarValueTo<&str>` alias.
-    - Renamed `into_string()` method to as `try_into_string()` and made it defined by default as `TryInto<String>` alias.
+    - Renamed `as_bool()` method as `try_to_bool()` and made it defined by default as `TryScalarValueTo<bool>` alias.
+    - Renamed `as_float()` method as `try_to_float()` and made it defined by default as `TryScalarValueTo<f64>` alias.
+    - Renamed `as_int()` method as `try_to_int()` and made it defined by default as `TryScalarValueTo<i32>` alias.
+    - Renamed `as_string()` method as `try_to_string()` and made it defined by default as `TryScalarValueTo<String>` alias.
+    - Renamed `as_str()` method as `try_as_str()` and made it defined by default as `TryScalarValueTo<&str>` alias.
+    - Renamed `into_string()` method as `try_into_string()` and made it defined by default as `TryInto<String>` alias.
 - `#[derive(ScalarValue)]` macro: ([#1327])
     - Renamed `#[value(as_bool)]` attribute as `#[value(to_bool)]`.
     - Renamed `#[value(as_float)]` attribute as `#[value(to_float)]`.

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -51,7 +51,7 @@ bson = { version = "2.4", optional = true }
 chrono = { version = "0.4.30", features = ["alloc"], default-features = false, optional = true }
 chrono-tz = { version = "0.10", default-features = false, optional = true }
 compact_str = "0.9"
-derive_more = { version = "2.0", features = ["debug", "deref", "display", "error", "from", "into", "into_iterator"] }
+derive_more = { version = "2.0", features = ["debug", "deref", "display", "error", "from", "into", "into_iterator", "try_into"] }
 fnv = "1.0.5"
 futures = { version = "0.3.22", features = ["alloc"], default-features = false }
 graphql-parser = { version = "0.4", optional = true }

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -59,6 +59,7 @@ indexmap = { version = "2.0", features = ["serde"] }
 itertools = "0.14"
 jiff = { version = "0.2", features = ["std"], default-features = false, optional = true }
 juniper_codegen = { version = "0.16.0", path = "../juniper_codegen" }
+ref-cast = "1.0"
 rust_decimal = { version = "1.20", default-features = false, optional = true }
 ryu = { version = "1.0", optional = true }
 serde = { version = "1.0.122", features = ["derive"] }

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -359,45 +359,12 @@ impl<S> InputValue<S> {
         }
     }
 
-    /// View the underlying int value, if present.
-    pub fn as_int_value(&self) -> Option<i32>
-    where
-        S: ScalarValue,
-    {
-        self.as_scalar_value().and_then(|s| s.as_int())
-    }
-
-    /// View the underlying float value, if present.
-    pub fn as_float_value(&self) -> Option<f64>
-    where
-        S: ScalarValue,
-    {
-        self.as_scalar_value().and_then(|s| s.as_float())
-    }
-
-    /// View the underlying string value, if present.
-    pub fn as_string_value(&self) -> Option<&str>
-    where
-        S: ScalarValue,
-    {
-        self.as_scalar_value().and_then(|s| s.as_str())
-    }
-
     /// View the underlying scalar value, if present.
     pub fn as_scalar(&self) -> Option<&S> {
         match self {
             Self::Scalar(s) => Some(s),
             _ => None,
         }
-    }
-
-    /// View the underlying scalar value, if present.
-    pub fn as_scalar_value<'a, T>(&'a self) -> Option<&'a T>
-    where
-        T: 'a,
-        Option<&'a T>: From<&'a S>,
-    {
-        self.as_scalar().and_then(Into::into)
     }
 
     /// Converts this [`InputValue`] to a [`Spanning::unlocated`] object value.

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use crate::{
     executor::Variables,
     parser::Spanning,
-    value::{DefaultScalarValue, ScalarValue},
+    value::{DefaultScalarValue, ScalarValue, ScalarValueFmt},
 };
 
 /// Type literal in a syntax tree.
@@ -474,11 +474,7 @@ impl<S: ScalarValue> fmt::Display for InputValue<S> {
         match self {
             Self::Null => write!(f, "null"),
             Self::Scalar(s) => {
-                if let Some(s) = s.as_str() {
-                    write!(f, "\"{s}\"")
-                } else {
-                    write!(f, "{s}")
-                }
+                fmt::Display::fmt(&ScalarValueFmt(s), f)
             }
             Self::Enum(v) => write!(f, "{v}"),
             Self::Variable(v) => write!(f, "${v}"),

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -473,9 +473,7 @@ impl<S: ScalarValue> fmt::Display for InputValue<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Null => write!(f, "null"),
-            Self::Scalar(s) => {
-                fmt::Display::fmt(&ScalarValueFmt(s), f)
-            }
+            Self::Scalar(s) => fmt::Display::fmt(&ScalarValueFmt(s), f),
             Self::Enum(v) => write!(f, "{v}"),
             Self::Variable(v) => write!(f, "${v}"),
             Self::List(v) => {

--- a/juniper/src/executor/look_ahead.rs
+++ b/juniper/src/executor/look_ahead.rs
@@ -772,7 +772,7 @@ impl<'a, S: ScalarValue> ChildrenBuilder<'a, '_, S> {
                                     LookAheadValue::from_input_value(v.as_ref(), Some(self.vars))
                                         .item
                                 {
-                                    s.as_bool().unwrap_or(false)
+                                    s.try_to_bool().unwrap_or(false)
                                 } else {
                                     false
                                 }
@@ -788,7 +788,7 @@ impl<'a, S: ScalarValue> ChildrenBuilder<'a, '_, S> {
                                     LookAheadValue::from_input_value(v.as_ref(), Some(self.vars))
                                         .item
                                 {
-                                    b.as_bool().map(Not::not).unwrap_or(false)
+                                    b.try_to_bool().map(Not::not).unwrap_or(false)
                                 } else {
                                     false
                                 }

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -207,10 +207,10 @@ impl<S> FieldError<S> {
     /// Maps the [`ScalarValue`] type of this [`FieldError`] into the specified
     /// one.
     #[must_use]
-    pub fn map_scalar_value<Into>(self) -> FieldError<Into>
+    pub fn map_scalar_value<T>(self) -> FieldError<T>
     where
         S: ScalarValue,
-        Into: ScalarValue,
+        T: ScalarValue,
     {
         FieldError {
             message: self.message,

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -282,6 +282,12 @@ impl<S> IntoFieldError<S> for Cow<'_, str> {
     }
 }
 
+impl<S> IntoFieldError<S> for Box<str> {
+    fn into_field_error(self) -> FieldError<S> {
+        FieldError::<S>::from(self)
+    }
+}
+
 #[doc(hidden)]
 pub trait IntoResolvable<'a, S, T, C>
 where

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -18,11 +18,11 @@ impl TestComplexScalar {
         graphql_value!("SerializedValue")
     }
 
-    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Self, String> {
-        v.as_string_value()
+    fn from_input(s: &impl ScalarValue) -> Result<Self, String> {
+        s.as_str()
             .filter(|s| *s == "SerializedValue")
             .map(|_| Self)
-            .ok_or_else(|| format!(r#"Expected "SerializedValue" string, found: {v}"#))
+            .ok_or_else(|| format!(r#"Expected "SerializedValue" string, found: {s}"#))
     }
 }
 

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -19,7 +19,7 @@ impl TestComplexScalar {
     }
 
     fn from_input(s: &impl ScalarValue) -> Result<Self, String> {
-        s.as_str()
+        s.try_as_str()
             .filter(|s| *s == "SerializedValue")
             .map(|_| Self)
             .ok_or_else(|| format!(r#"Expected "SerializedValue" string, found: {s}"#))

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,5 +1,5 @@
 use crate::{
-    GraphQLInputObject, GraphQLScalar, InputValue, ScalarValue, Value,
+    GraphQLInputObject, GraphQLScalar, ScalarValue, Value,
     executor::Variables,
     graphql_object, graphql_value, graphql_vars,
     parser::SourcePosition,
@@ -18,11 +18,12 @@ impl TestComplexScalar {
         graphql_value!("SerializedValue")
     }
 
-    fn from_input(s: &impl ScalarValue) -> Result<Self, String> {
-        s.try_as_str()
-            .filter(|s| *s == "SerializedValue")
-            .map(|_| Self)
-            .ok_or_else(|| format!(r#"Expected "SerializedValue" string, found: {s}"#))
+    fn from_input(s: &str) -> Result<Self, Box<str>> {
+        if s == "SerializedValue" {
+            Ok(Self)
+        } else {
+            Err(format!(r#"Expected "SerializedValue" string, found: "{s}""#).into())
+        }
     }
 }
 

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -10,7 +10,7 @@
 
 use std::str::FromStr as _;
 
-use crate::{Raw, ScalarValue, Value, WrongInputScalarTypeError, graphql_scalar};
+use crate::{Raw, ScalarValue, Value, graphql_scalar};
 
 // TODO: Try remove on upgrade of `bigdecimal` crate.
 mod for_minimal_versions_check_only {
@@ -53,15 +53,8 @@ mod bigdecimal_scalar {
             BigDecimal::from_str(buf.format(f))
                 .map_err(|e| format!("Failed to parse `BigDecimal` from `Float`: {e}").into())
         } else {
-            v.try_as_str()
-                .ok_or_else(|| {
-                    WrongInputScalarTypeError {
-                        type_name: arcstr::literal!("String"),
-                        input: &**v,
-                    }
-                    .to_string()
-                    .into()
-                })
+            v.try_to::<&str>()
+                .map_err(|e| e.to_string().into())
                 .and_then(|s| {
                     BigDecimal::from_str(s).map_err(|e| {
                         format!("Failed to parse `BigDecimal` from `String`: {e}").into()

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -10,7 +10,7 @@
 
 use std::str::FromStr as _;
 
-use crate::{Raw, ScalarValue, Value, graphql_scalar};
+use crate::{Scalar, ScalarValue, Value, graphql_scalar};
 
 // TODO: Try remove on upgrade of `bigdecimal` crate.
 mod for_minimal_versions_check_only {
@@ -43,7 +43,7 @@ mod bigdecimal_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(v: &Raw<impl ScalarValue>) -> Result<BigDecimal, Box<str>> {
+    pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<BigDecimal, Box<str>> {
         if let Some(i) = v.try_to_int() {
             Ok(BigDecimal::from(i))
         } else if let Some(f) = v.try_to_float() {

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -10,7 +10,7 @@
 
 use std::str::FromStr as _;
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 // TODO: Try remove on upgrade of `bigdecimal` crate.
 mod for_minimal_versions_check_only {
@@ -43,18 +43,18 @@ mod bigdecimal_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<BigDecimal, String> {
-        if let Some(i) = v.as_int_value() {
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<BigDecimal, String> {
+        if let Some(i) = s.as_int() {
             Ok(BigDecimal::from(i))
-        } else if let Some(f) = v.as_float_value() {
+        } else if let Some(f) = s.as_float() {
             // See akubera/bigdecimal-rs#103 for details:
             // https://github.com/akubera/bigdecimal-rs/issues/103
             let mut buf = ryu::Buffer::new();
             BigDecimal::from_str(buf.format(f))
                 .map_err(|e| format!("Failed to parse `BigDecimal` from `Float`: {e}"))
         } else {
-            v.as_string_value()
-                .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            s.as_str()
+                .ok_or_else(|| format!("Expected `String`, found: {s}"))
                 .and_then(|s| {
                     BigDecimal::from_str(s)
                         .map_err(|e| format!("Failed to parse `BigDecimal` from `String`: {e}"))

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -44,16 +44,16 @@ mod bigdecimal_scalar {
     }
 
     pub(super) fn from_input(v: &Raw<impl ScalarValue>) -> Result<BigDecimal, Box<str>> {
-        if let Some(i) = v.as_int() {
+        if let Some(i) = v.try_to_int() {
             Ok(BigDecimal::from(i))
-        } else if let Some(f) = v.as_float() {
+        } else if let Some(f) = v.try_to_float() {
             // See akubera/bigdecimal-rs#103 for details:
             // https://github.com/akubera/bigdecimal-rs/issues/103
             let mut buf = ryu::Buffer::new();
             BigDecimal::from_str(buf.format(f))
                 .map_err(|e| format!("Failed to parse `BigDecimal` from `Float`: {e}").into())
         } else {
-            v.as_str()
+            v.try_as_str()
                 .ok_or_else(|| {
                     WrongInputScalarTypeError {
                         type_name: arcstr::literal!("String"),

--- a/juniper/src/integrations/bson.rs
+++ b/juniper/src/integrations/bson.rs
@@ -13,7 +13,7 @@
 //! [s1]: https://graphql-scalars.dev/docs/scalars/object-id
 //! [s4]: https://graphql-scalars.dev/docs/scalars/date-time
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 // TODO: Try remove on upgrade of `bson` crate.
 mod for_minimal_versions_check_only {
@@ -44,9 +44,9 @@ mod object_id {
         Value::scalar(v.to_hex())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<ObjectId, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ObjectId, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 ObjectId::parse_str(s).map_err(|e| format!("Failed to parse `ObjectID`: {e}"))
             })
@@ -83,9 +83,9 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<DateTime, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 DateTime::parse_rfc3339_str(s)
                     .map_err(|e| format!("Failed to parse `DateTime`: {e}"))

--- a/juniper/src/integrations/bson.rs
+++ b/juniper/src/integrations/bson.rs
@@ -44,12 +44,8 @@ mod object_id {
         Value::scalar(v.to_hex())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ObjectId, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                ObjectId::parse_str(s).map_err(|e| format!("Failed to parse `ObjectID`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<ObjectId, Box<str>> {
+        ObjectId::parse_str(s).map_err(|e| format!("Failed to parse `ObjectID`: {e}").into())
     }
 }
 
@@ -83,13 +79,9 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                DateTime::parse_rfc3339_str(s)
-                    .map_err(|e| format!("Failed to parse `DateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {
+        DateTime::parse_rfc3339_str(s)
+            .map_err(|e| format!("Failed to parse `DateTime`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -58,13 +58,9 @@ mod local_date {
         Value::scalar(v.format(FORMAT).to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDate::parse_from_str(s, FORMAT)
-                    .map_err(|e| format!("Invalid `LocalDate`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
+        LocalDate::parse_from_str(s, FORMAT)
+            .map_err(|e| format!("Invalid `LocalDate`: {e}").into())
     }
 }
 
@@ -121,18 +117,13 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                // First, try to parse the most used format.
-                // At the end, try to parse the full format for the parsing
-                // error to be most informative.
-                LocalTime::parse_from_str(s, FORMAT_NO_MILLIS)
-                    .or_else(|_| LocalTime::parse_from_str(s, FORMAT_NO_SECS))
-                    .or_else(|_| LocalTime::parse_from_str(s, FORMAT))
-                    .map_err(|e| format!("Invalid `LocalTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
+        // First, try to parse the most used format.
+        // At the end, try to parse the full format for the parsing error to be most informative.
+        LocalTime::parse_from_str(s, FORMAT_NO_MILLIS)
+            .or_else(|_| LocalTime::parse_from_str(s, FORMAT_NO_SECS))
+            .or_else(|_| LocalTime::parse_from_str(s, FORMAT))
+            .map_err(|e| format!("Invalid `LocalTime`: {e}").into())
     }
 }
 
@@ -166,13 +157,9 @@ mod local_date_time {
         Value::scalar(v.format(FORMAT).to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDateTime::parse_from_str(s, FORMAT)
-                    .map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
+        LocalDateTime::parse_from_str(s, FORMAT)
+            .map_err(|e| format!("Invalid `LocalDateTime`: {e}").into())
     }
 }
 
@@ -216,17 +203,13 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input<Tz>(s: &impl ScalarValue) -> Result<DateTime<Tz>, String>
+    pub(super) fn from_input<Tz>(s: &str) -> Result<DateTime<Tz>, Box<str>>
     where
         Tz: TimeZone + FromFixedOffset,
     {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                DateTime::<FixedOffset>::parse_from_rfc3339(s)
-                    .map_err(|e| format!("Invalid `DateTime`: {e}"))
-                    .map(FromFixedOffset::from_fixed_offset)
-            })
+        DateTime::<FixedOffset>::parse_from_rfc3339(s)
+            .map(FromFixedOffset::from_fixed_offset)
+            .map_err(|e| format!("Invalid `DateTime`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -23,7 +23,7 @@ use std::fmt;
 
 use chrono::{FixedOffset, TimeZone};
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// Date in the proleptic Gregorian calendar (without time zone).
 ///
@@ -58,12 +58,9 @@ mod local_date {
         Value::scalar(v.format(FORMAT).to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalDate, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDate::parse_from_str(s, FORMAT)
                     .map_err(|e| format!("Invalid `LocalDate`: {e}"))
@@ -124,12 +121,9 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 // First, try to parse the most used format.
                 // At the end, try to parse the full format for the parsing
@@ -172,12 +166,9 @@ mod local_date_time {
         Value::scalar(v.format(FORMAT).to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalDateTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDateTime::parse_from_str(s, FORMAT)
                     .map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
@@ -225,13 +216,12 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input<S, Tz>(v: &InputValue<S>) -> Result<DateTime<Tz>, String>
+    pub(super) fn from_input<Tz>(s: &impl ScalarValue) -> Result<DateTime<Tz>, String>
     where
-        S: ScalarValue,
         Tz: TimeZone + FromFixedOffset,
     {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 DateTime::<FixedOffset>::parse_from_rfc3339(s)
                     .map_err(|e| format!("Invalid `DateTime`: {e}"))

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -59,8 +59,7 @@ mod local_date {
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
-        LocalDate::parse_from_str(s, FORMAT)
-            .map_err(|e| format!("Invalid `LocalDate`: {e}").into())
+        LocalDate::parse_from_str(s, FORMAT).map_err(|e| format!("Invalid `LocalDate`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/chrono_tz.rs
+++ b/juniper/src/integrations/chrono_tz.rs
@@ -11,7 +11,7 @@
 //! [1]: http://www.iana.org/time-zones
 //! [s1]: https://graphql-scalars.dev/docs/scalars/time-zone
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 // TODO: Try remove on upgrade of `chrono-tz` crate.
 mod for_minimal_versions_check_only {
@@ -45,9 +45,9 @@ mod tz {
         Value::scalar(v.name().to_owned())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<TimeZone, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZone, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 s.parse::<TimeZone>()
                     .map_err(|e| format!("Failed to parse `TimeZone`: {e}"))

--- a/juniper/src/integrations/chrono_tz.rs
+++ b/juniper/src/integrations/chrono_tz.rs
@@ -45,13 +45,9 @@ mod tz {
         Value::scalar(v.name().to_owned())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZone, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                s.parse::<TimeZone>()
-                    .map_err(|e| format!("Failed to parse `TimeZone`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<TimeZone, Box<str>> {
+        s.parse::<TimeZone>()
+            .map_err(|e| format!("Failed to parse `TimeZone`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -433,7 +433,8 @@ mod time_zone {
     }
 
     pub(super) fn from_input(s: &str) -> Result<TimeZone, Box<str>> {
-        s.parse().map_err(|e| format!("Invalid `TimeZone`: {e}").into())
+        s.parse()
+            .map_err(|e| format!("Invalid `TimeZone`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -90,12 +90,8 @@ mod local_date {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDate::strptime(FORMAT, s).map_err(|e| format!("Invalid `LocalDate`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
+        LocalDate::strptime(FORMAT, s).map_err(|e| format!("Invalid `LocalDate`: {e}").into())
     }
 }
 
@@ -150,18 +146,13 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                // First, try to parse the most used format.
-                // At the end, try to parse the full format for the parsing
-                // error to be most informative.
-                LocalTime::strptime(FORMAT_NO_MILLIS, s)
-                    .or_else(|_| LocalTime::strptime(FORMAT_NO_SECS, s))
-                    .or_else(|_| LocalTime::strptime(FORMAT, s))
-                    .map_err(|e| format!("Invalid `LocalTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
+        // First, try to parse the most used format.
+        // At the end, try to parse the full format for the parsing error to be most informative.
+        LocalTime::strptime(FORMAT_NO_MILLIS, s)
+            .or_else(|_| LocalTime::strptime(FORMAT_NO_SECS, s))
+            .or_else(|_| LocalTime::strptime(FORMAT, s))
+            .map_err(|e| format!("Invalid `LocalTime`: {e}").into())
     }
 }
 
@@ -201,13 +192,9 @@ mod local_date_time {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDateTime::strptime(FORMAT, s)
-                    .map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
+        LocalDateTime::strptime(FORMAT, s)
+            .map_err(|e| format!("Invalid `LocalDateTime`: {e}").into())
     }
 }
 
@@ -245,10 +232,8 @@ mod date_time {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| DateTime::from_str(s).map_err(|e| format!("Invalid `DateTime`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {
+        DateTime::from_str(s).map_err(|e| format!("Invalid `DateTime`: {e}").into())
     }
 }
 
@@ -287,12 +272,8 @@ mod zoned_date_time {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ZonedDateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                ZonedDateTime::from_str(s).map_err(|e| format!("Invalid `ZonedDateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<ZonedDateTime, Box<str>> {
+        ZonedDateTime::from_str(s).map_err(|e| format!("Invalid `ZonedDateTime`: {e}").into())
     }
 }
 
@@ -326,10 +307,8 @@ mod duration {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Duration, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| Duration::from_str(s).map_err(|e| format!("Invalid `Duration`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<Duration, Box<str>> {
+        Duration::from_str(s).map_err(|e| format!("Invalid `Duration`: {e}").into())
     }
 }
 
@@ -377,15 +356,11 @@ mod time_zone_or_utc_offset {
         ))
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZoneOrUtcOffset, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                TimeZoneOrUtcOffset::get(s)
-                    .map_err(TimeZoneParsingError::InvalidTimeZone)
-                    .or_else(|_| utc_offset::utc_offset_from_str(s).map(TimeZoneOrUtcOffset::fixed))
-                    .map_err(|e| format!("Invalid `TimeZoneOrUtcOffset`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<TimeZoneOrUtcOffset, Box<str>> {
+        TimeZoneOrUtcOffset::get(s)
+            .map_err(TimeZoneParsingError::InvalidTimeZone)
+            .or_else(|_| utc_offset::utc_offset_from_str(s).map(TimeZoneOrUtcOffset::fixed))
+            .map_err(|e| format!("Invalid `TimeZoneOrUtcOffset`: {e}").into())
     }
 }
 
@@ -457,10 +432,8 @@ mod time_zone {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZone, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| s.parse().map_err(|e| format!("Invalid `TimeZone`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<TimeZone, Box<str>> {
+        s.parse().map_err(|e| format!("Invalid `TimeZone`: {e}").into())
     }
 }
 
@@ -507,10 +480,8 @@ mod utc_offset {
         Value::scalar(buf)
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<UtcOffset, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| utc_offset_from_str(s).map_err(|e| format!("Invalid `UtcOffset`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<UtcOffset, Box<str>> {
+        utc_offset_from_str(s).map_err(|e| format!("Invalid `UtcOffset`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -54,7 +54,7 @@ use std::str;
 
 use derive_more::with_trait::{Debug, Display, Error, Into};
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// Representation of a civil date in the Gregorian calendar.
 ///
@@ -90,12 +90,9 @@ mod local_date {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalDate, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDate::strptime(FORMAT, s).map_err(|e| format!("Invalid `LocalDate`: {e}"))
             })
@@ -153,12 +150,9 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 // First, try to parse the most used format.
                 // At the end, try to parse the full format for the parsing
@@ -207,12 +201,9 @@ mod local_date_time {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<LocalDateTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDateTime::strptime(FORMAT, s)
                     .map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
@@ -254,12 +245,9 @@ mod date_time {
         Value::scalar(v.strftime(FORMAT).to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<DateTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| DateTime::from_str(s).map_err(|e| format!("Invalid `DateTime`: {e}")))
     }
 }
@@ -299,12 +287,9 @@ mod zoned_date_time {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<ZonedDateTime, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ZonedDateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 ZonedDateTime::from_str(s).map_err(|e| format!("Invalid `ZonedDateTime`: {e}"))
             })
@@ -341,12 +326,9 @@ mod duration {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<Duration, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Duration, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| Duration::from_str(s).map_err(|e| format!("Invalid `Duration`: {e}")))
     }
 }
@@ -395,12 +377,9 @@ mod time_zone_or_utc_offset {
         ))
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<TimeZoneOrUtcOffset, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZoneOrUtcOffset, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 TimeZoneOrUtcOffset::get(s)
                     .map_err(TimeZoneParsingError::InvalidTimeZone)
@@ -478,12 +457,9 @@ mod time_zone {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<TimeZone, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<TimeZone, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| s.parse().map_err(|e| format!("Invalid `TimeZone`: {e}")))
     }
 }
@@ -531,12 +507,9 @@ mod utc_offset {
         Value::scalar(buf)
     }
 
-    pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<UtcOffset, String>
-    where
-        S: ScalarValue,
-    {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<UtcOffset, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| utc_offset_from_str(s).map_err(|e| format!("Invalid `UtcOffset`: {e}")))
     }
 }

--- a/juniper/src/integrations/rust_decimal.rs
+++ b/juniper/src/integrations/rust_decimal.rs
@@ -42,13 +42,13 @@ mod rust_decimal_scalar {
     }
 
     pub(super) fn from_input(v: &Raw<impl ScalarValue>) -> Result<Decimal, Box<str>> {
-        if let Some(i) = v.as_int() {
+        if let Some(i) = v.try_to_int() {
             Ok(Decimal::from(i))
-        } else if let Some(f) = v.as_float() {
+        } else if let Some(f) = v.try_to_float() {
             Decimal::try_from(f)
                 .map_err(|e| format!("Failed to parse `Decimal` from `Float`: {e}").into())
         } else {
-            v.as_str()
+            v.try_as_str()
                 .ok_or_else(|| {
                     WrongInputScalarTypeError {
                         type_name: arcstr::literal!("String"),

--- a/juniper/src/integrations/rust_decimal.rs
+++ b/juniper/src/integrations/rust_decimal.rs
@@ -10,7 +10,7 @@
 
 use std::str::FromStr as _;
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// 128 bit representation of a fixed-precision decimal number.
 ///
@@ -40,14 +40,14 @@ mod rust_decimal_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Decimal, String> {
-        if let Some(i) = v.as_int_value() {
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Decimal, String> {
+        if let Some(i) = s.as_int() {
             Ok(Decimal::from(i))
-        } else if let Some(f) = v.as_float_value() {
+        } else if let Some(f) = s.as_float() {
             Decimal::try_from(f).map_err(|e| format!("Failed to parse `Decimal` from `Float`: {e}"))
         } else {
-            v.as_string_value()
-                .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            s.as_str()
+                .ok_or_else(|| format!("Expected `String`, found: {s}"))
                 .and_then(|s| {
                     Decimal::from_str(s)
                         .map_err(|e| format!("Failed to parse `Decimal` from `String`: {e}"))

--- a/juniper/src/integrations/rust_decimal.rs
+++ b/juniper/src/integrations/rust_decimal.rs
@@ -35,7 +35,6 @@ type Decimal = rust_decimal::Decimal;
 
 mod rust_decimal_scalar {
     use super::*;
-    use crate::WrongInputScalarTypeError;
 
     pub(super) fn to_output<S: ScalarValue>(v: &Decimal) -> Value<S> {
         Value::scalar(v.to_string())
@@ -48,15 +47,8 @@ mod rust_decimal_scalar {
             Decimal::try_from(f)
                 .map_err(|e| format!("Failed to parse `Decimal` from `Float`: {e}").into())
         } else {
-            v.try_as_str()
-                .ok_or_else(|| {
-                    WrongInputScalarTypeError {
-                        type_name: arcstr::literal!("String"),
-                        input: &**v,
-                    }
-                    .to_string()
-                    .into()
-                })
+            v.try_to::<&str>()
+                .map_err(|e| e.to_string().into())
                 .and_then(|s| {
                     Decimal::from_str(s)
                         .map_err(|e| format!("Failed to parse `Decimal` from `String`: {e}").into())

--- a/juniper/src/integrations/rust_decimal.rs
+++ b/juniper/src/integrations/rust_decimal.rs
@@ -10,7 +10,7 @@
 
 use std::str::FromStr as _;
 
-use crate::{Raw, ScalarValue, Value, graphql_scalar};
+use crate::{Scalar, ScalarValue, Value, graphql_scalar};
 
 /// 128 bit representation of a fixed-precision decimal number.
 ///
@@ -40,7 +40,7 @@ mod rust_decimal_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(v: &Raw<impl ScalarValue>) -> Result<Decimal, Box<str>> {
+    pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<Decimal, Box<str>> {
         if let Some(i) = v.try_to_int() {
             Ok(Decimal::from(i))
         } else if let Some(f) = v.try_to_float() {

--- a/juniper/src/integrations/time.rs
+++ b/juniper/src/integrations/time.rs
@@ -62,12 +62,8 @@ mod local_date {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDate::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDate`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
+        LocalDate::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDate`: {e}").into())
     }
 }
 
@@ -121,18 +117,13 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                // First, try to parse the most used format.
-                // At the end, try to parse the full format for the parsing
-                // error to be most informative.
-                LocalTime::parse(s, FORMAT_NO_MILLIS)
-                    .or_else(|_| LocalTime::parse(s, FORMAT_NO_SECS))
-                    .or_else(|_| LocalTime::parse(s, FORMAT))
-                    .map_err(|e| format!("Invalid `LocalTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
+        // First, try to parse the most used format.
+        // At the end, try to parse the full format for the parsing error to be most informative.
+        LocalTime::parse(s, FORMAT_NO_MILLIS)
+            .or_else(|_| LocalTime::parse(s, FORMAT_NO_SECS))
+            .or_else(|_| LocalTime::parse(s, FORMAT))
+            .map_err(|e| format!("Invalid `LocalTime`: {e}").into())
     }
 }
 
@@ -167,12 +158,8 @@ mod local_date_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                LocalDateTime::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
+        LocalDateTime::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDateTime`: {e}").into())
     }
 }
 
@@ -206,13 +193,10 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                DateTime::parse(s, &Rfc3339).map_err(|e| format!("Invalid `DateTime`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {
+        DateTime::parse(s, &Rfc3339)
             .map(|dt| dt.to_offset(UtcOffset::UTC))
+            .map_err(|e| format!("Invalid `DateTime`: {e}").into())
     }
 }
 
@@ -248,13 +232,9 @@ mod utc_offset {
         )
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<UtcOffset, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| {
-                UtcOffset::parse(s, UTC_OFFSET_FORMAT)
-                    .map_err(|e| format!("Invalid `UtcOffset`: {e}"))
-            })
+    pub(super) fn from_input(s: &str) -> Result<UtcOffset, Box<str>> {
+        UtcOffset::parse(s, UTC_OFFSET_FORMAT)
+            .map_err(|e| format!("Invalid `UtcOffset`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/time.rs
+++ b/juniper/src/integrations/time.rs
@@ -27,7 +27,7 @@ use time::{
     macros::format_description,
 };
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// Date in the proleptic Gregorian calendar (without time zone).
 ///
@@ -62,9 +62,9 @@ mod local_date {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<LocalDate, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDate, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDate::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDate`: {e}"))
             })
@@ -121,9 +121,9 @@ mod local_time {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<LocalTime, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 // First, try to parse the most used format.
                 // At the end, try to parse the full format for the parsing
@@ -167,9 +167,9 @@ mod local_date_time {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<LocalDateTime, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<LocalDateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 LocalDateTime::parse(s, FORMAT).map_err(|e| format!("Invalid `LocalDateTime`: {e}"))
             })
@@ -206,9 +206,9 @@ mod date_time {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<DateTime, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<DateTime, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 DateTime::parse(s, &Rfc3339).map_err(|e| format!("Invalid `DateTime`: {e}"))
             })
@@ -248,9 +248,9 @@ mod utc_offset {
         )
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<UtcOffset, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<UtcOffset, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 UtcOffset::parse(s, UTC_OFFSET_FORMAT)
                     .map_err(|e| format!("Invalid `UtcOffset`: {e}"))

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -36,10 +36,8 @@ mod url_scalar {
         Value::scalar(v.as_str().to_owned())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Url, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| Url::parse(s).map_err(|e| format!("Failed to parse `URL`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<Url, Box<str>> {
+        Url::parse(s).map_err(|e| format!("Failed to parse `URL`: {e}").into())
     }
 }
 

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -9,7 +9,7 @@
 //! [`Url`]: url::Url
 //! [s1]: https://graphql-scalars.dev/docs/scalars/url
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// [Standard URL][0] format as specified in [RFC 3986].
 ///
@@ -36,9 +36,9 @@ mod url_scalar {
         Value::scalar(v.as_str().to_owned())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Url, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Url, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| Url::parse(s).map_err(|e| format!("Failed to parse `URL`: {e}")))
     }
 }

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -9,7 +9,7 @@
 //! [`Uuid`]: uuid::Uuid
 //! [s1]: https://graphql-scalars.dev/docs/scalars/uuid
 
-use crate::{InputValue, ScalarValue, Value, graphql_scalar};
+use crate::{ScalarValue, Value, graphql_scalar};
 
 /// [Universally Unique Identifier][0] (UUID).
 ///
@@ -35,9 +35,9 @@ mod uuid_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Uuid, String> {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Uuid, String> {
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| Uuid::parse_str(s).map_err(|e| format!("Failed to parse `UUID`: {e}")))
     }
 }

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -35,10 +35,8 @@ mod uuid_scalar {
         Value::scalar(v.to_string())
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Uuid, String> {
-        s.as_str()
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
-            .and_then(|s| Uuid::parse_str(s).map_err(|e| format!("Failed to parse `UUID`: {e}")))
+    pub(super) fn from_input(s: &str) -> Result<Uuid, Box<str>> {
+        Uuid::parse_str(s).map_err(|e| format!("Failed to parse `UUID`: {e}").into())
     }
 }
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::{
     validation::RuleError,
     value::{
         AnyExt, DefaultScalarValue, IntoValue, Object, ParseScalarResult, ParseScalarValue,
-        ScalarValue, Value,
+        ScalarValue, Value, TryScalarValueTo, ScalarValueFmt, WrongInputScalarTypeError,
     },
 };
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::{
     validation::RuleError,
     value::{
         AnyExt, DefaultScalarValue, IntoValue, Object, ParseScalarResult, ParseScalarValue, Scalar,
-        ScalarValue, ScalarValueFmt, TryScalarValueTo, Value, WrongInputScalarTypeError,
+        ScalarValue, TryScalarValueTo, Value, WrongInputScalarTypeError,
     },
 };
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -56,9 +56,9 @@ pub mod tests;
 #[cfg(test)]
 mod executor_tests;
 
-use derive_more::with_trait::{Deref, Display, From};
+use derive_more::with_trait::{Display, From};
 use itertools::Itertools as _;
-use ref_cast::RefCast;
+
 // Needs to be public because macros use it.
 pub use crate::util::to_camel_case;
 
@@ -103,7 +103,7 @@ pub use crate::{
     },
     validation::RuleError,
     value::{
-        AnyExt, DefaultScalarValue, IntoValue, Object, ParseScalarResult, ParseScalarValue,
+        AnyExt, DefaultScalarValue, IntoValue, Object, ParseScalarResult, ParseScalarValue, Scalar,
         ScalarValue, ScalarValueFmt, TryScalarValueTo, Value, WrongInputScalarTypeError,
     },
 };
@@ -319,7 +319,3 @@ where
         context,
     )
 }
-
-#[derive(Debug, Deref, Display, RefCast)]
-#[repr(transparent)]
-pub struct Raw<T: ?Sized>(T);

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -56,9 +56,9 @@ pub mod tests;
 #[cfg(test)]
 mod executor_tests;
 
-use derive_more::with_trait::{Display, From};
+use derive_more::with_trait::{Deref, Display, From};
 use itertools::Itertools as _;
-
+use ref_cast::RefCast;
 // Needs to be public because macros use it.
 pub use crate::util::to_camel_case;
 
@@ -104,7 +104,7 @@ pub use crate::{
     validation::RuleError,
     value::{
         AnyExt, DefaultScalarValue, IntoValue, Object, ParseScalarResult, ParseScalarValue,
-        ScalarValue, Value, TryScalarValueTo, ScalarValueFmt, WrongInputScalarTypeError,
+        ScalarValue, ScalarValueFmt, TryScalarValueTo, Value, WrongInputScalarTypeError,
     },
 };
 
@@ -319,3 +319,7 @@ where
         context,
     )
 }
+
+#[derive(Debug, Deref, Display, RefCast)]
+#[repr(transparent)]
+pub struct Raw<T: ?Sized>(T);

--- a/juniper/src/macros/helper/mod.rs
+++ b/juniper/src/macros/helper/mod.rs
@@ -6,10 +6,7 @@ use std::{convert::Infallible, fmt};
 
 use futures::future::{self, BoxFuture};
 
-use crate::{
-    DefaultScalarValue, FieldError, FieldResult, GraphQLScalar, InputValue, IntoFieldError,
-    ScalarValue,
-};
+use crate::FieldError;
 
 /// This trait is used by [`graphql_scalar!`] macro to retrieve [`Error`] type
 /// from a [`Result`].

--- a/juniper/src/macros/helper/mod.rs
+++ b/juniper/src/macros/helper/mod.rs
@@ -2,17 +2,17 @@
 
 pub mod subscription;
 
-use std::{convert::Infallible, fmt};
+use std::convert::Infallible;
 
+use derive_more::with_trait::Display;
 use futures::future::{self, BoxFuture};
 
-use crate::FieldError;
+use crate::{FieldError, InputValue, ScalarValue};
 
-/// This trait is used by [`graphql_scalar!`] macro to retrieve [`Error`] type
-/// from a [`Result`].
+/// This trait is used by [`graphql_scalar`] macro to retrieve [`Error`] type from a [`Result`].
 ///
 /// [`Error`]: Result::Error
-/// [`graphql_scalar!`]: macro@crate::graphql_scalar
+/// [`graphql_scalar`]: macro@crate::graphql_scalar
 pub trait ExtractError {
     /// Extracted [`Error`] type of this [`Result`].
     ///
@@ -28,7 +28,7 @@ impl<T, E> ExtractError for Result<T, E> {
 /// which immediately resolves into [`FieldError`].
 pub fn err_fut<'ok, D, Ok, S>(msg: D) -> BoxFuture<'ok, Result<Ok, FieldError<S>>>
 where
-    D: fmt::Display,
+    D: Display,
     Ok: Send + 'ok,
     S: Send + 'static,
 {
@@ -53,6 +53,11 @@ where
 {
     Box::pin(future::err(err_unnamed_type(name)))
 }
+
+/// Error of an [`InputValue`] not representing a [`ScalarValue`], used in macro expansions.
+#[derive(Display)]
+#[display("Expected GraphQL scalar, found: {_0}")]
+pub struct NotScalarError<'a, S: ScalarValue>(pub &'a InputValue<S>);
 
 /// [Autoref-based specialized][0] coercion into a [`Result`] for a function call for providing a
 /// return-type polymorphism in macros.

--- a/juniper/src/schema/translate/graphql_parser.rs
+++ b/juniper/src/schema/translate/graphql_parser.rs
@@ -107,13 +107,13 @@ impl GraphQLParserTranslator {
         match input {
             InputValue::Null => ExternalValue::Null,
             InputValue::Scalar(x) => {
-                if let Some(v) = x.as_string() {
+                if let Some(v) = x.try_to_string() {
                     ExternalValue::String(v)
-                } else if let Some(v) = x.as_int() {
+                } else if let Some(v) = x.try_to_int() {
                     ExternalValue::Int(ExternalNumber::from(v))
-                } else if let Some(v) = x.as_float() {
+                } else if let Some(v) = x.try_to_float() {
                     ExternalValue::Float(v)
-                } else if let Some(v) = x.as_bool() {
+                } else if let Some(v) = x.try_to_bool() {
                     ExternalValue::Boolean(v)
                 } else {
                     panic!("unknown argument type")

--- a/juniper/src/tests/introspection_tests.rs
+++ b/juniper/src/tests/introspection_tests.rs
@@ -2,15 +2,14 @@ use std::collections::HashSet;
 
 use pretty_assertions::assert_eq;
 
+use super::schema_introspection::*;
 use crate::{
-    graphql_vars,
+    ScalarValue as _, graphql_vars,
     introspection::IntrospectionFormat,
     schema::model::RootNode,
     tests::fixtures::starwars::schema::{Database, Query},
     types::scalars::{EmptyMutation, EmptySubscription},
 };
-
-use super::schema_introspection::*;
 
 #[tokio::test]
 async fn test_introspection_query_type_name() {
@@ -270,8 +269,9 @@ async fn test_introspection_possible_types() {
                 .expect("possible type not an object")
                 .get_field_value("name")
                 .expect("'name' not present in type")
-                .as_scalar_value::<String>()
-                .expect("'name' not a string") as &str
+                .as_scalar()
+                .and_then(|s| s.try_as_str())
+                .expect("'name' not a string")
         })
         .collect::<HashSet<_>>();
 

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -668,13 +668,13 @@ mod coercion {
         assert_eq!(
             <Vec<i32>>::from_input_value(&v),
             Err(FromInputValueVecError::Item(
-                "Expected `Int`, found: null".into_field_error(),
+                "Expected GraphQL scalar, found: null".into_field_error(),
             )),
         );
         assert_eq!(
             <Option<Vec<i32>>>::from_input_value(&v),
             Err(FromInputValueVecError::Item(
-                "Expected `Int`, found: null".into_field_error(),
+                "Expected GraphQL scalar, found: null".into_field_error(),
             )),
         );
         assert_eq!(
@@ -778,13 +778,13 @@ mod coercion {
         assert_eq!(
             <[i32; 3]>::from_input_value(&v),
             Err(FromInputValueArrayError::Item(
-                "Expected `Int`, found: null".into_field_error(),
+                "Expected GraphQL scalar, found: null".into_field_error(),
             )),
         );
         assert_eq!(
             <Option<[i32; 3]>>::from_input_value(&v),
             Err(FromInputValueArrayError::Item(
-                "Expected `Int`, found: null".into_field_error(),
+                "Expected GraphQL scalar, found: null".into_field_error(),
             )),
         );
         assert_eq!(

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -1,4 +1,4 @@
-use std::{char, marker::PhantomData, rc::Rc, thread::JoinHandle};
+use std::{char, marker::PhantomData, rc::Rc, thread::JoinHandle, convert::Infallible};
 
 use derive_more::with_trait::{Deref, Display, From, Into};
 use serde::{Deserialize, Serialize};
@@ -60,9 +60,8 @@ mod impl_string_scalar {
         Value::scalar(v.to_owned())
     }
 
-    pub(super) fn from_input(v: &impl ScalarValue) -> Result<String, String> {
-        v.as_string()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+    pub(super) fn from_input(s: String) -> Result<String, Infallible> {
+        Ok(s)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -174,18 +173,17 @@ where
 type ArcStr = arcstr::ArcStr;
 
 mod impl_arcstr_scalar {
-    use crate::{IntoValue as _, ScalarValue, Value};
+    use std::convert::Infallible;
 
+    use crate::{IntoValue as _, ScalarValue, Value};
     use super::ArcStr;
 
     pub(super) fn to_output<S: ScalarValue>(v: &ArcStr) -> Value<S> {
         v.into_value()
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ArcStr, String> {
-        s.as_str()
-            .map(Into::into)
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
+    pub(super) fn from_input(s: &str) -> Result<ArcStr, Infallible> {
+        Ok(s.into())
     }
 }
 
@@ -194,18 +192,17 @@ mod impl_arcstr_scalar {
 type CompactString = compact_str::CompactString;
 
 mod impl_compactstring_scalar {
-    use crate::{IntoValue as _, ScalarValue, Value};
+    use std::convert::Infallible;
 
+    use crate::{IntoValue as _, ScalarValue, Value};
     use super::CompactString;
 
     pub(super) fn to_output<S: ScalarValue>(v: &CompactString) -> Value<S> {
         v.into_value()
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<CompactString, String> {
-        s.as_str()
-            .map(Into::into)
-            .ok_or_else(|| format!("Expected `String`, found: {s}"))
+    pub(super) fn from_input(s: &str) -> Result<CompactString, Infallible> {
+        Ok(s.into())
     }
 }
 
@@ -290,9 +287,8 @@ mod impl_boolean_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Boolean, String> {
-        s.as_bool()
-            .ok_or_else(|| format!("Expected `Boolean`, found: {s}"))
+    pub(super) fn from_input(b: Boolean) -> Result<Boolean, Infallible> {
+        Ok(b)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -312,9 +308,8 @@ mod impl_int_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Int, String> {
-        s.as_int()
-            .ok_or_else(|| format!("Expected `Int`, found: {s}"))
+    pub(super) fn from_input(i: Int) -> Result<Int, Infallible> {
+        Ok(i)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -339,9 +334,8 @@ mod impl_float_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Float, String> {
-        s.as_float()
-            .ok_or_else(|| format!("Expected `Float`, found: {s}"))
+    pub(super) fn from_input(f: Float) -> Result<Float, Infallible> {
+        Ok(f)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -480,7 +480,7 @@ impl<T> Default for EmptySubscription<T> {
 mod tests {
     use crate::{
         parser::ScalarToken,
-        value::{DefaultScalarValue, ParseScalarValue},
+        value::{DefaultScalarValue, ParseScalarValue, ScalarValue as _},
     };
 
     use super::{EmptyMutation, EmptySubscription, ID};
@@ -488,20 +488,20 @@ mod tests {
     #[test]
     fn test_id_from_string() {
         let actual = ID::from(String::from("foo"));
-        let expected = ID(String::from("foo"));
+        let expected = ID("foo".into());
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn test_id_new() {
         let actual = ID::new("foo");
-        let expected = ID(String::from("foo"));
+        let expected = ID("foo".into());
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn test_id_deref() {
-        let id = ID(String::from("foo"));
+        let id = ID("foo".into());
         assert_eq!(id.len(), 3);
     }
 
@@ -517,7 +517,7 @@ mod tests {
             let s =
                 <String as ParseScalarValue<DefaultScalarValue>>::from_str(ScalarToken::String(s));
             assert!(s.is_ok(), "A parsing error occurred: {s:?}");
-            let s: Option<String> = s.unwrap().into();
+            let s: Option<String> = s.unwrap().try_to().ok();
             assert!(s.is_some(), "No string returned");
             assert_eq!(s.unwrap(), expected);
         }
@@ -545,7 +545,7 @@ mod tests {
             let n = <f64 as ParseScalarValue<DefaultScalarValue>>::from_str(ScalarToken::Int(v));
             assert!(n.is_ok(), "A parsing error occurred: {:?}", n.unwrap_err());
 
-            let n: Option<f64> = n.unwrap().into();
+            let n: Option<f64> = n.unwrap().try_to().ok();
             assert!(n.is_some(), "No `f64` returned");
             assert_eq!(n.unwrap(), f64::from(expected));
         }
@@ -563,7 +563,7 @@ mod tests {
             let n = <f64 as ParseScalarValue<DefaultScalarValue>>::from_str(ScalarToken::Float(v));
             assert!(n.is_ok(), "A parsing error occurred: {:?}", n.unwrap_err());
 
-            let n: Option<f64> = n.unwrap().into();
+            let n: Option<f64> = n.unwrap().try_to().ok();
             assert!(n.is_some(), "No `f64` returned");
             assert_eq!(n.unwrap(), expected);
         }

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -1,4 +1,4 @@
-use std::{char, convert::Infallible, marker::PhantomData, rc::Rc, thread::JoinHandle};
+use std::{char, convert::identity, marker::PhantomData, rc::Rc, thread::JoinHandle};
 
 use derive_more::with_trait::{Deref, Display, From, Into};
 use serde::{Deserialize, Serialize};
@@ -56,7 +56,7 @@ impl ID {
 }
 
 #[graphql_scalar]
-#[graphql(with = impl_string_scalar)]
+#[graphql(with = impl_string_scalar, from_input_with = identity::<String>)]
 type String = std::string::String;
 
 mod impl_string_scalar {
@@ -64,10 +64,6 @@ mod impl_string_scalar {
 
     pub(super) fn to_output<S: ScalarValue>(v: &str) -> Value<S> {
         Value::scalar(v.to_owned())
-    }
-
-    pub(super) fn from_input(s: String) -> Result<String, Infallible> {
-        Ok(s)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -179,8 +175,6 @@ where
 type ArcStr = arcstr::ArcStr;
 
 mod impl_arcstr_scalar {
-    use std::convert::Infallible;
-
     use super::ArcStr;
     use crate::{IntoValue as _, ScalarValue, Value};
 
@@ -188,8 +182,8 @@ mod impl_arcstr_scalar {
         v.into_value()
     }
 
-    pub(super) fn from_input(s: &str) -> Result<ArcStr, Infallible> {
-        Ok(s.into())
+    pub(super) fn from_input(s: &str) -> ArcStr {
+        s.into()
     }
 }
 
@@ -198,8 +192,6 @@ mod impl_arcstr_scalar {
 type CompactString = compact_str::CompactString;
 
 mod impl_compactstring_scalar {
-    use std::convert::Infallible;
-
     use super::CompactString;
     use crate::{IntoValue as _, ScalarValue, Value};
 
@@ -207,8 +199,8 @@ mod impl_compactstring_scalar {
         v.into_value()
     }
 
-    pub(super) fn from_input(s: &str) -> Result<CompactString, Infallible> {
-        Ok(s.into())
+    pub(super) fn from_input(s: &str) -> CompactString {
+        s.into()
     }
 }
 
@@ -283,7 +275,7 @@ where
 }
 
 #[graphql_scalar]
-#[graphql(with = impl_boolean_scalar)]
+#[graphql(with = impl_boolean_scalar, from_input_with = identity::<Boolean>)]
 type Boolean = bool;
 
 mod impl_boolean_scalar {
@@ -293,10 +285,6 @@ mod impl_boolean_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(b: Boolean) -> Result<Boolean, Infallible> {
-        Ok(b)
-    }
-
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
         // `Boolean`s are parsed separately, they shouldn't reach this code path.
         Err(ParseError::unexpected_token(Token::Scalar(value)))
@@ -304,7 +292,7 @@ mod impl_boolean_scalar {
 }
 
 #[graphql_scalar]
-#[graphql(with = impl_int_scalar)]
+#[graphql(with = impl_int_scalar, from_input_with = identity::<Int>)]
 type Int = i32;
 
 mod impl_int_scalar {
@@ -312,10 +300,6 @@ mod impl_int_scalar {
 
     pub(super) fn to_output<S: ScalarValue>(v: &Int) -> Value<S> {
         Value::scalar(*v)
-    }
-
-    pub(super) fn from_input(i: Int) -> Result<Int, Infallible> {
-        Ok(i)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -330,7 +314,7 @@ mod impl_int_scalar {
 }
 
 #[graphql_scalar]
-#[graphql(with = impl_float_scalar)]
+#[graphql(with = impl_float_scalar, from_input_with = identity::<Float>)]
 type Float = f64;
 
 mod impl_float_scalar {
@@ -338,10 +322,6 @@ mod impl_float_scalar {
 
     pub(super) fn to_output<S: ScalarValue>(v: &Float) -> Value<S> {
         Value::scalar(*v)
-    }
-
-    pub(super) fn from_input(f: Float) -> Result<Float, Infallible> {
-        Ok(f)
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -34,12 +34,11 @@ impl ID {
         Value::scalar(self.0.clone())
     }
 
-    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Self, String> {
-        v.as_string_value()
-            .map(str::to_owned)
-            .or_else(|| v.as_int_value().as_ref().map(ToString::to_string))
+    fn from_input(s: &impl ScalarValue) -> Result<Self, String> {
+        s.as_string()
+            .or_else(|| s.as_int().as_ref().map(ToString::to_string))
             .map(Self)
-            .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+            .ok_or_else(|| format!("Expected `String` or `Int`, found: {s}"))
     }
 }
 
@@ -61,9 +60,8 @@ mod impl_string_scalar {
         Value::scalar(v.to_owned())
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<String, String> {
-        v.as_string_value()
-            .map(str::to_owned)
+    pub(super) fn from_input(v: &impl ScalarValue) -> Result<String, String> {
+        v.as_string()
             .ok_or_else(|| format!("Expected `String`, found: {v}"))
     }
 
@@ -176,7 +174,7 @@ where
 type ArcStr = arcstr::ArcStr;
 
 mod impl_arcstr_scalar {
-    use crate::{InputValue, IntoValue as _, ScalarValue, Value};
+    use crate::{IntoValue as _, ScalarValue, Value};
 
     use super::ArcStr;
 
@@ -184,10 +182,10 @@ mod impl_arcstr_scalar {
         v.into_value()
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<ArcStr, String> {
-        v.as_string_value()
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<ArcStr, String> {
+        s.as_str()
             .map(Into::into)
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
     }
 }
 
@@ -196,7 +194,7 @@ mod impl_arcstr_scalar {
 type CompactString = compact_str::CompactString;
 
 mod impl_compactstring_scalar {
-    use crate::{InputValue, IntoValue as _, ScalarValue, Value};
+    use crate::{IntoValue as _, ScalarValue, Value};
 
     use super::CompactString;
 
@@ -204,10 +202,10 @@ mod impl_compactstring_scalar {
         v.into_value()
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<CompactString, String> {
-        v.as_string_value()
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<CompactString, String> {
+        s.as_str()
             .map(Into::into)
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
     }
 }
 
@@ -292,10 +290,9 @@ mod impl_boolean_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Boolean, String> {
-        v.as_scalar_value()
-            .and_then(ScalarValue::as_bool)
-            .ok_or_else(|| format!("Expected `Boolean`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Boolean, String> {
+        s.as_bool()
+            .ok_or_else(|| format!("Expected `Boolean`, found: {s}"))
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -315,9 +312,9 @@ mod impl_int_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Int, String> {
-        v.as_int_value()
-            .ok_or_else(|| format!("Expected `Int`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Int, String> {
+        s.as_int()
+            .ok_or_else(|| format!("Expected `Int`, found: {s}"))
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -342,9 +339,9 @@ mod impl_float_scalar {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Float, String> {
-        v.as_float_value()
-            .ok_or_else(|| format!("Expected `Float`, found: {v}"))
+    pub(super) fn from_input(s: &impl ScalarValue) -> Result<Float, String> {
+        s.as_float()
+            .ok_or_else(|| format!("Expected `Float`, found: {s}"))
     }
 
     pub(super) fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -4,7 +4,7 @@ use derive_more::with_trait::{Deref, Display, From, Into};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    GraphQLScalar, Raw,
+    GraphQLScalar, Scalar,
     ast::{InputValue, Selection, ToInputValue},
     executor::{ExecutionResult, Executor, Registry},
     graphql_scalar,
@@ -36,7 +36,7 @@ impl ID {
         Value::scalar(self.0.clone().into_string())
     }
 
-    fn from_input<S: ScalarValue>(v: &Raw<S>) -> Result<Self, WrongInputScalarTypeError<'_, S>> {
+    fn from_input<S: ScalarValue>(v: &Scalar<S>) -> Result<Self, WrongInputScalarTypeError<'_, S>> {
         v.try_to_string()
             .or_else(|| v.try_to_int().as_ref().map(ToString::to_string))
             .map(|s| Self(s.into()))

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -37,8 +37,8 @@ impl ID {
     }
 
     fn from_input<S: ScalarValue>(v: &Raw<S>) -> Result<Self, WrongInputScalarTypeError<'_, S>> {
-        v.as_string()
-            .or_else(|| v.as_int().as_ref().map(ToString::to_string))
+        v.try_to_string()
+            .or_else(|| v.try_to_int().as_ref().map(ToString::to_string))
             .map(|s| Self(s.into()))
             .ok_or_else(|| WrongInputScalarTypeError {
                 type_name: arcstr::literal!("String` or `Int"),

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -250,8 +250,8 @@ where
 
     match value {
         // TODO: avoid this bad duplicate as_str() call. (value system refactor)
-        InputValue::Scalar(scalar) if scalar.as_str().is_some() => {
-            if let Some(name) = scalar.as_str() {
+        InputValue::Scalar(scalar) if scalar.try_as_str().is_some() => {
+            if let Some(name) = scalar.try_as_str() {
                 if !meta.values.iter().any(|ev| ev.name == *name) {
                     errors.push(unification_error(
                         var_name,

--- a/juniper/src/validation/test_harness.rs
+++ b/juniper/src/validation/test_harness.rs
@@ -233,7 +233,7 @@ where
 {
     type Error = &'static str;
 
-    fn from_input_value<'a>(v: &InputValue<S>) -> Result<DogCommand, Self::Error> {
+    fn from_input_value(v: &InputValue<S>) -> Result<DogCommand, Self::Error> {
         match v.as_enum_value() {
             Some("SIT") => Ok(DogCommand::Sit),
             Some("HEEL") => Ok(DogCommand::Heel),
@@ -335,7 +335,7 @@ where
 {
     type Error = &'static str;
 
-    fn from_input_value<'a>(v: &InputValue<S>) -> Result<FurColor, Self::Error> {
+    fn from_input_value(v: &InputValue<S>) -> Result<FurColor, Self::Error> {
         match v.as_enum_value() {
             Some("BROWN") => Ok(FurColor::Brown),
             Some("BLACK") => Ok(FurColor::Black),
@@ -611,7 +611,7 @@ where
 {
     type Error = FieldError<S>;
 
-    fn from_input_value<'a>(v: &InputValue<S>) -> Result<ComplexInput, Self::Error> {
+    fn from_input_value(v: &InputValue<S>) -> Result<ComplexInput, Self::Error> {
         let obj = v.to_object_value().ok_or("Expected object")?;
 
         Ok(ComplexInput {

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -77,17 +77,6 @@ impl<S> Value<S> {
         }
     }
 
-    /// View the underlying float value, if present.
-    pub fn as_float_value(&self) -> Option<f64>
-    where
-        S: ScalarValue,
-    {
-        match self {
-            Self::Scalar(s) => s.as_float(),
-            _ => None,
-        }
-    }
-
     /// View the underlying object value, if present.
     pub fn as_object_value(&self) -> Option<&Object<S>> {
         match self {
@@ -139,18 +128,16 @@ impl<S> Value<S> {
     }
 
     /// Maps the [`ScalarValue`] type of this [`Value`] into the specified one.
-    pub fn map_scalar_value<Into>(self) -> Value<Into>
+    pub fn map_scalar_value<T>(self) -> Value<T>
     where
         S: ScalarValue,
-        Into: ScalarValue,
+        T: ScalarValue,
     {
-        if TypeId::of::<Into>() == TypeId::of::<S>() {
-            // SAFETY: This is safe, because we're transmuting the value into
-            //         itself, so no invariants may change and we're just
-            //         satisfying the type checker.
-            //         As `mem::transmute_copy` creates a copy of data, we need
-            //         `mem::ManuallyDrop` here to omit double-free when
-            //         `S: Drop`.
+        if TypeId::of::<T>() == TypeId::of::<S>() {
+            // SAFETY: This is safe, because we're transmuting the value into itself, so no 
+            //         invariants may change, and we're just satisfying the type checker.
+            //         As `mem::transmute_copy` creates a copy of the data, we need the
+            //         `mem::ManuallyDrop` here to omit double-free when `S: Drop`.
             let val = mem::ManuallyDrop::new(self);
             unsafe { mem::transmute_copy(&*val) }
         } else {

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -6,13 +6,16 @@ use std::{any::TypeId, borrow::Cow, fmt, mem};
 use arcstr::ArcStr;
 use compact_str::CompactString;
 
+pub use self::{
+    object::Object,
+    scalar::{
+        AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarValue,
+        ScalarValueFmt, TryScalarValueTo, WrongInputScalarTypeError,
+    },
+};
 use crate::{
     ast::{InputValue, ToInputValue},
     parser::Spanning,
-};
-pub use self::{
-    object::Object,
-    scalar::{AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarValue, TryScalarValueTo, ScalarValueFmt, WrongInputScalarTypeError},
 };
 
 /// Serializable value returned from query and field execution.
@@ -193,9 +196,7 @@ impl<S: ScalarValue> fmt::Display for Value<S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Null => write!(f, "null"),
-            Self::Scalar(s) => {
-                fmt::Display::fmt(&ScalarValueFmt(s), f)
-            }
+            Self::Scalar(s) => fmt::Display::fmt(&ScalarValueFmt(s), f),
             Self::List(list) => {
                 write!(f, "[")?;
                 for (idx, item) in list.iter().enumerate() {

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -134,7 +134,7 @@ impl<S> Value<S> {
         T: ScalarValue,
     {
         if TypeId::of::<T>() == TypeId::of::<S>() {
-            // SAFETY: This is safe, because we're transmuting the value into itself, so no 
+            // SAFETY: This is safe, because we're transmuting the value into itself, so no
             //         invariants may change, and we're just satisfying the type checker.
             //         As `mem::transmute_copy` creates a copy of the data, we need the
             //         `mem::ManuallyDrop` here to omit double-free when `S: Drop`.

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -6,11 +6,12 @@ use std::{any::TypeId, borrow::Cow, fmt, mem};
 use arcstr::ArcStr;
 use compact_str::CompactString;
 
+pub(crate) use self::scalar::ScalarValueFmt;
 pub use self::{
     object::Object,
     scalar::{
         AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, Scalar, ScalarValue,
-        ScalarValueFmt, TryScalarValueTo, WrongInputScalarTypeError,
+        TryScalarValueTo, WrongInputScalarTypeError,
     },
 };
 use crate::{

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -67,17 +67,6 @@ impl<S> Value<S> {
         matches!(*self, Self::Null)
     }
 
-    /// View the underlying scalar value if present
-    pub fn as_scalar_value<'a, T>(&'a self) -> Option<&'a T>
-    where
-        Option<&'a T>: From<&'a S>,
-    {
-        match self {
-            Self::Scalar(s) => s.into(),
-            _ => None,
-        }
-    }
-
     /// View the underlying object value, if present.
     pub fn as_object_value(&self) -> Option<&Object<S>> {
         match self {
@@ -118,14 +107,6 @@ impl<S> Value<S> {
             Self::Scalar(s) => Some(s),
             _ => None,
         }
-    }
-
-    /// View the underlying string value, if present.
-    pub fn as_string_value<'a>(&'a self) -> Option<&'a str>
-    where
-        Option<&'a String>: From<&'a S>,
-    {
-        self.as_scalar_value::<String>().map(String::as_str)
     }
 
     /// Maps the [`ScalarValue`] type of this [`Value`] into the specified one.

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -9,7 +9,7 @@ use compact_str::CompactString;
 pub use self::{
     object::Object,
     scalar::{
-        AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarValue,
+        AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, Scalar, ScalarValue,
         ScalarValueFmt, TryScalarValueTo, WrongInputScalarTypeError,
     },
 };

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -10,10 +10,9 @@ use crate::{
     ast::{InputValue, ToInputValue},
     parser::Spanning,
 };
-
 pub use self::{
     object::Object,
-    scalar::{AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarValue},
+    scalar::{AnyExt, DefaultScalarValue, ParseScalarResult, ParseScalarValue, ScalarValue, TryScalarValueTo, ScalarValueFmt, WrongInputScalarTypeError},
 };
 
 /// Serializable value returned from query and field execution.
@@ -195,11 +194,7 @@ impl<S: ScalarValue> fmt::Display for Value<S> {
         match self {
             Self::Null => write!(f, "null"),
             Self::Scalar(s) => {
-                if let Some(string) = s.as_string() {
-                    write!(f, "\"{string}\"")
-                } else {
-                    write!(f, "{s}")
-                }
+                fmt::Display::fmt(&ScalarValueFmt(s), f)
             }
             Self::List(list) => {
                 write!(f, "[")?;

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -187,13 +187,7 @@ pub trait ScalarValue:
     /// assert_eq!(value.is_type::<f64>(), false);
     /// ```
     #[must_use]
-    fn is_type<'a, T>(&'a self) -> bool
-    where
-        T: 'a,
-        Self: TryScalarValueTo<'a, &'a T, Error: IntoFieldError<Self>>,
-    {
-        self.try_scalar_value_to().is_ok()
-    }
+    fn is_type<T: Any + ?Sized>(&self) -> bool;
 
     /// Tries to represent this [`ScalarValue`] as the specified type `T`.
     /// 

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -9,7 +9,7 @@ use arcstr::ArcStr;
 use derive_more::with_trait::{Display, Error, From};
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{InputValue, FieldError, parser::{ParseError, ScalarToken}, IntoFieldError};
+use crate::{FieldError, parser::{ParseError, ScalarToken}, IntoFieldError};
 #[cfg(doc)]
 use crate::{Value, GraphQLValue};
 
@@ -171,6 +171,7 @@ pub trait ScalarValue:
     + for<'a> TryScalarValueTo<'a, f64, Error: IntoFieldError<Self>>
     + for<'a> TryScalarValueTo<'a, String, Error: IntoFieldError<Self>>
     + for<'a> TryScalarValueTo<'a, &'a str, Error: IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, &'a Self, Error: IntoFieldError<Self>>
     + 'static
 {
     /// Checks whether this [`ScalarValue`] contains the value of the given

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -171,12 +171,12 @@ pub trait ScalarValue:
     + From<bool>
     + From<i32>
     + From<f64>
-    + for<'a> TryScalarValueTo<'a, bool, Error: IntoFieldError<Self>>
-    + for<'a> TryScalarValueTo<'a, i32, Error: IntoFieldError<Self>>
-    + for<'a> TryScalarValueTo<'a, f64, Error: IntoFieldError<Self>>
-    + for<'a> TryScalarValueTo<'a, String, Error: IntoFieldError<Self>>
-    + for<'a> TryScalarValueTo<'a, &'a str, Error: IntoFieldError<Self>>
-    + for<'a> TryScalarValueTo<'a, &'a Self, Error: IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, bool, Error: Display + IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, i32, Error: Display + IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, f64, Error: Display + IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, String, Error: Display + IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, &'a str, Error: Display + IntoFieldError<Self>>
+    + for<'a> TryScalarValueTo<'a, &'a Self, Error: Display + IntoFieldError<Self>>
     + TryInto<String>
     + 'static
 {

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -407,7 +407,8 @@ impl<'a, S: ScalarValue> IntoFieldError<S> for WrongInputScalarTypeError<'a, S> 
     }
 }
 
-pub struct ScalarValueFmt<'a, S: ScalarValue>(pub &'a S);
+/// [`Display`]-formatter for a [`ScalarValue`] to render as a [`Value`].
+pub(crate) struct ScalarValueFmt<'a, S: ScalarValue>(pub &'a S);
 
 impl<'a, S: ScalarValue> Display for ScalarValueFmt<'a, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -10,7 +10,10 @@ use std::{
     fmt, ptr,
 };
 
-use crate::{FieldError, IntoFieldError, Raw, parser::{ParseError, ScalarToken}};
+use crate::{
+    FieldError, IntoFieldError, Raw,
+    parser::{ParseError, ScalarToken},
+};
 #[cfg(doc)]
 use crate::{GraphQLValue, Value};
 
@@ -180,13 +183,13 @@ pub trait ScalarValue:
     /// Checks whether this [`ScalarValue`] contains the value of the provided type `T`.
     ///
     /// # Implementation
-    /// 
+    ///
     /// Implementations should implement this method.
-    /// 
+    ///
     /// This is usually an enum dispatch with calling [`AnyExt::is::<T>()`] method on each variant.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// # use juniper::{ScalarValue, DefaultScalarValue};
     /// #
@@ -199,15 +202,15 @@ pub trait ScalarValue:
     fn is_type<T: Any + ?Sized>(&self) -> bool;
 
     /// Tries to represent this [`ScalarValue`] as the specified type `T`.
-    /// 
-    /// This method could be used instead of other helpers in case the [`TryScalarValueTo::Error`] 
+    ///
+    /// This method could be used instead of other helpers in case the [`TryScalarValueTo::Error`]
     /// is needed.
     ///
     /// # Implementation
     ///
     /// This method is an ergonomic alias for the [`TryScalarValueTo<T>`] conversion.
     ///
-    /// Implementations should not implement this method, but rather implement the 
+    /// Implementations should not implement this method, but rather implement the
     /// [`TryScalarValueTo<T>`] conversion directly.
     fn try_to<'a, T>(&'a self) -> Result<T, <Self as TryScalarValueTo<'a, T>>::Error>
     where
@@ -216,18 +219,18 @@ pub trait ScalarValue:
     {
         self.try_scalar_value_to()
     }
-    
+
     /// Tries to represent this [`ScalarValue`] as a [`bool`] value.
-    /// 
-    /// Use the [`ScalarValue::try_to::<bool>()`] method in case the [`TryScalarValueTo::Error`] is 
+    ///
+    /// Use the [`ScalarValue::try_to::<bool>()`] method in case the [`TryScalarValueTo::Error`] is
     /// needed.
-    /// 
+    ///
     /// # Implementation
     ///
-    /// This method is an ergonomic alias for the [`TryScalarValueTo<bool>`] conversion, which is 
+    /// This method is an ergonomic alias for the [`TryScalarValueTo<bool>`] conversion, which is
     /// used for implementing [`GraphQLValue`] for [`bool`] for all possible [`ScalarValue`]s.
     ///
-    /// Implementations should not implement this method, but rather implement the 
+    /// Implementations should not implement this method, but rather implement the
     /// [`TryScalarValueTo<bool>`] conversions for all the supported boolean types.
     #[must_use]
     fn try_to_bool(&self) -> Option<bool> {
@@ -236,16 +239,16 @@ pub trait ScalarValue:
 
     /// Tries to represent this [`ScalarValue`] as an [`i32`] value.
     ///
-    /// Use the [`ScalarValue::try_to::<i32>()`] method in case the [`TryScalarValueTo::Error`] is 
+    /// Use the [`ScalarValue::try_to::<i32>()`] method in case the [`TryScalarValueTo::Error`] is
     /// needed.
     ///
     /// # Implementation
-    /// 
-    /// This method is an ergonomic alias for the [`TryScalarValueTo<i32>`] conversion, which is 
+    ///
+    /// This method is an ergonomic alias for the [`TryScalarValueTo<i32>`] conversion, which is
     /// used for implementing [`GraphQLValue`] for [`i32`] for all possible [`ScalarValue`]s.
     ///
-    /// Implementations should not implement this method, but rather implement the 
-    /// [`TryScalarValueTo<i32>`] conversions for all the supported integer types with 32 bit or 
+    /// Implementations should not implement this method, but rather implement the
+    /// [`TryScalarValueTo<i32>`] conversions for all the supported integer types with 32 bit or
     /// less to an integer, if requested.
     #[must_use]
     fn try_to_int(&self) -> Option<i32> {
@@ -254,16 +257,16 @@ pub trait ScalarValue:
 
     /// Tries to represent this [`ScalarValue`] as a [`f64`] value.
     ///
-    /// Use the [`ScalarValue::try_to::<f64>()`] method in case the [`TryScalarValueTo::Error`] is 
+    /// Use the [`ScalarValue::try_to::<f64>()`] method in case the [`TryScalarValueTo::Error`] is
     /// needed.
-    /// 
+    ///
     /// # Implementation
-    /// 
-    /// This method is an ergonomic alias for the [`TryScalarValueTo<f64>`] conversion, which is 
+    ///
+    /// This method is an ergonomic alias for the [`TryScalarValueTo<f64>`] conversion, which is
     /// used for implementing [`GraphQLValue`] for [`f64`] for all possible [`ScalarValue`]s.
     ///
-    /// Implementations should not implement this method, but rather implement the 
-    /// [`TryScalarValueTo<f64>`] conversions for all the supported integer types with 64 bit and 
+    /// Implementations should not implement this method, but rather implement the
+    /// [`TryScalarValueTo<f64>`] conversions for all the supported integer types with 64 bit and
     /// all floating point values with 64 bit or less to a float, if requested.
     #[must_use]
     fn try_to_float(&self) -> Option<f64> {
@@ -271,19 +274,19 @@ pub trait ScalarValue:
     }
 
     /// Tries to represent this [`ScalarValue`] as a [`String`] value.
-    /// 
-    /// Allocates every time is called. For read-only and non-owning use of the underlying 
+    ///
+    /// Allocates every time is called. For read-only and non-owning use of the underlying
     /// [`String`] value, consider using the [`ScalarValue::try_as_str()`] method.
     ///
-    /// Use the [`ScalarValue::try_to::<String>()`] method in case the [`TryScalarValueTo::Error`] 
+    /// Use the [`ScalarValue::try_to::<String>()`] method in case the [`TryScalarValueTo::Error`]
     /// is needed.
     ///
     /// # Implementation
     ///
-    /// This method is an ergonomic alias for the [`TryScalarValueTo<String>`] conversion, which is 
+    /// This method is an ergonomic alias for the [`TryScalarValueTo<String>`] conversion, which is
     /// used for implementing [`GraphQLValue`] for [`String`] for all possible [`ScalarValue`]s.
     ///
-    /// Implementations should not implement this method, but rather implement the 
+    /// Implementations should not implement this method, but rather implement the
     /// [`TryScalarValueTo<String>`] conversions for all the supported string types, if requested.
     #[must_use]
     fn try_to_string(&self) -> Option<String> {
@@ -292,16 +295,16 @@ pub trait ScalarValue:
 
     /// Tries to convert this [`ScalarValue`] into a [`String`] value.
     ///
-    /// Similar to the [`ScalarValue::try_to_string()`] method, but takes ownership, so allows to 
+    /// Similar to the [`ScalarValue::try_to_string()`] method, but takes ownership, so allows to
     /// omit redundant [`Clone`]ing.
     ///
     /// Use the [`TryInto<String>`] conversion in case the [`TryInto::Error`] is needed.
-    /// 
+    ///
     /// # Implementation
     ///
     /// This method is an ergonomic alias for the [`TryInto<String>`] conversion.
     ///
-    /// Implementations should not implement this method, but rather implement the 
+    /// Implementations should not implement this method, but rather implement the
     /// [`TryInto<String>`] conversion for all the supported string types, if requested.
     #[must_use]
     fn try_into_string(self) -> Option<String> {
@@ -310,17 +313,17 @@ pub trait ScalarValue:
 
     /// Tries to represent this [`ScalarValue`] as a [`str`] value.
     ///
-    /// Use the [`ScalarValue::try_to::<&str>()`] method in case the [`TryScalarValueTo::Error`] 
+    /// Use the [`ScalarValue::try_to::<&str>()`] method in case the [`TryScalarValueTo::Error`]
     /// is needed.
     ///
     /// # Implementation
     ///
-    /// This method is an ergonomic alias for the [`TryScalarValueTo`]`<&`[`str`]`>` conversion, 
-    /// which is used for implementing [`GraphQLValue`] for [`String`] for all possible 
+    /// This method is an ergonomic alias for the [`TryScalarValueTo`]`<&`[`str`]`>` conversion,
+    /// which is used for implementing [`GraphQLValue`] for [`String`] for all possible
     /// [`ScalarValue`]s.
     ///
-    /// Implementations should not implement this method, but rather implement the 
-    /// [`TryScalarValueTo`]`<&`[`str`]`>` conversions for all the supported string types, if 
+    /// Implementations should not implement this method, but rather implement the
+    /// [`TryScalarValueTo`]`<&`[`str`]`>` conversions for all the supported string types, if
     /// requested.
     #[must_use]
     fn try_as_str(&self) -> Option<&str> {
@@ -329,10 +332,10 @@ pub trait ScalarValue:
 
     /// Converts this [`ScalarValue`] into another one via [`i32`], [`f64`], [`bool`] or [`String`]
     /// conversion.
-    /// 
+    ///
     /// # Panics
-    /// 
-    /// If this [`ScalarValue`] doesn't represent at least one of [`i32`], [`f64`], [`bool`] or 
+    ///
+    /// If this [`ScalarValue`] doesn't represent at least one of [`i32`], [`f64`], [`bool`] or
     /// [`String`].
     #[must_use]
     fn into_another<S: ScalarValue>(self) -> S {

--- a/juniper_codegen/CHANGELOG.md
+++ b/juniper_codegen/CHANGELOG.md
@@ -10,14 +10,28 @@ All user visible changes to `juniper_codegen` crate will be documented in this f
 
 ### BC Breaks
 
+- `#[derive(ScalarValue)]` macro: ([#1327])
+    - Renamed `#[value(as_bool)]` attribute as `#[value(to_bool)]`.
+    - Renamed `#[value(as_float)]` attribute as `#[value(to_float)]`.
+    - Renamed `#[value(as_int)]` attribute as `#[value(to_int)]`.
+    - Renamed `#[value(as_string)]` attribute as `#[value(to_string)]`.
+    - Removed `#[value(into_string)]` attribute.
+    - Removed `#[value(allow_missing_attributes)]` attribute.
+    - `From` and `Display` implementations are not derived anymore.
+- `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
+    - Made provided `from_input()` function to accept `ScalarValue` directly instead of `InputValue`.
 - Bumped up [MSRV] to 1.85. ([#1272], [1b1fc618])
 
 ### Added
 
-- Support of top-level `#[value(from_displayable_with = ...)]` attribute in `derive(ScalarValue)`. ([#1324])
+- Support of top-level `#[value(from_displayable_with = ...)]` attribute in `#[derive(ScalarValue)]` macro. ([#1324])
+- `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
+    - Support for specifying concrete types as input argument in provided `from_input()` function. 
+    - Support for non-`Result` return type in provided `from_input()` function. 
 
 [#1272]: /../../pull/1272
 [#1324]: /../../pull/1324
+[#1327]: /../../pull/1327
 [1b1fc618]: /../../commit/1b1fc61879ffdd640d741e187dc20678bf7ab295
 
 

--- a/juniper_codegen/CHANGELOG.md
+++ b/juniper_codegen/CHANGELOG.md
@@ -10,6 +10,7 @@ All user visible changes to `juniper_codegen` crate will be documented in this f
 
 ### BC Breaks
 
+- Bumped up [MSRV] to 1.85. ([#1272], [1b1fc618])
 - `#[derive(ScalarValue)]` macro: ([#1327])
     - Renamed `#[value(as_bool)]` attribute as `#[value(to_bool)]`.
     - Renamed `#[value(as_float)]` attribute as `#[value(to_float)]`.
@@ -20,11 +21,11 @@ All user visible changes to `juniper_codegen` crate will be documented in this f
     - `From` and `Display` implementations are not derived anymore.
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
     - Made provided `from_input()` function to accept `ScalarValue` directly instead of `InputValue`.
-- Bumped up [MSRV] to 1.85. ([#1272], [1b1fc618])
 
 ### Added
 
-- Support of top-level `#[value(from_displayable_with = ...)]` attribute in `#[derive(ScalarValue)]` macro. ([#1324])
+- `#[derive(ScalarValue)]` macro: ([#1324])
+    - Support of top-level `#[value(from_displayable_with = ...)]` attribute.
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros: ([#1327])
     - Support for specifying concrete types as input argument in provided `from_input()` function. 
     - Support for non-`Result` return type in provided `from_input()` function. 

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -29,7 +29,7 @@ syn = { version = "2.0", features = ["extra-traits", "full", "visit", "visit-mut
 url = "2.0"
 
 [dev-dependencies]
-derive_more = { version = "2.0", features = ["from"] }
+derive_more = { version = "2.0", features = ["from", "try_into"] }
 futures = "0.3.22"
 juniper = { path = "../juniper" }
 serde = "1.0.122"

--- a/juniper_codegen/src/graphql_enum/mod.rs
+++ b/juniper_codegen/src/graphql_enum/mod.rs
@@ -594,7 +594,7 @@ impl Definition {
                 fn from_input_value(
                     v: &::juniper::InputValue<#scalar>,
                 ) -> ::core::result::Result<Self, Self::Error> {
-                    match v.as_enum_value().or_else(|| v.as_string_value()) {
+                    match v.as_enum_value().or_else(|| v.as_scalar()?.try_as_str()) {
                         #( #variants )*
                         _ => ::core::result::Result::Err(
                             ::std::format!("Unknown enum value: {}", v),

--- a/juniper_codegen/src/graphql_enum/mod.rs
+++ b/juniper_codegen/src/graphql_enum/mod.rs
@@ -594,7 +594,9 @@ impl Definition {
                 fn from_input_value(
                     v: &::juniper::InputValue<#scalar>,
                 ) -> ::core::result::Result<Self, Self::Error> {
-                    match v.as_enum_value().or_else(|| v.as_scalar()?.try_as_str()) {
+                    match v.as_enum_value()
+                           .or_else(|| ::juniper::ScalarValue::try_as_str(v.as_scalar()?))
+                    {
                         #( #variants )*
                         _ => ::core::result::Result::Err(
                             ::std::format!("Unknown enum value: {}", v),

--- a/juniper_codegen/src/graphql_scalar/mod.rs
+++ b/juniper_codegen/src/graphql_scalar/mod.rs
@@ -773,6 +773,8 @@ impl Methods {
                 quote! {
                     let input = ::juniper::InputValue::as_scalar(input)
                         .ok_or_else(|| format!("Expected GraphQL scalar, found: {input}"))?;
+                    let input = ::juniper::TryScalarValueTo::try_scalar_value_to(input)
+                        .map_err(::juniper::executor::IntoFieldError::<#scalar>::into_field_error)?;
                     #from_input(input)
                 }
             }

--- a/juniper_codegen/src/graphql_scalar/mod.rs
+++ b/juniper_codegen/src/graphql_scalar/mod.rs
@@ -774,7 +774,7 @@ impl Methods {
                     use ::juniper::macros::helper::ToResultCall as _;
 
                     let input = ::juniper::InputValue::as_scalar(input)
-                        .ok_or_else(|| format!("Expected GraphQL scalar, found: {input}"))?;
+                        .ok_or_else(|| ::juniper::macros::helper::NotScalarError(input))?;
                     let input = ::juniper::TryScalarValueTo::try_scalar_value_to(input)
                         .map_err(::juniper::executor::IntoFieldError::<#scalar>::into_field_error)?;
                     let func: fn(_) -> _ = #from_input;

--- a/juniper_codegen/src/graphql_scalar/mod.rs
+++ b/juniper_codegen/src/graphql_scalar/mod.rs
@@ -771,11 +771,14 @@ impl Methods {
                 ..
             } => {
                 quote! {
+                    use ::juniper::macros::helper::ToResultCall as _;
+
                     let input = ::juniper::InputValue::as_scalar(input)
                         .ok_or_else(|| format!("Expected GraphQL scalar, found: {input}"))?;
                     let input = ::juniper::TryScalarValueTo::try_scalar_value_to(input)
                         .map_err(::juniper::executor::IntoFieldError::<#scalar>::into_field_error)?;
-                    #from_input(input)
+                    let func: fn(_) -> _ = #from_input;
+                    (&&func).__to_result_call(input)
                 }
             }
             Self::Delegated { field, .. } => {

--- a/juniper_codegen/src/graphql_scalar/mod.rs
+++ b/juniper_codegen/src/graphql_scalar/mod.rs
@@ -770,7 +770,11 @@ impl Methods {
                 from_input: Some(from_input),
                 ..
             } => {
-                quote! { #from_input(input) }
+                quote! {
+                    let input = ::juniper::InputValue::as_scalar(input)
+                        .ok_or_else(|| format!("Expected GraphQL scalar, found: {input}"))?;
+                    #from_input(input)
+                }
             }
             Self::Delegated { field, .. } => {
                 let field_ty = field.ty();

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -440,20 +440,20 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// Customization of a [GraphQL scalar][0] type parsing is possible via
 /// `#[graphql(from_input_with = <fn path>)]` attribute:
 /// ```rust
-/// # use juniper::{DefaultScalarValue, GraphQLScalar, InputValue, ScalarValue};
+/// # use juniper::{DefaultScalarValue, GraphQLScalar, ScalarValue};
 /// #
 /// #[derive(GraphQLScalar)]
 /// #[graphql(from_input_with = Self::from_input, transparent)]
 /// struct UserId(String);
 ///
 /// impl UserId {
-///     /// Checks whether [`InputValue`] is `String` beginning with `id: ` and
-///     /// strips it.
-///     fn from_input<S: ScalarValue>(
-///         input: &InputValue<S>,
+///     /// Checks whether the [`ScalarValue`] is a [`String`] beginning with
+///     /// `id: ` and strips it.
+///     fn from_input(
+///         input: &impl ScalarValue,
 ///     ) -> Result<Self, String> {
 ///         //            ^^^^^^ must implement `IntoFieldError`
-///         input.as_string_value()
+///         input.as_str()
 ///             .ok_or_else(|| format!("Expected `String`, found: {input}"))
 ///             .and_then(|str| {
 ///                 str.strip_prefix("id: ")
@@ -476,8 +476,8 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// `#[graphql(parse_token(<types>)]` attributes:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, InputValue, ParseScalarResult, ParseScalarValue,
-/// #     ScalarValue, ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
+/// #     ScalarToken, Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -501,10 +501,10 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<StringOrInt, String> {
-///     v.as_string_value()
-///         .map(|s| StringOrInt::String(s.into()))
-///         .or_else(|| v.as_int_value().map(StringOrInt::Int))
+/// fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+///     v.as_string()
+///         .map(StringOrInt::String)
+///         .or_else(|| v.as_int().map(StringOrInt::Int))
 ///         .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 /// }
 ///
@@ -523,8 +523,8 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// `parse_token()` functions:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, InputValue, ParseScalarResult, ParseScalarValue,
-/// #     ScalarValue, ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
+/// #     ScalarToken, Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -544,10 +544,10 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     pub(super) fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<StringOrInt, String> {
-///         v.as_string_value()
-///             .map(|s| StringOrInt::String(s.into()))
-///             .or_else(|| v.as_int_value().map(StringOrInt::Int))
+///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+///         v.as_string()
+///             .map(StringOrInt::String)
+///             .or_else(|| v.as_int().map(StringOrInt::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -563,8 +563,8 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// A regular `impl` block is also suitable for that:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, InputValue, ParseScalarResult, ParseScalarValue,
-/// #     ScalarValue, ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
+/// #     ScalarToken, Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -582,13 +582,10 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     fn from_input<S>(v: &InputValue<S>) -> Result<Self, String>
-///     where
-///         S: ScalarValue
-///     {
-///         v.as_string_value()
-///             .map(|s| Self::String(s.into()))
-///             .or_else(|| v.as_int_value().map(Self::Int))
+///     fn from_input(v: &impl ScalarValue) -> Result<Self, String> {
+///         v.as_string()
+///             .map(Self::String)
+///             .or_else(|| v.as_int().map(Self::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -607,8 +604,7 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// At the same time, any custom function still may be specified separately:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, InputValue, ParseScalarResult, ScalarValue,
-/// #     ScalarToken, Value
+/// #     GraphQLScalar, ParseScalarResult, ScalarValue, ScalarToken, Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -634,13 +630,10 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     pub(super) fn from_input<S>(v: &InputValue<S>) -> Result<StringOrInt, String>
-///     where
-///         S: ScalarValue,
-///     {
-///         v.as_string_value()
-///             .map(|s| StringOrInt::String(s.into()))
-///             .or_else(|| v.as_int_value().map(StringOrInt::Int))
+///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+///         v.as_string()
+///             .map(StringOrInt::String)
+///             .or_else(|| v.as_int().map(StringOrInt::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -728,7 +721,7 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
 /// # }
 /// #
 /// # use juniper::DefaultScalarValue as CustomScalarValue;
-/// use juniper::{graphql_scalar, InputValue, ScalarValue, Value};
+/// use juniper::{graphql_scalar, ScalarValue, Value};
 ///
 /// #[graphql_scalar]
 /// #[graphql(
@@ -747,8 +740,8 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
 ///         Value::scalar(v.to_string())
 ///     }
 ///
-///     pub(super) fn from_input(v: &InputValue<CustomScalarValue>) -> Result<Date, String> {
-///       v.as_string_value()
+///     pub(super) fn from_input(v: &CustomScalarValue) -> Result<Date, String> {
+///       v.as_str()
 ///           .ok_or_else(|| format!("Expected `String`, found: {v}"))
 ///           .and_then(|s| s.parse().map_err(|e| format!("Failed to parse `Date`: {e}")))
 ///     }

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -445,8 +445,7 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// struct UserId(String);
 ///
 /// impl UserId {
-///     /// Checks whether the [`ScalarValue`] is a [`String`] beginning with
-///     /// `id: ` and strips it.
+///     /// Checks whether the [`ScalarValue`] is a [`String`] beginning with `id: ` and strips it.
 ///     fn from_input(
 ///         input: &str,
 ///         //     ^^^^ any concrete type having `TryScalarValueTo` implementation could be used

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -365,15 +365,13 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
     })
 }
 
-/// `#[derive(GraphQLScalar)]` macro for deriving a [GraphQL scalar][0]
-/// implementation.
+/// `#[derive(GraphQLScalar)]` macro for deriving a [GraphQL scalar][0] implementation.
 ///
 /// # Transparent delegation
 ///
-/// Quite often we want to create a custom [GraphQL scalar][0] type by just
-/// wrapping an existing one, inheriting all its behavior. In Rust, this is
-/// often called as ["newtype pattern"][1]. This is achieved by annotating
-/// the definition with the `#[graphql(transparent)]` attribute:
+/// Quite often we want to create a custom [GraphQL scalar][0] type by just wrapping an existing
+/// one, inheriting all its behavior. In Rust, this is often called as ["newtype pattern"][1]. This
+/// could be achieved by annotating the definition with the `#[graphql(transparent)]` attribute:
 /// ```rust
 /// # use juniper::{GraphQLObject, GraphQLScalar};
 /// #
@@ -415,8 +413,8 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// struct UserId(String);
 /// ```
 ///
-/// All the methods inherited from `Newtype`'s field may also be overridden
-/// with the attributes described below.
+/// All the methods inherited from `Newtype`'s field may also be overridden with the attributes
+/// described below.
 ///
 /// # Custom resolving
 ///
@@ -440,7 +438,7 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// Customization of a [GraphQL scalar][0] type parsing is possible via
 /// `#[graphql(from_input_with = <fn path>)]` attribute:
 /// ```rust
-/// # use juniper::{DefaultScalarValue, GraphQLScalar, ScalarValue};
+/// # use juniper::{GraphQLScalar, ScalarValue};
 /// #
 /// #[derive(GraphQLScalar)]
 /// #[graphql(from_input_with = Self::from_input, transparent)]
@@ -450,34 +448,57 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     /// Checks whether the [`ScalarValue`] is a [`String`] beginning with
 ///     /// `id: ` and strips it.
 ///     fn from_input(
-///         input: &impl ScalarValue,
-///     ) -> Result<Self, String> {
-///         //            ^^^^^^ must implement `IntoFieldError`
-///         input.try_as_str()
-///             .ok_or_else(|| format!("Expected `String`, found: {input}"))
-///             .and_then(|str| {
-///                 str.strip_prefix("id: ")
-///                     .ok_or_else(|| {
-///                         format!(
-///                             "Expected `UserId` to begin with `id: `, \
-///                              found: {input}",
-///                         )
-///                     })
+///         input: &str,
+///         //     ^^^^ any concrete type having `TryScalarValueTo` implementation could be used
+///     ) -> Result<Self, Box<str>> {
+///     //                ^^^^^^^^ must implement `IntoFieldError`
+///         input
+///             .strip_prefix("id: ")
+///             .ok_or_else(|| {
+///                 format!("Expected `UserId` to begin with `id: `, found: {input}").into()
 ///             })
 ///             .map(|id| Self(id.into()))
 ///     }
 /// }
 /// ```
 ///
+/// The provided function is polymorphic by input and output types:
+/// ```rust
+/// # use juniper::{GraphQLScalar, Scalar, ScalarValue};
+/// #
+/// #[derive(GraphQLScalar)]
+/// #[graphql(from_input_with = Self::from_input, transparent)]
+/// struct UserId(String);
+///
+/// impl UserId {
+///     fn from_input(
+///         input: &Scalar<impl ScalarValue>,
+///         //      ^^^^^^ for generic argument using `Scalar` transparent wrapper is required,
+///         //             otherwise Rust won't be able to infer the required type
+///     ) -> Self {
+///     //   ^^^^ if the result is infallible, it's OK to not use `Result`
+///         Self(
+///             input
+///                 .try_to_int().map(|i| i.to_string())
+///                 .or_else(|| input.try_to_bool().map(|f| f.to_string()))
+///                 .or_else(|| input.try_to_float().map(|b| b.to_string()))
+///                 .or_else(|| input.try_to_string())
+///                 .unwrap_or_else(|| {
+///                     unreachable!("`ScalarValue` is at least one of primitive GraphQL types")
+///                 }),
+///         )
+///     }
+/// }
+/// ```
+///
 /// # Custom token parsing
 ///
-/// Customization of which tokens a [GraphQL scalar][0] type should be parsed is
-/// possible via `#[graphql(parse_token_with = <fn path>)]` or
-/// `#[graphql(parse_token(<types>)]` attributes:
+/// Customization of which tokens a [GraphQL scalar][0] type should be parsed is possible via
+/// `#[graphql(parse_token_with = <fn path>)]` or `#[graphql(parse_token(<types>)]` attributes:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
-/// #     ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
+/// #     Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -501,11 +522,11 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+/// fn from_input(v: &Scalar<impl ScalarValue>) -> Result<StringOrInt, Box<str>> {
 ///     v.try_to_string()
 ///         .map(StringOrInt::String)
 ///         .or_else(|| v.try_to_int().map(StringOrInt::Int))
-///         .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+///         .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}").into())
 /// }
 ///
 /// fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -513,18 +534,17 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         .or_else(|_| <i32 as ParseScalarValue<S>>::from_str(value))
 /// }
 /// ```
-/// > __NOTE:__ Once we provide all 3 custom functions, there is no sense in
-/// >           following the [newtype pattern][1] anymore.
+/// > __NOTE:__ Once we provide all 3 custom functions, there is no sense in following the
+/// >           [newtype pattern][1] anymore.
 ///
 /// # Full behavior
 ///
-/// Instead of providing all custom functions separately, it's possible to
-/// provide a module holding the appropriate `to_output()`, `from_input()` and
-/// `parse_token()` functions:
+/// Instead of providing all custom functions separately, it's possible to provide a module holding
+/// the appropriate `to_output()`, `from_input()` and `parse_token()` functions:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
-/// #     ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
+/// #     Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -544,11 +564,11 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+///     pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<StringOrInt, Box<str>> {
 ///         v.try_to_string()
 ///             .map(StringOrInt::String)
 ///             .or_else(|| v.try_to_int().map(StringOrInt::Int))
-///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}").into())
 ///     }
 ///
 ///     pub(super) fn parse_token<S: ScalarValue>(t: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -563,8 +583,8 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// A regular `impl` block is also suitable for that:
 /// ```rust
 /// # use juniper::{
-/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarValue,
-/// #     ScalarToken, Value,
+/// #     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
+/// #     Value,
 /// # };
 /// #
 /// #[derive(GraphQLScalar)]
@@ -582,11 +602,11 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     fn from_input(v: &impl ScalarValue) -> Result<Self, String> {
+///     fn from_input(v: &Scalar<impl ScalarValue>) -> Result<Self, Box<str>> {
 ///         v.try_to_string()
 ///             .map(Self::String)
 ///             .or_else(|| v.try_to_int().map(Self::Int))
-///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}").into())
 ///     }
 ///
 ///     fn parse_token<S>(value: ScalarToken<'_>) -> ParseScalarResult<S>
@@ -603,9 +623,7 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///
 /// At the same time, any custom function still may be specified separately:
 /// ```rust
-/// # use juniper::{
-/// #     GraphQLScalar, ParseScalarResult, ScalarValue, ScalarToken, Value,
-/// # };
+/// # use juniper::{GraphQLScalar, ParseScalarResult, Scalar, ScalarToken, ScalarValue, Value};
 /// #
 /// #[derive(GraphQLScalar)]
 /// #[graphql(
@@ -630,11 +648,11 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         }
 ///     }
 ///
-///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
+///     pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<StringOrInt, Box<str>> {
 ///         v.try_to_string()
 ///             .map(StringOrInt::String)
 ///             .or_else(|| v.try_to_int().map(StringOrInt::Int))
-///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}").into())
 ///     }
 ///
 ///     // No need in `parse_token()` function.
@@ -645,18 +663,17 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///
 /// # Custom `ScalarValue`
 ///
-/// By default, this macro generates code, which is generic over a
-/// [`ScalarValue`] type. Concrete [`ScalarValue`] type may be specified via
-/// `#[graphql(scalar = <type>)]` attribute.
+/// By default, this macro generates code, which is generic over a [`ScalarValue`] type. Concrete
+/// [`ScalarValue`] type may be specified via the `#[graphql(scalar = <type>)]` attribute.
 ///
-/// It also may be used to provide additional bounds to the [`ScalarValue`]
-/// generic, like the following: `#[graphql(scalar = S: Trait)]`.
+/// It also may be used to provide additional bounds to the [`ScalarValue`] generic, like the
+/// following: `#[graphql(scalar = S: Trait)]`.
 ///
 /// # Additional arbitrary trait bounds
 ///
-/// [GraphQL scalar][0] type implementation may be bound with any additional
-/// trait bounds via `#[graphql(where(<bounds>))]` attribute, like the
-/// following: `#[graphql(where(S: Trait, Self: fmt::Debug + fmt::Display))]`.
+/// [GraphQL scalar][0] type implementation may be bound with any additional trait bounds via
+/// `#[graphql(where(<bounds>))]` attribute, like the following:
+/// `#[graphql(where(S: Trait, Self: fmt::Debug + fmt::Display))]`.
 ///
 /// [0]: https://spec.graphql.org/October2021#sec-Scalars
 /// [1]: https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html
@@ -670,9 +687,8 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
     })
 }
 
-/// `#[graphql_scalar]` macro.is interchangeable with
-/// `#[derive(`[`GraphQLScalar`]`)]` macro, and is used for deriving a
-/// [GraphQL scalar][0] implementation.
+/// `#[graphql_scalar]` macro.is interchangeable with the `#[derive(`[`GraphQLScalar`]`)]` macro,
+/// and is used for deriving a [GraphQL scalar][0] implementation.
 ///
 /// ```rust
 /// # use juniper::graphql_scalar;
@@ -696,11 +712,10 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
 ///
 /// # Foreign types
 ///
-/// Additionally, `#[graphql_scalar]` can be used directly on foreign types via
-/// type alias, without using the [newtype pattern][1].
+/// Additionally, `#[graphql_scalar]` can be used directly on foreign types via type alias, without
+/// using the [newtype pattern][1].
 ///
-/// > __NOTE:__ To satisfy [orphan rules] you should provide local
-/// >           [`ScalarValue`] implementation.
+/// > __NOTE:__ To satisfy [orphan rules] you should provide local [`ScalarValue`] implementation.
 ///
 /// ```rust
 /// # mod date {
@@ -740,10 +755,8 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
 ///         Value::scalar(v.to_string())
 ///     }
 ///
-///     pub(super) fn from_input(v: &CustomScalarValue) -> Result<Date, String> {
-///       v.try_as_str()
-///           .ok_or_else(|| format!("Expected `String`, found: {v}"))
-///           .and_then(|s| s.parse().map_err(|e| format!("Failed to parse `Date`: {e}")))
+///     pub(super) fn from_input(s: &str) -> Result<Date, Box<str>> {
+///         s.parse().map_err(|e| format!("Failed to parse `Date`: {e}").into())
 ///     }
 /// }
 /// #
@@ -777,10 +790,10 @@ pub fn graphql_scalar(attr: TokenStream, body: TokenStream) -> TokenStream {
 /// ```rust
 /// # use std::{any::Any, fmt};
 /// #
-/// # use serde::{de, Deserialize, Deserializer, Serialize};
+/// use derive_more::with_trait::{Display, From, TryInto};
 /// # use juniper::ScalarValue;
-/// #
-/// #[derive(Clone, Debug, PartialEq, ScalarValue, Serialize)]
+/// # use serde::{de, Deserialize, Deserializer, Serialize};
+/// #[derive(Clone, Debug, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
 /// #[serde(untagged)]
 /// #[value(from_displayable_with = from_custom_str)]
 /// enum MyScalarValue {
@@ -801,7 +814,7 @@ pub fn graphql_scalar(attr: TokenStream, body: TokenStream) -> TokenStream {
 ///
 /// // Custom implementation of `ScalarValue::from_displayable()` method for
 /// // possible efficient conversions into `MyScalarValue` from custom string types.
-/// fn from_custom_str<Str: fmt::Display + Any + ?Sized>(s: &Str) -> MyScalarValue {
+/// fn from_custom_str<Str: Display + Any + ?Sized>(s: &Str) -> MyScalarValue {
 ///     use juniper::AnyExt as _; // allows downcasting directly on types without `dyn`
 ///
 ///     // Imagine this is some custom optimized string type.

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -453,7 +453,7 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///         input: &impl ScalarValue,
 ///     ) -> Result<Self, String> {
 ///         //            ^^^^^^ must implement `IntoFieldError`
-///         input.as_str()
+///         input.try_as_str()
 ///             .ok_or_else(|| format!("Expected `String`, found: {input}"))
 ///             .and_then(|str| {
 ///                 str.strip_prefix("id: ")
@@ -502,9 +502,9 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
-///     v.as_string()
+///     v.try_to_string()
 ///         .map(StringOrInt::String)
-///         .or_else(|| v.as_int().map(StringOrInt::Int))
+///         .or_else(|| v.try_to_int().map(StringOrInt::Int))
 ///         .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 /// }
 ///
@@ -545,9 +545,9 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
-///         v.as_string()
+///         v.try_to_string()
 ///             .map(StringOrInt::String)
-///             .or_else(|| v.as_int().map(StringOrInt::Int))
+///             .or_else(|| v.try_to_int().map(StringOrInt::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -583,9 +583,9 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     fn from_input(v: &impl ScalarValue) -> Result<Self, String> {
-///         v.as_string()
+///         v.try_to_string()
 ///             .map(Self::String)
-///             .or_else(|| v.as_int().map(Self::Int))
+///             .or_else(|| v.try_to_int().map(Self::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -631,9 +631,9 @@ pub fn derive_enum(input: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     pub(super) fn from_input(v: &impl ScalarValue) -> Result<StringOrInt, String> {
-///         v.as_string()
+///         v.try_to_string()
 ///             .map(StringOrInt::String)
-///             .or_else(|| v.as_int().map(StringOrInt::Int))
+///             .or_else(|| v.try_to_int().map(StringOrInt::Int))
 ///             .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
 ///     }
 ///
@@ -741,7 +741,7 @@ pub fn derive_scalar(input: TokenStream) -> TokenStream {
 ///     }
 ///
 ///     pub(super) fn from_input(v: &CustomScalarValue) -> Result<Date, String> {
-///       v.as_str()
+///       v.try_as_str()
 ///           .ok_or_else(|| format!("Expected `String`, found: {v}"))
 ///           .and_then(|s| s.parse().map_err(|e| format!("Failed to parse `Date`: {e}")))
 ///     }

--- a/juniper_codegen/src/lib.rs
+++ b/juniper_codegen/src/lib.rs
@@ -766,13 +766,13 @@ pub fn graphql_scalar(attr: TokenStream, body: TokenStream) -> TokenStream {
 
 /// `#[derive(ScalarValue)]` macro for deriving a [`ScalarValue`] implementation.
 ///
-/// To derive a [`ScalarValue`] on enum you should mark the corresponding enum
-/// variants with `as_int`, `as_float`, `as_string`, `into_string`, `as_str` and
-/// `as_bool` attribute arguments (names correspond to [`ScalarValue`] required
-/// methods).
+/// To derive a [`ScalarValue`] on enum you either could mark the corresponding enum variants with
+/// `to_int`, `to_float`, `to_string`, `as_str` and `to_bool` attribute arguments (names correspond
+/// to the similar [`ScalarValue`] methods aliasing the required [`TryScalarValueTo`] conversions),
+/// or implement the required [`TryScalarValueTo`] conversions by hand.
 ///
-/// Additional `from_displayable_with` argument could be used to specify a custom
-/// implementation to override the default `ScalarValue::from_displayable()` method.
+/// Additional `from_displayable_with` argument could be used to specify a custom function to
+/// override the default `ScalarValue::from_displayable()` method.
 ///
 /// ```rust
 /// # use std::{any::Any, fmt};
@@ -784,19 +784,18 @@ pub fn graphql_scalar(attr: TokenStream, body: TokenStream) -> TokenStream {
 /// #[serde(untagged)]
 /// #[value(from_displayable_with = from_custom_str)]
 /// enum MyScalarValue {
-///     #[value(as_float, as_int)]
+///     #[value(to_float, to_int)]
 ///     Int(i32),
 ///     Long(i64),
-///     #[value(as_float)]
+///     #[value(to_float)]
 ///     Float(f64),
 ///     #[value(
-///         into_string,
 ///         as_str,
-///         as_string = String::clone,
+///         to_string = String::clone,
 ///     )]
 ///     //              ^^^^^^^^^^^^^ custom resolvers may be provided
 ///     String(String),
-///     #[value(as_bool)]
+///     #[value(to_bool)]
 ///     Boolean(bool),
 /// }
 ///
@@ -884,6 +883,7 @@ pub fn graphql_scalar(attr: TokenStream, body: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [`ScalarValue`]: juniper::ScalarValue
+/// [`TryScalarValueTo`]: juniper::TryScalarValueTo
 #[proc_macro_derive(ScalarValue, attributes(value))]
 pub fn derive_scalar_value(input: TokenStream) -> TokenStream {
     diagnostic::entry_point(|| {

--- a/juniper_codegen/src/scalar_value/mod.rs
+++ b/juniper_codegen/src/scalar_value/mod.rs
@@ -343,12 +343,12 @@ impl Definition {
                 let var_ident = &var.ident;
                 let field = Field::try_from(var.fields.clone()).unwrap();
                 let var_pattern = field.match_arg();
-                
-                quote! { 
+
+                quote! {
                     Self::#var_ident #var_pattern => ::juniper::AnyExt::is::<__T>(v),
                 }
             });
-            
+
             quote! {
                 fn is_type<__T: ::core::any::Any + ?::core::marker::Sized>(&self) -> bool {
                     match self {

--- a/juniper_codegen/src/scalar_value/mod.rs
+++ b/juniper_codegen/src/scalar_value/mod.rs
@@ -265,13 +265,11 @@ impl Definition {
         generics.params.push(parse_quote! { #ref_lt });
         let (lt_impl_gens, _, _) = generics.split_for_impl();
 
-        let methods = [
-            (
-                Method::IntoString,
-                quote! { fn into_string(self) -> ::core::option::Option<::std::string::String> },
-                quote! { ::std::string::String::from(v) },
-            ),
-        ];
+        let methods = [(
+            Method::IntoString,
+            quote! { fn into_string(self) -> ::core::option::Option<::std::string::String> },
+            quote! { ::std::string::String::from(v) },
+        )];
         let methods = methods.iter().map(|(m, sig, def)| {
             let arms = self.methods.get(m).into_iter().flatten().map(|v| {
                 let arm = v.match_arm();
@@ -328,13 +326,13 @@ impl Definition {
                 } else {
                     default_expr.clone()
                 };
-                quote! { 
-                    #arm_pattern => ::core::result::Result::Ok(#call), 
+                quote! {
+                    #arm_pattern => ::core::result::Result::Ok(#call),
                 }
             });
             quote! {
                 #[automatically_derived]
-                impl #lt_impl_gens ::juniper::TryScalarValueTo<#ref_lt, #as_ty> 
+                impl #lt_impl_gens ::juniper::TryScalarValueTo<#ref_lt, #as_ty>
                  for #ty_ident #ty_gens #where_clause
                 {
                     type Error = ::juniper::WrongInputScalarTypeError<#ref_lt, #ty_ident #ty_gens>;
@@ -370,7 +368,7 @@ impl Definition {
                 #( #methods )*
                 #from_displayable
             }
-            
+
             #( #impls )*
         }
     }

--- a/juniper_codegen/src/scalar_value/mod.rs
+++ b/juniper_codegen/src/scalar_value/mod.rs
@@ -262,27 +262,6 @@ impl Definition {
         generics.params.push(parse_quote! { #ref_lt });
         let (lt_impl_gens, _, _) = generics.split_for_impl();
 
-        let methods = [(
-            Method::IntoString,
-            quote! { fn into_string(self) -> ::core::option::Option<::std::string::String> },
-            quote! { ::std::string::String::from(v) },
-        )];
-        let methods = methods.iter().map(|(m, sig, def)| {
-            let arms = self.methods.get(m).into_iter().flatten().map(|v| {
-                let arm = v.match_arm();
-                let call = v.expr.as_ref().map_or(def.clone(), |f| quote! { #f(v) });
-                quote! { #arm => ::core::option::Option::Some(#call), }
-            });
-            quote! {
-                #sig {
-                    match self {
-                        #(#arms)*
-                        _ => ::core::option::Option::None,
-                    }
-                }
-            }
-        });
-
         let methods2 = [
             (
                 Method::AsInt,
@@ -383,7 +362,6 @@ impl Definition {
             #[automatically_derived]
             impl #impl_gens ::juniper::ScalarValue for #ty_ident #ty_gens #where_clause {
                 #is_type
-                #( #methods )*
                 #from_displayable
             }
 

--- a/tests/codegen/Cargo.toml
+++ b/tests/codegen/Cargo.toml
@@ -8,8 +8,10 @@ publish = false
 rustversion = "1.0"
 
 [dev-dependencies]
+derive_more = { version = "2.0", features = ["display", "from", "try_into"] }
 futures = "0.3"
 juniper = { path = "../../juniper" }
+serde = { version = "1.0", features = ["derive"] }
 trybuild = "1.0.63"
 
 [lints.clippy]

--- a/tests/codegen/fail/scalar/derive_input/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/derive_input/attr_invalid_url.rs
@@ -1,6 +1,7 @@
 use juniper::graphql_scalar;
 
-#[graphql_scalar(specified_by_url = "not an url", transparent)]
+#[graphql_scalar]
+#[graphql(specified_by_url = "not an url", transparent)]
 struct ScalarSpecifiedByUrl(i32);
 
 fn main() {}

--- a/tests/codegen/fail/scalar/derive_input/attr_invalid_url.stderr
+++ b/tests/codegen/fail/scalar/derive_input/attr_invalid_url.stderr
@@ -1,5 +1,11 @@
 error: Invalid URL: relative URL without a base
- --> fail/scalar/derive_input/attr_invalid_url.rs:3:37
+ --> fail/scalar/derive_input/attr_invalid_url.rs:4:30
   |
-3 | #[graphql_scalar(specified_by_url = "not an url", transparent)]
-  |                                     ^^^^^^^^^^^^
+4 | #[graphql(specified_by_url = "not an url", transparent)]
+  |                              ^^^^^^^^^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/derive_input/attr_invalid_url.rs:4:3
+  |
+4 | #[graphql(specified_by_url = "not an url", transparent)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_and_with.rs
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_and_with.rs
@@ -1,6 +1,7 @@
 use juniper::graphql_scalar;
 
-#[graphql_scalar(with = Self, transparent)]
+#[graphql_scalar]
+#[graphql(with = Self, transparent)]
 struct Scalar;
 
 fn main() {}

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_and_with.stderr
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_and_with.stderr
@@ -1,5 +1,11 @@
 error: GraphQL scalar `with = <path>` attribute argument cannot be combined with `transparent`. You can specify custom resolvers with `to_output_with`, `from_input_with`, `parse_token`/`parse_token_with` attribute arguments and still use `transparent` for unspecified ones.
- --> fail/scalar/derive_input/attr_transparent_and_with.rs:3:25
+ --> fail/scalar/derive_input/attr_transparent_and_with.rs:4:18
   |
-3 | #[graphql_scalar(with = Self, transparent)]
-  |                         ^^^^
+4 | #[graphql(with = Self, transparent)]
+  |                  ^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/derive_input/attr_transparent_and_with.rs:4:3
+  |
+4 | #[graphql(with = Self, transparent)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_named_fields.rs
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_named_fields.rs
@@ -1,6 +1,7 @@
 use juniper::graphql_scalar;
 
-#[graphql_scalar(transparent)]
+#[graphql_scalar]
+#[graphql(transparent)]
 struct Scalar {
     id: i32,
     another: i32,

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_named_fields.stderr
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_named_fields.stderr
@@ -1,5 +1,11 @@
 error: GraphQL scalar `transparent` attribute argument requires exactly 1 field
- --> fail/scalar/derive_input/attr_transparent_multiple_named_fields.rs:4:1
+ --> fail/scalar/derive_input/attr_transparent_multiple_named_fields.rs:5:1
   |
-4 | struct Scalar {
+5 | struct Scalar {
   | ^^^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/derive_input/attr_transparent_multiple_named_fields.rs:4:3
+  |
+4 | #[graphql(transparent)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.rs
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.rs
@@ -1,6 +1,7 @@
 use juniper::graphql_scalar;
 
-#[graphql_scalar(transparent)]
+#[graphql_scalar]
+#[graphql(transparent)]
 struct Scalar(i32, i32);
 
 fn main() {}

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.stderr
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.stderr
@@ -1,5 +1,11 @@
 error: GraphQL scalar `transparent` attribute argument requires exactly 1 field
- --> fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.rs:4:1
+ --> fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.rs:5:1
   |
-4 | struct Scalar(i32, i32);
+5 | struct Scalar(i32, i32);
   | ^^^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/derive_input/attr_transparent_multiple_unnamed_fields.rs:4:3
+  |
+4 | #[graphql(transparent)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_unit_struct.rs
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_unit_struct.rs
@@ -1,6 +1,7 @@
 use juniper::graphql_scalar;
 
-#[graphql_scalar(transparent)]
+#[graphql_scalar]
+#[graphql(transparent)]
 struct ScalarSpecifiedByUrl;
 
 fn main() {}

--- a/tests/codegen/fail/scalar/derive_input/attr_transparent_unit_struct.stderr
+++ b/tests/codegen/fail/scalar/derive_input/attr_transparent_unit_struct.stderr
@@ -1,5 +1,11 @@
 error: GraphQL scalar `transparent` attribute argument requires exactly 1 field
- --> fail/scalar/derive_input/attr_transparent_unit_struct.rs:4:1
+ --> fail/scalar/derive_input/attr_transparent_unit_struct.rs:5:1
   |
-4 | struct ScalarSpecifiedByUrl;
+5 | struct ScalarSpecifiedByUrl;
   | ^^^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/derive_input/attr_transparent_unit_struct.rs:4:3
+  |
+4 | #[graphql(transparent)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use juniper::{graphql_scalar, ScalarValue, Value};
 
 struct ScalarSpecifiedByUrl;
@@ -18,8 +16,8 @@ mod scalar {
         Value::scalar(0)
     }
 
-    pub(super) fn from_input(_: &impl ScalarValue) -> Result<ScalarSpecifiedByUrl, Infallible> {
-        Ok(ScalarSpecifiedByUrl)
+    pub(super) fn from_input(_: &Raw<impl ScalarValue>) -> ScalarSpecifiedByUrl {
+        ScalarSpecifiedByUrl
     }
 }
 

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
@@ -1,8 +1,9 @@
-use juniper::{graphql_scalar, ScalarValue, Value};
+use juniper::{graphql_scalar, Scalar, ScalarValue, Value};
 
 struct ScalarSpecifiedByUrl;
 
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     specified_by_url = "not an url",
     with = scalar,
     parse_token(i32),
@@ -16,7 +17,7 @@ mod scalar {
         Value::scalar(0)
     }
 
-    pub(super) fn from_input(_: &Raw<impl ScalarValue>) -> ScalarSpecifiedByUrl {
+    pub(super) fn from_input(_: &Scalar<impl ScalarValue>) -> ScalarSpecifiedByUrl {
         ScalarSpecifiedByUrl
     }
 }

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
@@ -8,7 +8,7 @@ struct ScalarSpecifiedByUrl;
     with = scalar,
     parse_token(i32),
 )]
-type Scalar = ScalarSpecifiedByUrl;
+type MyScalar = ScalarSpecifiedByUrl;
 
 mod scalar {
     use super::*;

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
@@ -1,4 +1,6 @@
-use juniper::{graphql_scalar, InputValue, ScalarValue, Value};
+use std::convert::Infallible;
+
+use juniper::{graphql_scalar, ScalarValue, Value};
 
 struct ScalarSpecifiedByUrl;
 
@@ -16,9 +18,7 @@ mod scalar {
         Value::scalar(0)
     }
 
-    pub(super) fn from_input<S: ScalarValue>(
-        _: &InputValue<S>,
-    ) -> Result<ScalarSpecifiedByUrl, String> {
+    pub(super) fn from_input(_: &impl ScalarValue) -> Result<ScalarSpecifiedByUrl, Infallible> {
         Ok(ScalarSpecifiedByUrl)
     }
 }

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.stderr
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.stderr
@@ -1,5 +1,11 @@
 error: Invalid URL: relative URL without a base
- --> fail/scalar/type_alias/attr_invalid_url.rs:6:24
+ --> fail/scalar/type_alias/attr_invalid_url.rs:7:24
   |
-6 |     specified_by_url = "not an url",
+7 |     specified_by_url = "not an url",
   |                        ^^^^^^^^^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/type_alias/attr_invalid_url.rs:6:3
+  |
+6 | #[graphql(
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.rs
@@ -2,7 +2,8 @@ use juniper::{graphql_scalar, Value};
 
 struct Scalar;
 
-#[graphql_scalar(to_output_with = Scalar::to_output)]
+#[graphql_scalar]
+#[graphql(to_output_with = Scalar::to_output)]
 type CustomScalar = Scalar;
 
 impl Scalar {

--- a/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.stderr
+++ b/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.stderr
@@ -1,5 +1,11 @@
 error: GraphQL scalar all the resolvers have to be provided via `with` attribute argument or a combination of `to_output_with`, `from_input_with`, `parse_token_with`/`parse_token` attribute arguments
- --> fail/scalar/type_alias/attr_with_not_all_resolvers.rs:6:1
+ --> fail/scalar/type_alias/attr_with_not_all_resolvers.rs:7:1
   |
-6 | type CustomScalar = Scalar;
+7 | type CustomScalar = Scalar;
   | ^^^^
+
+error: cannot find attribute `graphql` in this scope
+ --> fail/scalar/type_alias/attr_with_not_all_resolvers.rs:6:3
+  |
+6 | #[graphql(to_output_with = Scalar::to_output)]
+  |   ^^^^^^^

--- a/tests/codegen/fail/scalar_value/missing_attributes.rs
+++ b/tests/codegen/fail/scalar_value/missing_attributes.rs
@@ -1,12 +1,15 @@
+use derive_more::{Display, From, TryInto};
 use juniper::ScalarValue;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, ScalarValue)]
+#[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
 pub enum DefaultScalarValue {
     Int(i32),
+    #[value(to_float)]
     Float(f64),
-    #[value(as_str, as_string, into_string)]
+    #[value(as_str, to_string)]
     String(String),
-    #[value(as_bool)]
+    #[value(to_bool)]
     Boolean(bool),
 }
 

--- a/tests/codegen/fail/scalar_value/missing_attributes.stderr
+++ b/tests/codegen/fail/scalar_value/missing_attributes.stderr
@@ -1,5 +1,11 @@
-error: GraphQL built-in scalars missing `#[value(as_int, as_float)]` attributes. In case you are sure that it's ok, use `#[value(allow_missing_attributes)]` to suppress this error.
- --> fail/scalar_value/missing_attributes.rs:4:1
+error[E0277]: the trait bound `for<'a> DefaultScalarValue: TryScalarValueTo<'a, i32>` is not satisfied
+ --> fail/scalar_value/missing_attributes.rs:6:10
   |
-4 | pub enum DefaultScalarValue {
-  | ^^^
+6 | pub enum DefaultScalarValue {
+  |          ^^^^^^^^^^^^^^^^^^ the trait `for<'a> TryScalarValueTo<'a, i32>` is not implemented for `DefaultScalarValue`
+  |
+  = help: the following other types implement trait `TryScalarValueTo<'me, T>`:
+            `DefaultScalarValue` implements `TryScalarValueTo<'_, &str>`
+            `DefaultScalarValue` implements `TryScalarValueTo<'_, bool>`
+            `DefaultScalarValue` implements `TryScalarValueTo<'_, f64>`
+            `DefaultScalarValue` implements `TryScalarValueTo<'_, std::string::String>`

--- a/tests/codegen/src/lib.rs
+++ b/tests/codegen/src/lib.rs
@@ -5,8 +5,10 @@
 
 #[cfg(test)]
 mod for_codegen_tests_only {
+    use derive_more as _;
     use futures as _;
     use juniper as _;
+    use serde as _;
 }
 
 #[rustversion::stable]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }
-derive_more = { version = "2.0", features = ["display", "from"] }
+derive_more = { version = "2.0", features = ["display", "from", "try_into"] }
 futures = "0.3"
 itertools = "0.14"
 juniper = { path = "../../juniper", features = ["chrono"] }

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false }
+derive_more = { version = "2.0", features = ["display", "from"] }
 futures = "0.3"
 itertools = "0.14"
 juniper = { path = "../../juniper", features = ["chrono"] }

--- a/tests/integration/tests/codegen_scalar_attr_derive_input.rs
+++ b/tests/integration/tests/codegen_scalar_attr_derive_input.rs
@@ -97,7 +97,8 @@ mod trivial {
 mod transparent {
     use super::*;
 
-    #[graphql_scalar(transparent)]
+    #[graphql_scalar]
+    #[graphql(transparent)]
     struct Counter(i32);
 
     struct QueryRoot;
@@ -157,7 +158,8 @@ mod transparent {
 mod transparent_with_resolver {
     use super::*;
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         transparent,
         to_output_with = Self::to_output,
     )]
@@ -299,7 +301,8 @@ mod all_custom_resolvers {
 mod explicit_name {
     use super::*;
 
-    #[graphql_scalar(name = "Counter")]
+    #[graphql_scalar]
+    #[graphql(name = "Counter")]
     struct CustomCounter(i32);
 
     impl CustomCounter {
@@ -373,7 +376,8 @@ mod explicit_name {
 mod delegated_parse_token {
     use super::*;
 
-    #[graphql_scalar(parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {
@@ -443,7 +447,8 @@ mod delegated_parse_token {
 mod multiple_delegated_parse_token {
     use super::*;
 
-    #[graphql_scalar(parse_token(prelude::String, i32))]
+    #[graphql_scalar]
+    #[graphql(parse_token(prelude::String, i32))]
     enum StringOrInt {
         String(prelude::String),
         Int(i32),
@@ -502,7 +507,8 @@ mod multiple_delegated_parse_token {
 mod where_attribute {
     use super::*;
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
         from_input_with = from_input,
         parse_token(prelude::String),
@@ -577,7 +583,8 @@ mod where_attribute {
 mod with_self {
     use super::*;
 
-    #[graphql_scalar(with = Self)]
+    #[graphql_scalar]
+    #[graphql(with = Self)]
     struct Counter(i32);
 
     impl Counter {
@@ -651,7 +658,8 @@ mod with_self {
 mod with_module {
     use super::*;
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         with = custom_date_time,
         parse_token(prelude::String),
         where(Tz: From<Utc>, Tz::Offset: fmt::Display),
@@ -732,7 +740,8 @@ mod description_from_doc_comment {
     use super::*;
 
     /// Description
-    #[graphql_scalar(parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {
@@ -806,7 +815,8 @@ mod description_from_attribute {
     use super::*;
 
     /// Doc comment
-    #[graphql_scalar(description = "Description from attribute", parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(description = "Description from attribute", parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {
@@ -880,7 +890,8 @@ mod custom_scalar {
     use super::*;
 
     /// Description
-    #[graphql_scalar(scalar = MyScalarValue, parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(scalar = MyScalarValue, parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {
@@ -954,7 +965,8 @@ mod generic_scalar {
     use super::*;
 
     /// Description
-    #[graphql_scalar(scalar = S: ScalarValue, parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(scalar = S: ScalarValue, parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {
@@ -1027,7 +1039,8 @@ mod generic_scalar {
 mod bounded_generic_scalar {
     use super::*;
 
-    #[graphql_scalar(scalar = S: ScalarValue + prelude::Clone, parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(scalar = S: ScalarValue + prelude::Clone, parse_token(i32))]
     struct Counter(i32);
 
     impl Counter {

--- a/tests/integration/tests/codegen_scalar_attr_derive_input.rs
+++ b/tests/integration/tests/codegen_scalar_attr_derive_input.rs
@@ -8,7 +8,7 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    ParseScalarResult, ParseScalarValue, Raw, ScalarToken, ScalarValue, Value, execute,
+    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value, execute,
     graphql_object, graphql_scalar, graphql_value, graphql_vars,
 };
 
@@ -159,7 +159,7 @@ mod transparent_with_resolver {
     use super::*;
 
     #[graphql_scalar]
-    #[graphql(
+    #[graphql_scalar(
         transparent,
         to_output_with = Self::to_output,
     )]
@@ -462,7 +462,7 @@ mod multiple_delegated_parse_token {
             }
         }
 
-        fn from_input(v: &Raw<impl ScalarValue>) -> prelude::Result<Self, prelude::Box<str>> {
+        fn from_input(v: &Scalar<impl ScalarValue>) -> prelude::Result<Self, prelude::Box<str>> {
             v.try_to_string()
                 .map(Self::String)
                 .or_else(|| v.try_to_int().map(Self::Int))

--- a/tests/integration/tests/codegen_scalar_attr_derive_input.rs
+++ b/tests/integration/tests/codegen_scalar_attr_derive_input.rs
@@ -4,7 +4,7 @@
 
 pub mod common;
 
-use std::{convert::Infallible, fmt};
+use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
@@ -31,8 +31,8 @@ mod trivial {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(t: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -226,19 +226,16 @@ mod transparent_with_resolver {
 mod all_custom_resolvers {
     use super::*;
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
-        from_input_with = from_input,
+        from_input_with = Counter,
     )]
-    #[graphql_scalar(parse_token_with = parse_token)]
+    #[graphql(parse_token_with = parse_token)]
     struct Counter(i32);
 
     fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
         Value::scalar(v.0)
-    }
-
-    fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-        Ok(Counter(i))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -310,8 +307,8 @@ mod explicit_name {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -384,8 +381,8 @@ mod delegated_parse_token {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -588,8 +585,8 @@ mod with_self {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -743,8 +740,8 @@ mod description_from_doc_comment {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -817,8 +814,8 @@ mod description_from_attribute {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -891,8 +888,8 @@ mod custom_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -965,8 +962,8 @@ mod generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -1038,8 +1035,8 @@ mod bounded_generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_attr_derive_input.rs
+++ b/tests/integration/tests/codegen_scalar_attr_derive_input.rs
@@ -4,12 +4,12 @@
 
 pub mod common;
 
-use std::{fmt, convert::Infallible};
+use std::{convert::Infallible, fmt};
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue, Value, execute, graphql_object,
-    graphql_scalar, graphql_value, graphql_vars, Raw,
+    ParseScalarResult, ParseScalarValue, Raw, ScalarToken, ScalarValue, Value, execute,
+    graphql_object, graphql_scalar, graphql_value, graphql_vars,
 };
 
 use self::common::{

--- a/tests/integration/tests/codegen_scalar_attr_type_alias.rs
+++ b/tests/integration/tests/codegen_scalar_attr_type_alias.rs
@@ -2,7 +2,7 @@
 
 pub mod common;
 
-use std::{convert::Infallible, fmt};
+use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
@@ -20,13 +20,12 @@ use self::common::hygiene::*;
 
 mod all_custom_resolvers {
     use super::*;
-    use std::convert::Infallible;
 
     struct CustomCounter(i32);
 
     #[graphql_scalar(
         to_output_with = to_output,
-        from_input_with = from_input,
+        from_input_with = CustomCounter,
     )]
     #[graphql_scalar(
         parse_token_with = parse_token,
@@ -35,10 +34,6 @@ mod all_custom_resolvers {
 
     fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
         Value::scalar(v.0)
-    }
-
-    fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-        Ok(CustomCounter(i))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -107,17 +102,13 @@ mod explicit_name {
     #[graphql_scalar(
         name = "Counter",
         to_output_with = to_output,
-        from_input_with = from_input,
+        from_input_with = CustomCounter,
         parse_token_with = parse_token,
     )]
     type CounterScalar = CustomCounter;
 
     fn to_output<S: ScalarValue>(v: &CounterScalar) -> Value<S> {
         Value::scalar(v.0)
-    }
-
-    fn from_input(i: i32) -> prelude::Result<CounterScalar, Infallible> {
-        Ok(CustomCounter(i))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -205,17 +196,13 @@ mod delegated_parse_token {
 
     #[graphql_scalar(
         to_output_with = to_output,
-        from_input_with = from_input,
+        from_input_with = CustomCounter,
         parse_token(i32),
     )]
     type Counter = CustomCounter;
 
     fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
         Value::scalar(v.0)
-    }
-
-    fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-        Ok(CustomCounter(i))
     }
 
     struct QueryRoot;
@@ -425,8 +412,8 @@ mod with_self {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -586,8 +573,8 @@ mod description_from_doc_comment {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-            Ok(CustomCounter(i))
+        pub(super) fn from_input(i: i32) -> Counter {
+            CustomCounter(i)
         }
     }
 
@@ -668,8 +655,8 @@ mod description_from_attribute {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-            Ok(CustomCounter(i))
+        pub(super) fn from_input(i: i32) -> Counter {
+            CustomCounter(i)
         }
     }
 
@@ -750,8 +737,8 @@ mod custom_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-            Ok(CustomCounter(i))
+        pub(super) fn from_input(i: i32) -> Counter {
+            CustomCounter(i)
         }
     }
 
@@ -832,8 +819,8 @@ mod generic_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-            Ok(CustomCounter(i))
+        pub(super) fn from_input(i: i32) -> Counter {
+            CustomCounter(i)
         }
     }
 
@@ -914,8 +901,8 @@ mod bounded_generic_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-            Ok(CustomCounter(i))
+        pub(super) fn from_input(i: i32) -> Counter {
+            CustomCounter(i)
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_attr_type_alias.rs
+++ b/tests/integration/tests/codegen_scalar_attr_type_alias.rs
@@ -6,8 +6,8 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    InputValue, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue, Value, execute,
-    graphql_object, graphql_scalar, graphql_value, graphql_vars,
+    ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue, Value, execute, graphql_object,
+    graphql_scalar, graphql_value, graphql_vars,
 };
 
 use self::common::{
@@ -36,10 +36,10 @@ mod all_custom_resolvers {
         Value::scalar(v.0)
     }
 
-    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Counter, prelude::String> {
-        v.as_int_value()
+    fn from_input(s: &impl ScalarValue) -> prelude::Result<Counter, prelude::String> {
+        s.as_int()
             .map(CustomCounter)
-            .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+            .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -117,12 +117,10 @@ mod explicit_name {
         Value::scalar(v.0)
     }
 
-    fn from_input<S: ScalarValue>(
-        v: &InputValue<S>,
-    ) -> prelude::Result<CounterScalar, prelude::String> {
-        v.as_int_value()
+    fn from_input(s: &impl ScalarValue) -> prelude::Result<CounterScalar, prelude::String> {
+        s.as_int()
             .map(CustomCounter)
-            .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+            .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -219,10 +217,10 @@ mod delegated_parse_token {
         Value::scalar(v.0)
     }
 
-    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Counter, prelude::String> {
-        v.as_int_value()
+    fn from_input(s: &impl ScalarValue) -> prelude::Result<Counter, prelude::String> {
+        s.as_int()
             .map(CustomCounter)
-            .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+            .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
     }
 
     struct QueryRoot;
@@ -301,13 +299,11 @@ mod multiple_delegated_parse_token {
         }
     }
 
-    fn from_input<S: ScalarValue>(
-        v: &InputValue<S>,
-    ) -> prelude::Result<StringOrInt, prelude::String> {
-        v.as_string_value()
-            .map(|s| StringOrInt::String(s.to_owned()))
-            .or_else(|| v.as_int_value().map(StringOrInt::Int))
-            .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+    fn from_input(s: &impl ScalarValue) -> prelude::Result<StringOrInt, prelude::String> {
+        s.as_string()
+            .map(StringOrInt::String)
+            .or_else(|| s.as_int().map(StringOrInt::Int))
+            .ok_or_else(|| format!("Expected `String` or `Int`, found: {s}"))
     }
 
     struct QueryRoot;
@@ -367,14 +363,13 @@ mod where_attribute {
         Value::scalar(v.0.to_rfc3339())
     }
 
-    fn from_input<S, Tz>(v: &InputValue<S>) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
+    fn from_input<Tz>(s: &impl ScalarValue) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
     where
-        S: ScalarValue,
         Tz: From<Utc> + TimeZone,
         Tz::Offset: fmt::Display,
     {
-        v.as_string_value()
-            .ok_or_else(|| format!("Expected `String`, found: {v}"))
+        s.as_str()
+            .ok_or_else(|| format!("Expected `String`, found: {s}"))
             .and_then(|s| {
                 DateTime::parse_from_rfc3339(s)
                     .map(|dt| CustomDateTimeScalar(dt.with_timezone(&Tz::from(Utc))))
@@ -439,10 +434,10 @@ mod with_self {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -529,16 +524,15 @@ mod with_module {
             Value::scalar(v.0.to_rfc3339())
         }
 
-        pub(super) fn from_input<S, Tz>(
-            v: &InputValue<S>,
+        pub(super) fn from_input<Tz>(
+            s: &impl ScalarValue,
         ) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
         where
-            S: ScalarValue,
             Tz: From<Utc> + TimeZone,
             Tz::Offset: fmt::Display,
         {
-            v.as_string_value()
-                .ok_or_else(|| format!("Expected `String`, found: {v}"))
+            s.as_str()
+                .ok_or_else(|| format!("Expected `String`, found: {s}"))
                 .and_then(|s| {
                     DateTime::parse_from_rfc3339(s)
                         .map(|dt| CustomDateTimeScalar(dt.with_timezone(&Tz::from(Utc))))
@@ -607,12 +601,12 @@ mod description_from_doc_comment {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input<S: ScalarValue>(
-            v: &InputValue<S>,
+        pub(super) fn from_input(
+            s: &impl ScalarValue,
         ) -> prelude::Result<Counter, prelude::String> {
-            v.as_int_value()
+            s.as_int()
                 .map(CustomCounter)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -693,12 +687,12 @@ mod description_from_attribute {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input<S: ScalarValue>(
-            v: &InputValue<S>,
+        pub(super) fn from_input(
+            s: &impl ScalarValue,
         ) -> prelude::Result<Counter, prelude::String> {
-            v.as_int_value()
+            s.as_int()
                 .map(CustomCounter)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -779,12 +773,12 @@ mod custom_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input<S: ScalarValue>(
-            v: &InputValue<S>,
+        pub(super) fn from_input(
+            s: &impl ScalarValue,
         ) -> prelude::Result<Counter, prelude::String> {
-            v.as_int_value()
+            s.as_int()
                 .map(CustomCounter)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -865,12 +859,12 @@ mod generic_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input<S: ScalarValue>(
-            v: &InputValue<S>,
+        pub(super) fn from_input(
+            s: &impl ScalarValue,
         ) -> prelude::Result<Counter, prelude::String> {
-            v.as_int_value()
+            s.as_int()
                 .map(CustomCounter)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -951,12 +945,12 @@ mod bounded_generic_scalar {
             Value::scalar(v.0)
         }
 
-        pub(super) fn from_input<S: ScalarValue>(
-            v: &InputValue<S>,
+        pub(super) fn from_input(
+            s: &impl ScalarValue,
         ) -> prelude::Result<Counter, prelude::String> {
-            v.as_int_value()
+            s.as_int()
                 .map(CustomCounter)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_attr_type_alias.rs
+++ b/tests/integration/tests/codegen_scalar_attr_type_alias.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    ParseScalarResult, ParseScalarValue, Raw, ScalarToken, ScalarValue, Value, execute,
+    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value, execute,
     graphql_object, graphql_scalar, graphql_value, graphql_vars,
 };
 
@@ -285,7 +285,7 @@ mod multiple_delegated_parse_token {
         }
     }
 
-    fn from_input(v: &Raw<impl ScalarValue>) -> prelude::Result<StringOrInt, prelude::Box<str>> {
+    fn from_input(v: &Scalar<impl ScalarValue>) -> prelude::Result<StringOrInt, prelude::Box<str>> {
         v.try_to_string()
             .map(StringOrInt::String)
             .or_else(|| v.try_to_int().map(StringOrInt::Int))

--- a/tests/integration/tests/codegen_scalar_attr_type_alias.rs
+++ b/tests/integration/tests/codegen_scalar_attr_type_alias.rs
@@ -23,11 +23,12 @@ mod all_custom_resolvers {
 
     struct CustomCounter(i32);
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
         from_input_with = CustomCounter,
     )]
-    #[graphql_scalar(
+    #[graphql(
         parse_token_with = parse_token,
     )]
     type Counter = CustomCounter;
@@ -99,7 +100,8 @@ mod explicit_name {
 
     struct CustomCounter(i32);
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         name = "Counter",
         to_output_with = to_output,
         from_input_with = CustomCounter,
@@ -194,7 +196,8 @@ mod delegated_parse_token {
 
     struct CustomCounter(i32);
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
         from_input_with = CustomCounter,
         parse_token(i32),
@@ -267,7 +270,8 @@ mod multiple_delegated_parse_token {
         Int(i32),
     }
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
         from_input_with = from_input,
         parse_token(prelude::String, i32),
@@ -327,7 +331,8 @@ mod where_attribute {
 
     struct CustomDateTimeScalar<Tz: TimeZone>(DateTime<Tz>);
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         to_output_with = to_output,
         from_input_with = from_input,
         parse_token(prelude::String),
@@ -404,7 +409,8 @@ mod with_self {
 
     struct CustomCounter(i32);
 
-    #[graphql_scalar(with = Self)]
+    #[graphql_scalar]
+    #[graphql(with = Self)]
     type Counter = CustomCounter;
 
     impl Counter {
@@ -480,7 +486,8 @@ mod with_module {
 
     struct CustomDateTimeScalar<Tz: TimeZone>(DateTime<Tz>);
 
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         with = custom_date_time,
         parse_token(prelude::String),
         where(Tz: From<Utc> + TimeZone, Tz::Offset: fmt::Display),
@@ -563,7 +570,8 @@ mod description_from_doc_comment {
     struct CustomCounter(i32);
 
     /// Description
-    #[graphql_scalar(with = counter, parse_token(i32))]
+    #[graphql_scalar]
+    #[graphql(with = counter, parse_token(i32))]
     type Counter = CustomCounter;
 
     mod counter {
@@ -641,7 +649,8 @@ mod description_from_attribute {
     struct CustomCounter(i32);
 
     /// Doc comment
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         description = "Description from attribute",
         with = counter,
         parse_token(i32),
@@ -723,7 +732,8 @@ mod custom_scalar {
     struct CustomCounter(i32);
 
     /// Description
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         scalar = MyScalarValue,
         with = counter,
         parse_token(i32),
@@ -805,7 +815,8 @@ mod generic_scalar {
     struct CustomCounter(i32);
 
     /// Description
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         scalar = S: ScalarValue,
         with = counter,
         parse_token(i32),
@@ -887,7 +898,8 @@ mod bounded_generic_scalar {
     struct CustomCounter(i32);
 
     /// Description
-    #[graphql_scalar(
+    #[graphql_scalar]
+    #[graphql(
         scalar = S: ScalarValue + prelude::Clone,
         with = counter,
         parse_token(i32),

--- a/tests/integration/tests/codegen_scalar_derive.rs
+++ b/tests/integration/tests/codegen_scalar_derive.rs
@@ -6,8 +6,8 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    GraphQLScalar, InputValue, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue,
-    Value, execute, graphql_object, graphql_value, graphql_vars,
+    GraphQLScalar, ParseScalarResult, ParseScalarValue, ScalarToken, ScalarValue, Value, execute,
+    graphql_object, graphql_value, graphql_vars,
 };
 
 use self::common::{
@@ -29,10 +29,10 @@ mod trivial {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
 
         fn parse_token<S: ScalarValue>(t: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -237,10 +237,10 @@ mod all_custom_resolvers {
         Value::scalar(v.0)
     }
 
-    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Counter, prelude::String> {
-        v.as_int_value()
+    fn from_input(s: &impl ScalarValue) -> prelude::Result<Counter, prelude::String> {
+        s.as_int()
             .map(Counter)
-            .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+            .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -313,10 +313,10 @@ mod explicit_name {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -390,10 +390,10 @@ mod delegated_parse_token {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -469,11 +469,11 @@ mod multiple_delegated_parse_token {
             }
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_string_value()
-                .map(|s| Self::String(s.to_owned()))
-                .or_else(|| v.as_int_value().map(Self::Int))
-                .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_string()
+                .map(Self::String)
+                .or_else(|| s.as_int().map(Self::Int))
+                .ok_or_else(|| format!("Expected `String` or `Int`, found: {s}"))
         }
     }
 
@@ -533,13 +533,12 @@ mod where_attribute {
         Value::scalar(v.0.to_rfc3339())
     }
 
-    fn from_input<S, Tz>(v: &InputValue<S>) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
+    fn from_input<Tz>(v: &impl ScalarValue) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
     where
-        S: ScalarValue,
         Tz: From<Utc> + TimeZone,
         Tz::Offset: fmt::Display,
     {
-        v.as_string_value()
+        v.as_str()
             .ok_or_else(|| format!("Expected `String`, found: {v}"))
             .and_then(|s| {
                 DateTime::parse_from_rfc3339(s)
@@ -604,10 +603,10 @@ mod with_self {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -693,15 +692,14 @@ mod with_module {
             Value::scalar(v.0.to_rfc3339())
         }
 
-        pub(super) fn from_input<S, Tz>(
-            v: &InputValue<S>,
+        pub(super) fn from_input<Tz>(
+            v: &impl ScalarValue,
         ) -> prelude::Result<CustomDateTime<Tz>, prelude::String>
         where
-            S: ScalarValue,
             Tz: From<Utc> + TimeZone,
             Tz::Offset: fmt::Display,
         {
-            v.as_string_value()
+            v.as_str()
                 .ok_or_else(|| format!("Expected `String`, found: {v}"))
                 .and_then(|s| {
                     DateTime::parse_from_rfc3339(s)
@@ -768,10 +766,10 @@ mod description_from_doc_comment {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -845,10 +843,10 @@ mod description_from_attribute {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -922,10 +920,10 @@ mod custom_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -999,10 +997,10 @@ mod generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `Counter`, found: {v}"))
+                .ok_or_else(|| format!("Expected `Counter`, found: {s}"))
         }
     }
 
@@ -1075,10 +1073,10 @@ mod bounded_generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input<S: ScalarValue>(v: &InputValue<S>) -> prelude::Result<Self, prelude::String> {
-            v.as_int_value()
+        fn from_input(s: &impl ScalarValue) -> prelude::Result<Self, prelude::String> {
+            s.as_int()
                 .map(Self)
-                .ok_or_else(|| format!("Expected `String`, found: {v}"))
+                .ok_or_else(|| format!("Expected `String`, found: {s}"))
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_derive.rs
+++ b/tests/integration/tests/codegen_scalar_derive.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    GraphQLScalar, ParseScalarResult, ParseScalarValue, Raw, ScalarToken, ScalarValue, Value,
+    GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value,
     execute, graphql_object, graphql_value, graphql_vars,
 };
 
@@ -457,7 +457,7 @@ mod multiple_delegated_parse_token {
             }
         }
 
-        fn from_input(v: &Raw<impl ScalarValue>) -> prelude::Result<Self, prelude::Box<str>> {
+        fn from_input(v: &Scalar<impl ScalarValue>) -> prelude::Result<Self, prelude::Box<str>> {
             v.try_to_string()
                 .map(Self::String)
                 .or_else(|| v.try_to_int().map(Self::Int))

--- a/tests/integration/tests/codegen_scalar_derive.rs
+++ b/tests/integration/tests/codegen_scalar_derive.rs
@@ -2,7 +2,7 @@
 
 pub mod common;
 
-use std::{convert::Infallible, fmt};
+use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
@@ -29,8 +29,8 @@ mod trivial {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(t: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -226,17 +226,13 @@ mod all_custom_resolvers {
     #[derive(GraphQLScalar)]
     #[graphql(
         to_output_with = to_output,
-        from_input_with = from_input,
+        from_input_with = Counter,
     )]
     #[graphql(parse_token_with = parse_token)]
     struct Counter(i32);
 
     fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
         Value::scalar(v.0)
-    }
-
-    fn from_input(i: i32) -> prelude::Result<Counter, Infallible> {
-        Ok(Counter(i))
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -309,8 +305,8 @@ mod explicit_name {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -384,8 +380,8 @@ mod delegated_parse_token {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -591,8 +587,8 @@ mod with_self {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
 
         fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -748,8 +744,8 @@ mod description_from_doc_comment {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -823,8 +819,8 @@ mod description_from_attribute {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -898,8 +894,8 @@ mod custom_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -973,8 +969,8 @@ mod generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 
@@ -1047,8 +1043,8 @@ mod bounded_generic_scalar {
             Value::scalar(self.0)
         }
 
-        fn from_input(i: i32) -> prelude::Result<Self, Infallible> {
-            Ok(Self(i))
+        fn from_input(i: i32) -> Self {
+            Self(i)
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_value_derive.rs
+++ b/tests/integration/tests/codegen_scalar_value_derive.rs
@@ -12,7 +12,9 @@ use self::common::hygiene::*;
 mod trivial {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
+    #[derive(
+        Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    )]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -53,7 +55,9 @@ mod trivial {
 mod named_fields {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
+    #[derive(
+        Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    )]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -94,7 +98,9 @@ mod named_fields {
 mod custom_fn {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
+    #[derive(
+        Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    )]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -139,7 +145,9 @@ mod custom_fn {
 mod allow_missing_attributes {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
+    #[derive(
+        Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    )]
     #[serde(untagged)]
     #[value(allow_missing_attributes)]
     pub enum CustomScalarValue {

--- a/tests/integration/tests/codegen_scalar_value_derive.rs
+++ b/tests/integration/tests/codegen_scalar_value_derive.rs
@@ -2,6 +2,7 @@
 
 pub mod common;
 
+use derive_more::with_trait::{Display, From}
 use juniper::{DefaultScalarValue, ScalarValue};
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +12,7 @@ use self::common::hygiene::*;
 mod trivial {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -52,7 +53,7 @@ mod trivial {
 mod named_fields {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -93,7 +94,7 @@ mod named_fields {
 mod custom_fn {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -138,7 +139,7 @@ mod custom_fn {
 mod allow_missing_attributes {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
     #[serde(untagged)]
     #[value(allow_missing_attributes)]
     pub enum CustomScalarValue {
@@ -153,7 +154,7 @@ mod allow_missing_attributes {
 
     #[test]
     fn into_another() {
-        assert!(CustomScalarValue::Int(5).as_int().is_none());
+        assert!(CustomScalarValue::Int(5).to_int().is_none());
         assert!(
             CustomScalarValue::from(0.5_f64)
                 .into_another::<DefaultScalarValue>()

--- a/tests/integration/tests/codegen_scalar_value_derive.rs
+++ b/tests/integration/tests/codegen_scalar_value_derive.rs
@@ -162,11 +162,7 @@ mod missing_conv_attr {
         type Error = &'static str;
 
         fn try_scalar_value_to(&'me self) -> prelude::Result<i32, Self::Error> {
-            if let CustomScalarValue::Int(x) = self {
-                Ok(*x)
-            } else {
-                Err("Not `Int` definitely")
-            }
+            Err("Not `Int` definitely")
         }
     }
 

--- a/tests/integration/tests/codegen_scalar_value_derive.rs
+++ b/tests/integration/tests/codegen_scalar_value_derive.rs
@@ -2,7 +2,7 @@
 
 pub mod common;
 
-use derive_more::with_trait::{Display, From}
+use derive_more::with_trait::{Display, From};
 use juniper::{DefaultScalarValue, ScalarValue};
 use serde::{Deserialize, Serialize};
 
@@ -154,7 +154,7 @@ mod allow_missing_attributes {
 
     #[test]
     fn into_another() {
-        assert!(CustomScalarValue::Int(5).to_int().is_none());
+        assert!(CustomScalarValue::Int(5).try_to_int().is_none());
         assert!(
             CustomScalarValue::from(0.5_f64)
                 .into_another::<DefaultScalarValue>()

--- a/tests/integration/tests/codegen_scalar_value_derive.rs
+++ b/tests/integration/tests/codegen_scalar_value_derive.rs
@@ -2,7 +2,7 @@
 
 pub mod common;
 
-use derive_more::with_trait::{Display, From};
+use derive_more::with_trait::{Display, From, TryInto};
 use juniper::{DefaultScalarValue, ScalarValue};
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +12,7 @@ use self::common::hygiene::*;
 mod trivial {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -53,7 +53,7 @@ mod trivial {
 mod named_fields {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -94,7 +94,7 @@ mod named_fields {
 mod custom_fn {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
     #[serde(untagged)]
     pub enum CustomScalarValue {
         #[value(as_float, as_int)]
@@ -139,7 +139,7 @@ mod custom_fn {
 mod allow_missing_attributes {
     use super::*;
 
-    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
     #[serde(untagged)]
     #[value(allow_missing_attributes)]
     pub enum CustomScalarValue {

--- a/tests/integration/tests/common/mod.rs
+++ b/tests/integration/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use derive_more::with_trait::{Display, From};
+use derive_more::with_trait::{Display, From, TryInto};
 use juniper::{InputValue, IntoInputValue, IntoValue, ScalarValue, Value};
 use serde::{Deserialize, Deserializer, Serialize, de};
 use smartstring::alias::CompactString;
@@ -76,25 +76,16 @@ pub mod util {
     }
 }
 
-#[derive(Clone, Debug, Display, From, PartialEq, ScalarValue, Serialize)]
+#[derive(Clone, Debug, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
 #[serde(untagged)]
 pub enum MyScalarValue {
-    #[from]
     #[value(as_float, as_int)]
     Int(i32),
-
-    #[from]
     Long(i64),
-
-    #[from]
     #[value(as_float)]
     Float(f64),
-
-    #[from(&str, String)]
     #[value(as_str, as_string, into_string)]
     String(String),
-
-    #[from]
     #[value(as_bool)]
     Boolean(bool),
 }

--- a/tests/integration/tests/common/mod.rs
+++ b/tests/integration/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use derive_more::with_trait::{Display, From};
 use juniper::{InputValue, IntoInputValue, IntoValue, ScalarValue, Value};
 use serde::{Deserialize, Deserializer, Serialize, de};
 use smartstring::alias::CompactString;
@@ -75,16 +76,25 @@ pub mod util {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, ScalarValue, Serialize)]
+#[derive(Clone, Debug, Display, From, PartialEq, ScalarValue, Serialize)]
 #[serde(untagged)]
 pub enum MyScalarValue {
+    #[from]
     #[value(as_float, as_int)]
     Int(i32),
+
+    #[from]
     Long(i64),
+
+    #[from]
     #[value(as_float)]
     Float(f64),
+
+    #[from(&str, String)]
     #[value(as_str, as_string, into_string)]
     String(String),
+
+    #[from]
     #[value(as_bool)]
     Boolean(bool),
 }

--- a/tests/integration/tests/common/mod.rs
+++ b/tests/integration/tests/common/mod.rs
@@ -79,14 +79,14 @@ pub mod util {
 #[derive(Clone, Debug, Display, From, PartialEq, ScalarValue, Serialize, TryInto)]
 #[serde(untagged)]
 pub enum MyScalarValue {
-    #[value(as_float, as_int)]
+    #[value(to_float, to_int)]
     Int(i32),
     Long(i64),
-    #[value(as_float)]
+    #[value(to_float)]
     Float(f64),
-    #[value(as_str, as_string, into_string)]
+    #[value(as_str, to_string)]
     String(String),
-    #[value(as_bool)]
+    #[value(to_bool)]
     Boolean(bool),
 }
 

--- a/tests/integration/tests/custom_scalar.rs
+++ b/tests/integration/tests/custom_scalar.rs
@@ -22,11 +22,11 @@ mod long {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(s: &MyScalarValue) -> Result<Long, String> {
+    pub(super) fn from_input(s: &MyScalarValue) -> Result<Long, Box<str>> {
         if let MyScalarValue::Long(i) = s {
             Ok(*i)
         } else {
-            Err(format!("Expected `MyScalarValue::Long`, found: {s}"))
+            Err(format!("Expected `MyScalarValue::Long`, found: {s}").into())
         }
     }
 

--- a/tests/integration/tests/custom_scalar.rs
+++ b/tests/integration/tests/custom_scalar.rs
@@ -22,10 +22,12 @@ mod long {
         Value::scalar(*v)
     }
 
-    pub(super) fn from_input(v: &InputValue<MyScalarValue>) -> Result<Long, String> {
-        v.as_scalar_value::<i64>()
-            .copied()
-            .ok_or_else(|| format!("Expected `MyScalarValue::Long`, found: {v}"))
+    pub(super) fn from_input(s: &MyScalarValue) -> Result<Long, String> {
+        if let MyScalarValue::Long(i) = s {
+            Ok(*i)
+        } else {
+            Err(format!("Expected `MyScalarValue::Long`, found: {s}"))
+        }
     }
 
     pub(super) fn parse_token(value: ScalarToken<'_>) -> ParseScalarResult<MyScalarValue> {


### PR DESCRIPTION
## Synopsis

At the moment, defining a GraphQL scalar requires a `from_input()` function, which accepts `InputValue` as its argument:
```rust
#[derive(GraphQLScalar)]
#[graphql(parse_token(String, i32))]
pub struct ID(String);

impl ID {
    fn to_output<S: ScalarValue>(&self) -> Value<S> {
        Value::scalar(self.0.clone())
    }

    fn from_input<S: ScalarValue>(v: &InputValue<S>) -> Result<Self, String> {
    //                                ^^^^^^^^^^^^^ redundant, we need only `S`
        v.as_string_value()
            .map(str::to_owned)
            .or_else(|| v.as_int_value().as_ref().map(ToString::to_string))
            .map(Self)
            .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
    }
}
```
However, the only viable option to parse a `GraphQLScalar` is only from `InputValue::Scalar` variant. Machinery never passes to this function an `InputValue::Enum` or other variants. Thus, all the `GraphQLScalar` declarations use `InputValue::as_string_value()` or similar methods, which inside use the `InputValue::as_scalar_value()` method which tries to unwrap an `InputValue::Scalar`.

It's quite redundant to deal with the whole `InputValue` in `from_input()` functions, while the only viable and used variant is always `InputValue::Scalar`.


## Solution

Instead, it makes sense to pass into the `from_input()` the already unwrapped `InputValue::Scalar` as `ScalarValue`, so the user code could deal with it directly without a need to involve any `InputValue` functionality.

```rust
#[derive(GraphQLScalar)]
#[graphql(parse_token(String, i32))]
pub struct ID(String);

impl ID {
    fn to_output<S: ScalarValue>(&self) -> Value<S> {
        Value::scalar(self.0.clone())
    }

    fn from_input(v: &impl ScalarValue) -> Result<Self, String> {
    //                     ^^^^^^^^^^^ use `ScalarValue` directly
        v.as_string()
            .or_else(|| s.as_int().as_ref().map(ToString::to_string))
            .map(Self)
            .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
    }
}
```

And yet, we can take a step further and provide an input/output type polymorphism for the `from_input()` function:
```rust
#[derive(GraphQLScalar)]
#[graphql(parse_token(String, i32))]
pub struct ID(String);

impl ID {
    fn to_output<S: ScalarValue>(&self) -> Value<S> {
        Value::scalar(self.0.clone())
    }

    fn from_input(v: &str) -> Self { // result could be infallible
    //               ^^^^ use `&str` directly
        Self(s.into())
    }
}
```

This is achieved by revamping the `ScalarValue` trait and introducing input type polymorphism via helper `TryScalarValueTo` conversion trait. We cannot use just `TryFrom` or `TryInto` trait for this purpose, because the conversions are made from a reference, and thus, we cannot specify the required conversions as super-trait bounds for the `ScalarValue` trait (which we need to make them implied in macro expansions or whenever `ScalarValue` is used).

The only downside, that Rust cannot infer types if the generic is specified directly, and thus, when we need to use a generic in `from_input()` function, we should use the transparent `Scalar` wrapper to aid the inference:
```rust
#[derive(GraphQLScalar)]
#[graphql(parse_token(String, i32))]
pub struct ID(String);

impl ID {
    fn to_output<S: ScalarValue>(&self) -> Value<S> {
        Value::scalar(self.0.clone())
    }

    fn from_input(v: &Scalar<impl ScalarValue>) -> Result<Self, String> {
    //                ^^^^^^ required to aid type inference
        v.try_to_string()
            .or_else(|| s.try_to_int().as_ref().map(ToString::to_string))
            .map(Self)
            .ok_or_else(|| format!("Expected `String` or `Int`, found: {v}"))
    }
}
```

Into-`Result` output type polymorphism is achieved by `::juniper::macros::helper::ToResultCall` [autoref-based specialization](https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html) for the provided function.


## Checklist

- [x] Documentation is updated (Book and API docs)
- [x] CHANGELOG entry is added
- [x] Tests are updated