### PR TITLE
Strip `Value` from `to_output()` function for GraphQL scalars

### DIFF
--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 
 [dependencies]
 dataloader = "0.18" # for Book only
+derive_more = { version = "2.0", features = ["display", "from", "try_into"] }
+juniper = { path = "../juniper", features = ["jiff"] }
 
 [lints.clippy]
 allow_attributes = "warn"

--- a/book/Cargo.toml
+++ b/book/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 anyhow = "1.0"
 dataloader = "0.18"
 derive_more = { version = "2.0", features = ["display", "from", "try_into"] }
+jiff = { version = "0.2", features = ["std"], default-features = false }
 juniper = { path = "../juniper", features = ["anyhow", "jiff", "schema-language"] }
 juniper_subscriptions = { path = "../juniper_subscriptions" }
 serde_json = "1.0"

--- a/book/src/lib.rs
+++ b/book/src/lib.rs
@@ -1,3 +1,4 @@
 //! Crate keeping dependencies for running Book tests.
 
 use dataloader as _;
+use juniper as _;

--- a/book/src/lib.rs
+++ b/book/src/lib.rs
@@ -3,6 +3,7 @@
 use anyhow as _;
 use dataloader as _;
 use derive_more as _;
+use jiff as _;
 use juniper as _;
 use juniper_subscriptions as _;
 use serde_json as _;

--- a/book/src/types/scalars.md
+++ b/book/src/types/scalars.md
@@ -85,15 +85,49 @@ pub struct UserId(String);
 In case we need to customize [resolving][7] of a [custom GraphQL scalar][2] value (change the way it gets executed), the `#[graphql(to_output_with = <fn path>)]` attribute is the way to do so:
 ```rust
 # extern crate juniper;
-# use juniper::{GraphQLScalar, IntoValue as _, ScalarValue, Value};
+# use juniper::GraphQLScalar;
 #
 #[derive(GraphQLScalar)]
 #[graphql(to_output_with = to_output, transparent)]
 struct Incremented(i32);
 
-/// Increments [`Incremented`] before converting into a [`Value`].
-fn to_output<S: ScalarValue>(v: &Incremented) -> Value<S> {
-    (v.0 + 1).into_value()
+fn to_output(v: &Incremented) -> i32 {
+    //                           ^^^ any concrete type having `ToScalarValue` implementation
+    //                               could be used
+    v.0 + 1
+}
+#
+# fn main() {}
+```
+
+The provided function is polymorphic by its output type:
+```rust
+# extern crate jiff;
+# extern crate juniper;
+# use std::fmt::Display;
+# use juniper::{GraphQLScalar, ScalarValue};
+#
+#[derive(GraphQLScalar)]
+#[graphql(to_output_with = Self::to_output, transparent)]
+struct Incremented(i32);
+
+impl Incremented {
+    fn to_output<S: ScalarValue>(v: &Incremented) -> S {
+        //       ^^^^^^^^^^^^^^ returning generic or concrete `ScalarValue` is also OK
+        (v.0 + 1).into()
+    }
+}
+
+#[derive(GraphQLScalar)]
+#[graphql(to_output_with = Self::to_output, transparent)]
+struct CustomDateTime(jiff::Timestamp);
+
+impl CustomDateTime {
+    fn to_output(&self) -> impl Display {
+        //                 ^^^^^^^^^^^^ in this case macro expansion uses the
+        //                              `ScalarValue::from_displayable_non_static()` conversion
+        self.0.strftime("%Y-%m-%d %H:%M:%S%.fZ")
+    }
 }
 #
 # fn main() {}
@@ -117,7 +151,7 @@ impl UserId {
         input: &str,
         //     ^^^^ any concrete type having `FromScalarValue` implementation could be used
     ) -> Result<Self, Box<str>> {
-    //                ^^^^^^^^ must implement `IntoFieldError`
+        //            ^^^^^^^^ must implement `IntoFieldError`
         input
             .strip_prefix("id: ")
             .ok_or_else(|| {
@@ -130,7 +164,7 @@ impl UserId {
 # fn main() {}
 ```
 
-The provided function is polymorphic by input and output types:
+The provided function is polymorphic by its input and output types:
 ```rust
 # extern crate juniper;
 # use juniper::{GraphQLScalar, Scalar, ScalarValue};
@@ -169,7 +203,7 @@ Customization of which tokens a [custom GraphQL scalar][0] type should be parsed
 ```rust
 # extern crate juniper;
 # use juniper::{
-#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value,
+#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
 # };
 #
 #[derive(GraphQLScalar)]
@@ -186,10 +220,12 @@ enum StringOrInt {
     Int(i32),
 }
 
-fn to_output<S: ScalarValue>(v: &StringOrInt) -> Value<S> {
+fn to_output<S: ScalarValue>(v: &StringOrInt) -> S {
     match v {
-        StringOrInt::String(s) => Value::scalar(s.to_owned()),
-        StringOrInt::Int(i) => Value::scalar(*i),
+        StringOrInt::String(s) => S::from_displayable(s),
+        //                        ^^^^^^^^^^^^^^^^^^^ preferable conversion for types
+        //                                            represented by string token
+        StringOrInt::Int(i) => (*i).into(),
     }
 }
 
@@ -216,7 +252,7 @@ Instead of providing all custom functions separately, it's possible to provide a
 ```rust
 # extern crate juniper;
 # use juniper::{
-#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value,
+#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
 # };
 #
 #[derive(GraphQLScalar)]
@@ -229,10 +265,10 @@ enum StringOrInt {
 mod string_or_int {
     use super::*;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &StringOrInt) -> Value<S> {
+    pub(super) fn to_output<S: ScalarValue>(v: &StringOrInt) -> S {
         match v {
-            StringOrInt::String(s) => Value::scalar(s.to_owned()),
-            StringOrInt::Int(i) => Value::scalar(*i),
+            StringOrInt::String(s) => S::from_displayable(s),
+            StringOrInt::Int(i) => (*i).into(),
         }
     }
 
@@ -256,7 +292,7 @@ A regular `impl` block is also suitable for that:
 ```rust
 # extern crate juniper;
 # use juniper::{
-#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value,
+#     GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue,
 # };
 #
 #[derive(GraphQLScalar)]
@@ -267,10 +303,10 @@ enum StringOrInt {
 }
 
 impl StringOrInt {
-    fn to_output<S: ScalarValue>(&self) -> Value<S> {
+    fn to_output<S: ScalarValue>(&self) -> S {
         match self {
-            Self::String(s) => Value::scalar(s.to_owned()),
-            Self::Int(i) => Value::scalar(*i),
+            Self::String(s) => S::from_displayable(s),
+            Self::Int(i) => (*i).into(),
         }
     }
 
@@ -297,7 +333,7 @@ At the same time, any custom function still may be specified separately, if requ
 ```rust
 # extern crate juniper;
 # use juniper::{
-#     GraphQLScalar, ParseScalarResult, Scalar, ScalarToken, ScalarValue, Value,
+#     GraphQLScalar, ParseScalarResult, Scalar, ScalarToken, ScalarValue,
 # };
 #
 #[derive(GraphQLScalar)]
@@ -313,13 +349,10 @@ enum StringOrInt {
 mod string_or_int {
     use super::*;
 
-    pub(super) fn to_output<S>(v: &StringOrInt) -> Value<S>
-    where
-        S: ScalarValue,
-    {
+    pub(super) fn to_output<S: ScalarValue>(v: &StringOrInt) -> S {
         match v {
-            StringOrInt::String(s) => Value::scalar(s.to_owned()),
-            StringOrInt::Int(i) => Value::scalar(*i),
+            StringOrInt::String(s) => S::from_displayable(s),
+            StringOrInt::Int(i) => (*i).into(),
         }
     }
 
@@ -367,11 +400,12 @@ For implementing [custom scalars][2] on foreign types there is [`#[graphql_scala
 # }
 #
 # use juniper::DefaultScalarValue as CustomScalarValue;
-use juniper::{ScalarValue, Value, graphql_scalar};
+use juniper::{ScalarValue, graphql_scalar};
 
 #[graphql_scalar]
 #[graphql(
     with = date_scalar, 
+    to_output_with = ScalarValue::from_displayable, // use `Display` representation
     parse_token(String),
     scalar = CustomScalarValue,
 )]
@@ -381,10 +415,6 @@ type Date = date::Date;
 
 mod date_scalar {
     use super::*;
-  
-    pub(super) fn to_output(v: &Date) -> Value<CustomScalarValue> {
-        Value::scalar(v.to_string())
-    }
 
     pub(super) fn from_input(s: &str) -> Result<Date, Box<str>> {
         s.parse().map_err(|e| format!("Failed to parse `Date`: {e}").into())

--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -93,6 +93,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
     - `From` and `Display` implementations are not derived anymore (recommended way is to use [`derive_more` crate] for this).
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros:
     - Made provided `from_input()` function to accept `ScalarValue` (or anything `FromScalarValue`-convertible) directly instead of `InputValue`. ([#1327])
+    - Made provided `to_output()` function to return `ScalarValue` directly instead of `Value`. ([#1330])
 - Removed `LocalBoxFuture` usage from `http::tests::WsIntegration` trait. ([4b14c015])
 
 ### Added
@@ -112,18 +113,25 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 - `IntoValue` and `IntoInputValue` conversion traits allowing to work around orphan rules with custom `ScalarValue`. ([#1324])
 - `FromScalarValue` conversion trait. ([#1329])
 - `TryToPrimitive` conversion trait aiding `ScalarValue` trait. ([#1327], [#1329])
+- `ToScalarValue` conversion trait. ([#1330])
 - `ScalarValue` trait:
-    - `from_displayable()` method allowing to specialize `ScalarValue` conversion from custom string types. ([#1324], [#819])
+    - `from_displayable()` and `from_displayable_non_static()` methods allowing to specialize `ScalarValue` conversion from/for custom string types. ([#1324], [#1330], [#819])
     - `try_to::<T>()` method defined by default as `FromScalarValue<T>` alias. ([#1327], [#1329])
+- `#[derive(ScalarValue)]` macro:
+    - Support of top-level `#[value(from_displayable_with = ...)]` attribute. ([#1324])
+    - Support of top-level `#[value(from_displayable_non_static_with = ...)]` attribute. ([#1330])
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros:
     - Support for specifying concrete types as input argument in provided `from_input()` function. ([#1327])
     - Support for non-`Result` return type in provided `from_input()` function. ([#1327])
     - `Scalar` transparent wrapper for aiding type inference in `from_input()` function when input argument is generic `ScalarValue`. ([#1327])
     - Generating of `FromScalarValue` implementation. ([#1329])
+    - Support for concrete and `impl Display` return types in provided `to_output()` function. ([#1330])
+    - Generating of `ToScalarValue` implementation. ([#1330])
 
 ### Changed
 
 - Upgraded [GraphiQL] to [5.0.0 version](https://github.com/graphql/graphiql/blob/graphiql%405.0.0/packages/graphiql/CHANGELOG.md#500). ([#1331])
+- Lifted `Sized` requirement from `ToInputValue` conversion trait. ([#1330]) 
 
 ### Fixed
 
@@ -147,6 +155,7 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1324]: /../../pull/1324
 [#1327]: /../../pull/1327
 [#1329]: /../../pull/1329
+[#1330]: /../../pull/1330
 [#1331]: /../../pull/1331
 [1b1fc618]: /../../commit/1b1fc61879ffdd640d741e187dc20678bf7ab295
 [20609366]: /../../commit/2060936635609b0186d46d8fbd06eb30fce660e3

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -80,6 +80,7 @@ tap = { version = "1.0.1", optional = true }
 void = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
+arcstr = { version = "1.1", features = ["serde"] }
 bencher = "0.1.2"
 chrono = { version = "0.4.30", features = ["alloc"], default-features = false }
 compact_str = { version = "0.9", features = ["serde"] }

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -231,8 +231,8 @@ pub trait FromInputValue<S = DefaultScalarValue>: Sized {
     }
 }
 
-/// Losslessly clones a Rust data type into an InputValue.
-pub trait ToInputValue<S = DefaultScalarValue>: Sized {
+/// Losslessly clones a Rust data type into an [`InputValue`].
+pub trait ToInputValue<S = DefaultScalarValue> {
     /// Performs the conversion.
     fn to_input_value(&self) -> InputValue<S>;
 }

--- a/juniper/src/executor_tests/variables.rs
+++ b/juniper/src/executor_tests/variables.rs
@@ -1,5 +1,5 @@
 use crate::{
-    GraphQLInputObject, GraphQLScalar, ScalarValue, Value,
+    GraphQLInputObject, GraphQLScalar,
     executor::Variables,
     graphql_object, graphql_value, graphql_vars,
     parser::SourcePosition,
@@ -14,8 +14,8 @@ use crate::{
 struct TestComplexScalar;
 
 impl TestComplexScalar {
-    fn to_output<S: ScalarValue>(&self) -> Value<S> {
-        graphql_value!("SerializedValue")
+    fn to_output(&self) -> &'static str {
+        "SerializedValue"
     }
 
     fn from_input(s: &str) -> Result<Self, Box<str>> {

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -8,9 +8,7 @@
 //!
 //! [`BigDecimal`]: bigdecimal::BigDecimal
 
-use std::str::FromStr as _;
-
-use crate::{Scalar, ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 // TODO: Try remove on upgrade of `bigdecimal` crate.
 mod for_minimal_versions_check_only {
@@ -29,7 +27,8 @@ mod for_minimal_versions_check_only {
 /// See also [`bigdecimal`] crate for details.
 ///
 /// [`bigdecimal`]: https://docs.rs/bigdecimal
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = bigdecimal_scalar,
     parse_token(i32, f64, String),
     specified_by_url = "https://docs.rs/bigdecimal",
@@ -37,10 +36,11 @@ mod for_minimal_versions_check_only {
 type BigDecimal = bigdecimal::BigDecimal;
 
 mod bigdecimal_scalar {
-    use super::*;
+    use super::BigDecimal;
+    use crate::{Scalar, ScalarValue};
 
-    pub(super) fn to_output<S: ScalarValue>(v: &BigDecimal) -> Value<S> {
-        Value::scalar(v.to_string())
+    pub(super) fn to_output(v: &BigDecimal) -> String {
+        v.to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<BigDecimal, Box<str>> {
@@ -50,13 +50,14 @@ mod bigdecimal_scalar {
             // See akubera/bigdecimal-rs#103 for details:
             // https://github.com/akubera/bigdecimal-rs/issues/103
             let mut buf = ryu::Buffer::new();
-            BigDecimal::from_str(buf.format(f))
+            buf.format(f)
+                .parse::<BigDecimal>()
                 .map_err(|e| format!("Failed to parse `BigDecimal` from `Float`: {e}").into())
         } else {
             v.try_to::<&str>()
                 .map_err(|e| e.to_string().into())
                 .and_then(|s| {
-                    BigDecimal::from_str(s).map_err(|e| {
+                    s.parse::<BigDecimal>().map_err(|e| {
                         format!("Failed to parse `BigDecimal` from `String`: {e}").into()
                     })
                 })
@@ -66,8 +67,6 @@ mod bigdecimal_scalar {
 
 #[cfg(test)]
 mod test {
-    use std::str::FromStr as _;
-
     use crate::{FromInputValue as _, InputValue, ToInputValue as _, graphql_input_value};
 
     use super::BigDecimal;
@@ -91,7 +90,7 @@ mod test {
         ] {
             let input: InputValue = input;
             let parsed = BigDecimal::from_input_value(&input);
-            let expected = BigDecimal::from_str(expected).unwrap();
+            let expected = expected.parse::<BigDecimal>().unwrap();
 
             assert!(
                 parsed.is_ok(),
@@ -130,7 +129,7 @@ mod test {
             "123",
             "43.44",
         ] {
-            let actual: InputValue = BigDecimal::from_str(raw).unwrap().to_input_value();
+            let actual: InputValue = raw.parse::<BigDecimal>().unwrap().to_input_value();
 
             assert_eq!(actual, graphql_input_value!((raw)), "on value: {raw}");
         }

--- a/juniper/src/integrations/bigdecimal.rs
+++ b/juniper/src/integrations/bigdecimal.rs
@@ -8,7 +8,7 @@
 //!
 //! [`BigDecimal`]: bigdecimal::BigDecimal
 
-use crate::graphql_scalar;
+use crate::{ScalarValue, graphql_scalar};
 
 // TODO: Try remove on upgrade of `bigdecimal` crate.
 mod for_minimal_versions_check_only {
@@ -30,6 +30,7 @@ mod for_minimal_versions_check_only {
 #[graphql_scalar]
 #[graphql(
     with = bigdecimal_scalar,
+    to_output_with = ScalarValue::from_displayable,
     parse_token(i32, f64, String),
     specified_by_url = "https://docs.rs/bigdecimal",
 )]
@@ -38,10 +39,6 @@ type BigDecimal = bigdecimal::BigDecimal;
 mod bigdecimal_scalar {
     use super::BigDecimal;
     use crate::{Scalar, ScalarValue};
-
-    pub(super) fn to_output(v: &BigDecimal) -> String {
-        v.to_string() // TODO: Optimize via `Display`?
-    }
 
     pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<BigDecimal, Box<str>> {
         if let Some(i) = v.try_to_int() {

--- a/juniper/src/integrations/bson.rs
+++ b/juniper/src/integrations/bson.rs
@@ -13,7 +13,7 @@
 //! [s1]: https://graphql-scalars.dev/docs/scalars/object-id
 //! [s4]: https://graphql-scalars.dev/docs/scalars/date-time
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 // TODO: Try remove on upgrade of `bson` crate.
 mod for_minimal_versions_check_only {
@@ -29,7 +29,8 @@ mod for_minimal_versions_check_only {
 /// [0]: https://www.mongodb.com/docs/manual/reference/bson-types#objectid
 /// [1]: https://graphql-scalars.dev/docs/scalars/object-id
 /// [2]: https://docs.rs/bson/*/bson/oid/struct.ObjectId.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     name = "ObjectID",
     with = object_id,
     parse_token(String),
@@ -38,10 +39,10 @@ mod for_minimal_versions_check_only {
 type ObjectId = bson::oid::ObjectId;
 
 mod object_id {
-    use super::*;
+    use super::ObjectId;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &ObjectId) -> Value<S> {
-        Value::scalar(v.to_hex())
+    pub(super) fn to_output(v: &ObjectId) -> String {
+        v.to_hex()
     }
 
     pub(super) fn from_input(s: &str) -> Result<ObjectId, Box<str>> {
@@ -62,7 +63,8 @@ mod object_id {
 /// [1]: https://graphql-scalars.dev/docs/scalars/date-time
 /// [2]: https://docs.rs/bson/*/bson/struct.DateTime.html
 /// [3]: https://www.mongodb.com/docs/manual/reference/bson-types#date
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = date_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/date-time",
@@ -70,13 +72,11 @@ mod object_id {
 type DateTime = bson::DateTime;
 
 mod date_time {
-    use super::*;
+    use super::DateTime;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &DateTime) -> Value<S> {
-        Value::scalar(
-            (*v).try_to_rfc3339_string()
-                .unwrap_or_else(|e| panic!("failed to format `DateTime` as RFC 3339: {e}")),
-        )
+    pub(super) fn to_output(v: &DateTime) -> String {
+        (*v).try_to_rfc3339_string()
+            .unwrap_or_else(|e| panic!("failed to format `DateTime` as RFC 3339: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -45,6 +45,8 @@ use crate::graphql_scalar;
 pub type LocalDate = chrono::NaiveDate;
 
 mod local_date {
+    use std::fmt::Display;
+
     use super::LocalDate;
 
     /// Format of a [`LocalDate` scalar][1].
@@ -52,8 +54,8 @@ mod local_date {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
     const FORMAT: &str = "%Y-%m-%d";
 
-    pub(super) fn to_output(v: &LocalDate) -> String {
-        v.format(FORMAT).to_string() // TODO: Optimize via `Display`?
+    pub(super) fn to_output(v: &LocalDate) -> impl Display {
+        v.format(FORMAT)
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
@@ -82,6 +84,8 @@ mod local_date {
 pub type LocalTime = chrono::NaiveTime;
 
 mod local_time {
+    use std::fmt::Display;
+
     use chrono::Timelike as _;
 
     use super::LocalTime;
@@ -101,13 +105,12 @@ mod local_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
     const FORMAT_NO_SECS: &str = "%H:%M";
 
-    pub(super) fn to_output(v: &LocalTime) -> String {
+    pub(super) fn to_output(v: &LocalTime) -> impl Display {
         if v.nanosecond() == 0 {
             v.format(FORMAT_NO_MILLIS)
         } else {
             v.format(FORMAT)
         }
-        .to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
@@ -137,6 +140,8 @@ mod local_time {
 pub type LocalDateTime = chrono::NaiveDateTime;
 
 mod local_date_time {
+    use std::fmt::Display;
+
     use super::LocalDateTime;
 
     /// Format of a [`LocalDateTime` scalar][1].
@@ -144,8 +149,8 @@ mod local_date_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-date-time
     const FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
 
-    pub(super) fn to_output(v: &LocalDateTime) -> String {
-        v.format(FORMAT).to_string() // TODO: Optimize via `Display`?
+    pub(super) fn to_output(v: &LocalDateTime) -> impl Display {
+        v.format(FORMAT)
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
@@ -191,7 +196,7 @@ mod date_time {
         Tz::Offset: fmt::Display,
     {
         v.with_timezone(&Utc)
-            .to_rfc3339_opts(SecondsFormat::AutoSi, true) // TODO: Optimize via `Display`?
+            .to_rfc3339_opts(SecondsFormat::AutoSi, true)
     }
 
     pub(super) fn from_input<Tz>(s: &str) -> Result<DateTime<Tz>, Box<str>>

--- a/juniper/src/integrations/chrono.rs
+++ b/juniper/src/integrations/chrono.rs
@@ -184,7 +184,7 @@ mod local_date_time {
 pub type DateTime<Tz> = chrono::DateTime<Tz>;
 
 mod date_time {
-    use std::fmt;
+    use std::fmt::Display;
 
     use chrono::{FixedOffset, SecondsFormat, TimeZone, Utc};
 
@@ -193,7 +193,7 @@ mod date_time {
     pub(super) fn to_output<Tz>(v: &DateTime<Tz>) -> String
     where
         Tz: TimeZone,
-        Tz::Offset: fmt::Display,
+        Tz::Offset: Display,
     {
         v.with_timezone(&Utc)
             .to_rfc3339_opts(SecondsFormat::AutoSi, true)

--- a/juniper/src/integrations/chrono_tz.rs
+++ b/juniper/src/integrations/chrono_tz.rs
@@ -11,7 +11,7 @@
 //! [1]: http://www.iana.org/time-zones
 //! [s1]: https://graphql-scalars.dev/docs/scalars/time-zone
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 // TODO: Try remove on upgrade of `chrono-tz` crate.
 mod for_minimal_versions_check_only {
@@ -31,7 +31,8 @@ mod for_minimal_versions_check_only {
 /// [1]: https://graphql-scalars.dev/docs/scalars/time-zone
 /// [2]: https://docs.rs/chrono-tz/*/chrono_tz/enum.Tz.html
 /// [3]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = tz,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/time-zone",
@@ -39,10 +40,10 @@ mod for_minimal_versions_check_only {
 pub type TimeZone = chrono_tz::Tz;
 
 mod tz {
-    use super::*;
+    use super::TimeZone;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &TimeZone) -> Value<S> {
-        Value::scalar(v.name().to_owned())
+    pub(super) fn to_output(v: &TimeZone) -> &'static str {
+        v.name()
     }
 
     pub(super) fn from_input(s: &str) -> Result<TimeZone, Box<str>> {

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -327,7 +327,7 @@ mod time_zone_or_utc_offset {
                     .to_string()
             },
             ToOwned::to_owned,
-        ) // TODO: Optimize via `Display`?
+        )
     }
 
     pub(super) fn from_input(s: &str) -> Result<TimeZoneOrUtcOffset, Box<str>> {
@@ -445,7 +445,7 @@ mod utc_offset {
             &jiff::Zoned::now().with_time_zone(jiff::tz::TimeZone::fixed(*v)),
         );
         tm.format(FORMAT, &mut buf).unwrap();
-        buf // TODO: Optimize via `Display`?
+        buf
     }
 
     pub(super) fn from_input(s: &str) -> Result<UtcOffset, Box<str>> {

--- a/juniper/src/integrations/jiff.rs
+++ b/juniper/src/integrations/jiff.rs
@@ -54,7 +54,7 @@ use std::str;
 
 use derive_more::with_trait::{Debug, Display, Error, Into};
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 /// Representation of a civil date in the Gregorian calendar.
 ///
@@ -68,7 +68,8 @@ use crate::{ScalarValue, Value, graphql_scalar};
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
 /// [2]: https://docs.rs/jiff/*/jiff/civil/struct.Date.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_date,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-date",
@@ -83,11 +84,8 @@ mod local_date {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
     const FORMAT: &str = "%Y-%m-%d";
 
-    pub(super) fn to_output<S>(v: &LocalDate) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.strftime(FORMAT).to_string())
+    pub(super) fn to_output(v: &LocalDate) -> String {
+        v.strftime(FORMAT).to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
@@ -107,7 +105,8 @@ mod local_date {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
 /// [2]: https://docs.rs/jiff/*/jiff/civil/struct.Time.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-time",
@@ -132,18 +131,13 @@ mod local_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
     const FORMAT_NO_SECS: &str = "%H:%M";
 
-    pub(super) fn to_output<S>(v: &LocalTime) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(
-            if v.subsec_nanosecond() == 0 {
-                v.strftime(FORMAT_NO_MILLIS)
-            } else {
-                v.strftime(FORMAT)
-            }
-            .to_string(),
-        )
+    pub(super) fn to_output(v: &LocalTime) -> String {
+        if v.subsec_nanosecond() == 0 {
+            v.strftime(FORMAT_NO_MILLIS)
+        } else {
+            v.strftime(FORMAT)
+        }
+        .to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
@@ -170,7 +164,8 @@ mod local_time {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-date-time
 /// [2]: https://docs.rs/jiff/*/jiff/civil/struct.DateTime.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_date_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-date-time",
@@ -185,11 +180,8 @@ mod local_date_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-date-time
     const FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
 
-    pub(super) fn to_output<S>(v: &LocalDateTime) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.strftime(FORMAT).to_string())
+    pub(super) fn to_output(v: &LocalDateTime) -> String {
+        v.strftime(FORMAT).to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
@@ -208,7 +200,8 @@ mod local_date_time {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/date-time
 /// [2]: https://docs.rs/jiff/*/jiff/struct.Timestamp.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = date_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/date-time",
@@ -225,11 +218,8 @@ mod date_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/date-time
     const FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.fZ";
 
-    pub(super) fn to_output<S>(v: &DateTime) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.strftime(FORMAT).to_string())
+    pub(super) fn to_output(v: &DateTime) -> String {
+        v.strftime(FORMAT).to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {
@@ -253,7 +243,8 @@ mod date_time {
 /// [3]: https://docs.rs/jiff/latest/jiff/struct.Timestamp.html
 /// [4]: https://docs.rs/jiff/latest/jiff/civil/struct.DateTime.html
 /// [5]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = zoned_date_time,
     parse_token(String),
     specified_by_url = "https://datatracker.ietf.org/doc/html/rfc9557#section-4.1",
@@ -265,11 +256,8 @@ mod zoned_date_time {
 
     use super::*;
 
-    pub(super) fn to_output<S>(v: &ZonedDateTime) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.to_string())
+    pub(super) fn to_output(v: &ZonedDateTime) -> String {
+        v.to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<ZonedDateTime, Box<str>> {
@@ -288,7 +276,8 @@ mod zoned_date_time {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/duration
 /// [2]: https://docs.rs/jiff/*/jiff/struct.Span.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = duration,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/duration",
@@ -300,11 +289,8 @@ mod duration {
 
     use super::*;
 
-    pub(super) fn to_output<S>(v: &Duration) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.to_string())
+    pub(super) fn to_output(v: &Duration) -> String {
+        v.to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<Duration, Box<str>> {
@@ -326,7 +312,8 @@ mod duration {
 /// [2]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
 /// [3]: https://graphql-scalars.dev/docs/scalars/time-zone
 /// [4]: https://graphql-scalars.dev/docs/scalars/utc-offset
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = time_zone_or_utc_offset,
     parse_token(String),
 )]
@@ -338,11 +325,8 @@ mod time_zone_or_utc_offset {
     /// Format of a [`TimeZoneOrUtcOffset`] scalar.
     const FORMAT: &str = "%:Q";
 
-    pub(super) fn to_output<S>(v: &TimeZoneOrUtcOffset) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.iana_name().map_or_else(
+    pub(super) fn to_output(v: &TimeZoneOrUtcOffset) -> String {
+        v.iana_name().map_or_else(
             || {
                 // If no IANA time zone identifier is available, fall back to displaying the time
                 // offset directly (using format `[+-]HH:MM[:SS]` from RFC 9557, e.g. `+05:30`).
@@ -353,7 +337,7 @@ mod time_zone_or_utc_offset {
                     .to_string()
             },
             ToOwned::to_owned,
-        ))
+        ) // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<TimeZoneOrUtcOffset, Box<str>> {
@@ -392,7 +376,8 @@ pub enum TimeZoneParsingError {
 /// [0]: http://iana.org/time-zones
 /// [1]: https://graphql-scalars.dev/docs/scalars/time-zone
 /// [2]: https://docs.rs/jiff/latest/jiff/tz/struct.TimeZone.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = time_zone,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/time-zone",
@@ -425,11 +410,8 @@ impl str::FromStr for TimeZone {
 mod time_zone {
     use super::*;
 
-    pub(super) fn to_output<S>(v: &TimeZone) -> Value<S>
-    where
-        S: ScalarValue,
-    {
-        Value::scalar(v.to_string())
+    pub(super) fn to_output(v: &TimeZone) -> String {
+        v.to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<TimeZone, Box<str>> {
@@ -446,7 +428,8 @@ mod time_zone {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/utc-offset
 /// [2]: https://docs.rs/jiff/latest/jiff/tz/struct.Offset.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = utc_offset,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/utc-offset",
@@ -469,16 +452,13 @@ mod utc_offset {
         Ok(offset)
     }
 
-    pub(super) fn to_output<S>(v: &UtcOffset) -> Value<S>
-    where
-        S: ScalarValue,
-    {
+    pub(super) fn to_output(v: &UtcOffset) -> String {
         let mut buf = String::new();
         let tm = jiff::fmt::strtime::BrokenDownTime::from(
             &jiff::Zoned::now().with_time_zone(jiff::tz::TimeZone::fixed(*v)),
         );
         tm.format(FORMAT, &mut buf).unwrap();
-        Value::scalar(buf)
+        buf // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<UtcOffset, Box<str>> {

--- a/juniper/src/integrations/rust_decimal.rs
+++ b/juniper/src/integrations/rust_decimal.rs
@@ -8,7 +8,7 @@
 //!
 //! [`Decimal`]: rust_decimal::Decimal
 
-use crate::graphql_scalar;
+use crate::{ScalarValue, graphql_scalar};
 
 /// 128 bit representation of a fixed-precision decimal number.
 ///
@@ -27,6 +27,7 @@ use crate::graphql_scalar;
 #[graphql_scalar]
 #[graphql(
     with = rust_decimal_scalar,
+    to_output_with = ScalarValue::from_displayable,
     parse_token(i32, f64, String),
     specified_by_url = "https://docs.rs/rust_decimal",
 )]
@@ -35,10 +36,6 @@ type Decimal = rust_decimal::Decimal;
 mod rust_decimal_scalar {
     use super::Decimal;
     use crate::{Scalar, ScalarValue};
-
-    pub(super) fn to_output(v: &Decimal) -> String {
-        v.to_string() // TODO: Optimize via `Display`?
-    }
 
     pub(super) fn from_input(v: &Scalar<impl ScalarValue>) -> Result<Decimal, Box<str>> {
         if let Some(i) = v.try_to_int() {

--- a/juniper/src/integrations/time.rs
+++ b/juniper/src/integrations/time.rs
@@ -27,7 +27,7 @@ use time::{
     macros::format_description,
 };
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 /// Date in the proleptic Gregorian calendar (without time zone).
 ///
@@ -40,7 +40,8 @@ use crate::{ScalarValue, Value, graphql_scalar};
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
 /// [2]: https://docs.rs/time/*/time/struct.Date.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_date,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-date",
@@ -55,11 +56,10 @@ mod local_date {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-date
     const FORMAT: &[BorrowedFormatItem<'_>] = format_description!("[year]-[month]-[day]");
 
-    pub(super) fn to_output<S: ScalarValue>(v: &LocalDate) -> Value<S> {
-        Value::scalar(
-            v.format(FORMAT)
-                .unwrap_or_else(|e| panic!("failed to format `LocalDate`: {e}")),
-        )
+    pub(super) fn to_output(v: &LocalDate) -> String {
+        // TODO: Optimize via `Display`?
+        v.format(FORMAT)
+            .unwrap_or_else(|e| panic!("failed to format `LocalDate`: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDate, Box<str>> {
@@ -79,7 +79,8 @@ mod local_date {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
 /// [2]: https://docs.rs/time/*/time/struct.Time.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-time",
@@ -106,15 +107,14 @@ mod local_time {
     /// [1]: https://graphql-scalars.dev/docs/scalars/local-time
     const FORMAT_NO_SECS: &[BorrowedFormatItem<'_>] = format_description!("[hour]:[minute]");
 
-    pub(super) fn to_output<S: ScalarValue>(v: &LocalTime) -> Value<S> {
-        Value::scalar(
-            if v.millisecond() == 0 {
-                v.format(FORMAT_NO_MILLIS)
-            } else {
-                v.format(FORMAT)
-            }
-            .unwrap_or_else(|e| panic!("failed to format `LocalTime`: {e}")),
-        )
+    pub(super) fn to_output(v: &LocalTime) -> String {
+        // TODO: Optimize via `Display`?
+        if v.millisecond() == 0 {
+            v.format(FORMAT_NO_MILLIS)
+        } else {
+            v.format(FORMAT)
+        }
+        .unwrap_or_else(|e| panic!("failed to format `LocalTime`: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalTime, Box<str>> {
@@ -135,7 +135,8 @@ mod local_time {
 ///
 /// [1]: https://graphql-scalars.dev/docs/scalars/local-date-time
 /// [2]: https://docs.rs/time/*/time/struct.PrimitiveDateTime.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = local_date_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/local-date-time",
@@ -151,11 +152,10 @@ mod local_date_time {
     const FORMAT: &[BorrowedFormatItem<'_>] =
         format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");
 
-    pub(super) fn to_output<S: ScalarValue>(v: &LocalDateTime) -> Value<S> {
-        Value::scalar(
-            v.format(FORMAT)
-                .unwrap_or_else(|e| panic!("failed to format `LocalDateTime`: {e}")),
-        )
+    pub(super) fn to_output(v: &LocalDateTime) -> String {
+        // TODO: Optimize via `Display`?
+        v.format(FORMAT)
+            .unwrap_or_else(|e| panic!("failed to format `LocalDateTime`: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<LocalDateTime, Box<str>> {
@@ -175,7 +175,8 @@ mod local_date_time {
 /// [0]: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
 /// [1]: https://graphql-scalars.dev/docs/scalars/date-time
 /// [2]: https://docs.rs/time/*/time/struct.OffsetDateTime.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = date_time,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/date-time",
@@ -185,12 +186,11 @@ pub type DateTime = time::OffsetDateTime;
 mod date_time {
     use super::*;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &DateTime) -> Value<S> {
-        Value::scalar(
-            v.to_offset(UtcOffset::UTC)
-                .format(&Rfc3339)
-                .unwrap_or_else(|e| panic!("failed to format `DateTime`: {e}")),
-        )
+    pub(super) fn to_output(v: &DateTime) -> String {
+        // TODO: Optimize via `Display`?
+        v.to_offset(UtcOffset::UTC)
+            .format(&Rfc3339)
+            .unwrap_or_else(|e| panic!("failed to format `DateTime`: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<DateTime, Box<str>> {
@@ -215,7 +215,8 @@ const UTC_OFFSET_FORMAT: &[BorrowedFormatItem<'_>] =
 /// [0]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 /// [1]: https://graphql-scalars.dev/docs/scalars/utc-offset
 /// [2]: https://docs.rs/time/*/time/struct.UtcOffset.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     with = utc_offset,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/utc-offset",
@@ -225,11 +226,10 @@ pub type UtcOffset = time::UtcOffset;
 mod utc_offset {
     use super::*;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &UtcOffset) -> Value<S> {
-        Value::scalar(
-            v.format(UTC_OFFSET_FORMAT)
-                .unwrap_or_else(|e| panic!("failed to format `UtcOffset`: {e}")),
-        )
+    pub(super) fn to_output(v: &UtcOffset) -> String {
+        // TODO: Optimize via `Display`?
+        v.format(UTC_OFFSET_FORMAT)
+            .unwrap_or_else(|e| panic!("failed to format `UtcOffset`: {e}"))
     }
 
     pub(super) fn from_input(s: &str) -> Result<UtcOffset, Box<str>> {

--- a/juniper/src/integrations/time.rs
+++ b/juniper/src/integrations/time.rs
@@ -57,7 +57,6 @@ mod local_date {
     const FORMAT: &[BorrowedFormatItem<'_>] = format_description!("[year]-[month]-[day]");
 
     pub(super) fn to_output(v: &LocalDate) -> String {
-        // TODO: Optimize via `Display`?
         v.format(FORMAT)
             .unwrap_or_else(|e| panic!("failed to format `LocalDate`: {e}"))
     }
@@ -108,7 +107,6 @@ mod local_time {
     const FORMAT_NO_SECS: &[BorrowedFormatItem<'_>] = format_description!("[hour]:[minute]");
 
     pub(super) fn to_output(v: &LocalTime) -> String {
-        // TODO: Optimize via `Display`?
         if v.millisecond() == 0 {
             v.format(FORMAT_NO_MILLIS)
         } else {
@@ -153,7 +151,6 @@ mod local_date_time {
         format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]");
 
     pub(super) fn to_output(v: &LocalDateTime) -> String {
-        // TODO: Optimize via `Display`?
         v.format(FORMAT)
             .unwrap_or_else(|e| panic!("failed to format `LocalDateTime`: {e}"))
     }
@@ -187,7 +184,6 @@ mod date_time {
     use super::*;
 
     pub(super) fn to_output(v: &DateTime) -> String {
-        // TODO: Optimize via `Display`?
         v.to_offset(UtcOffset::UTC)
             .format(&Rfc3339)
             .unwrap_or_else(|e| panic!("failed to format `DateTime`: {e}"))
@@ -227,7 +223,6 @@ mod utc_offset {
     use super::*;
 
     pub(super) fn to_output(v: &UtcOffset) -> String {
-        // TODO: Optimize via `Display`?
         v.format(UTC_OFFSET_FORMAT)
             .unwrap_or_else(|e| panic!("failed to format `UtcOffset`: {e}"))
     }

--- a/juniper/src/integrations/url.rs
+++ b/juniper/src/integrations/url.rs
@@ -9,7 +9,7 @@
 //! [`Url`]: url::Url
 //! [s1]: https://graphql-scalars.dev/docs/scalars/url
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 /// [Standard URL][0] format as specified in [RFC 3986].
 ///
@@ -21,20 +21,18 @@ use crate::{ScalarValue, Value, graphql_scalar};
 /// [1]: https://graphql-scalars.dev/docs/scalars/url
 /// [2]: https://docs.rs/url/*/url/struct.Url.html
 /// [RFC 3986]: https://datatracker.ietf.org/doc/html/rfc3986
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     name = "URL",
     with = url_scalar,
+    to_output_with = Url::as_str,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/url",
 )]
 type Url = url::Url;
 
 mod url_scalar {
-    use super::*;
-
-    pub(super) fn to_output<S: ScalarValue>(v: &Url) -> Value<S> {
-        Value::scalar(v.as_str().to_owned())
-    }
+    use super::Url;
 
     pub(super) fn from_input(s: &str) -> Result<Url, Box<str>> {
         Url::parse(s).map_err(|e| format!("Failed to parse `URL`: {e}").into())

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -9,7 +9,7 @@
 //! [`Uuid`]: uuid::Uuid
 //! [s1]: https://graphql-scalars.dev/docs/scalars/uuid
 
-use crate::{ScalarValue, Value, graphql_scalar};
+use crate::graphql_scalar;
 
 /// [Universally Unique Identifier][0] (UUID).
 ///
@@ -20,7 +20,8 @@ use crate::{ScalarValue, Value, graphql_scalar};
 /// [0]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 /// [1]: https://graphql-scalars.dev/docs/scalars/uuid
 /// [2]: https://docs.rs/uuid/*/uuid/struct.Uuid.html
-#[graphql_scalar(
+#[graphql_scalar]
+#[graphql(
     name = "UUID",
     with = uuid_scalar,
     parse_token(String),
@@ -29,10 +30,10 @@ use crate::{ScalarValue, Value, graphql_scalar};
 type Uuid = uuid::Uuid;
 
 mod uuid_scalar {
-    use super::*;
+    use super::Uuid;
 
-    pub(super) fn to_output<S: ScalarValue>(v: &Uuid) -> Value<S> {
-        Value::scalar(v.to_string())
+    pub(super) fn to_output(v: &Uuid) -> String {
+        v.to_string() // TODO: Optimize via `Display`?
     }
 
     pub(super) fn from_input(s: &str) -> Result<Uuid, Box<str>> {

--- a/juniper/src/integrations/uuid.rs
+++ b/juniper/src/integrations/uuid.rs
@@ -9,7 +9,7 @@
 //! [`Uuid`]: uuid::Uuid
 //! [s1]: https://graphql-scalars.dev/docs/scalars/uuid
 
-use crate::graphql_scalar;
+use crate::{ScalarValue, graphql_scalar};
 
 /// [Universally Unique Identifier][0] (UUID).
 ///
@@ -24,6 +24,7 @@ use crate::graphql_scalar;
 #[graphql(
     name = "UUID",
     with = uuid_scalar,
+    to_output_with = ScalarValue::from_displayable,
     parse_token(String),
     specified_by_url = "https://graphql-scalars.dev/docs/scalars/uuid",
 )]
@@ -31,10 +32,6 @@ type Uuid = uuid::Uuid;
 
 mod uuid_scalar {
     use super::Uuid;
-
-    pub(super) fn to_output(v: &Uuid) -> String {
-        v.to_string() // TODO: Optimize via `Display`?
-    }
 
     pub(super) fn from_input(s: &str) -> Result<Uuid, Box<str>> {
         Uuid::parse_str(s).map_err(|e| format!("Failed to parse `UUID`: {e}").into())

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -103,8 +103,8 @@ pub use crate::{
     },
     validation::RuleError,
     value::{
-        AnyExt, DefaultScalarValue, FromScalarValue, ToScalarValue, IntoValue, Object,
-        ParseScalarResult, ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, Value,
+        AnyExt, DefaultScalarValue, FromScalarValue, IntoValue, Object, ParseScalarResult,
+        ParseScalarValue, Scalar, ScalarValue, ToScalarValue, TryToPrimitive, Value,
         WrongInputScalarTypeError,
     },
 };

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -104,7 +104,7 @@ pub use crate::{
     validation::RuleError,
     value::{
         AnyExt, DefaultScalarValue, FromScalarValue, IntoValue, Object, ParseScalarResult,
-        ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, Value, WrongInputScalarTypeError,
+        ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, Value, WrongInputScalarTypeError, IntoScalarValue,
     },
 };
 

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -103,8 +103,9 @@ pub use crate::{
     },
     validation::RuleError,
     value::{
-        AnyExt, DefaultScalarValue, FromScalarValue, IntoValue, Object, ParseScalarResult,
-        ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, Value, WrongInputScalarTypeError, IntoScalarValue,
+        AnyExt, DefaultScalarValue, FromScalarValue, ToScalarValue, IntoValue, Object,
+        ParseScalarResult, ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, Value,
+        WrongInputScalarTypeError,
     },
 };
 

--- a/juniper/src/macros/helper/mod.rs
+++ b/juniper/src/macros/helper/mod.rs
@@ -75,16 +75,6 @@ pub trait ToResultCall {
     fn __to_result_call(&self, input: Self::Input) -> Result<Self::Output, Self::Error>;
 }
 
-impl<I, O> ToResultCall for fn(I) -> O {
-    type Input = I;
-    type Output = O;
-    type Error = Infallible;
-
-    fn __to_result_call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
-        Ok(self(input))
-    }
-}
-
 impl<I, O, E> ToResultCall for &fn(I) -> Result<O, E> {
     type Input = I;
     type Output = O;
@@ -92,6 +82,16 @@ impl<I, O, E> ToResultCall for &fn(I) -> Result<O, E> {
 
     fn __to_result_call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
         self(input)
+    }
+}
+
+impl<I, O> ToResultCall for fn(I) -> O {
+    type Input = I;
+    type Output = O;
+    type Error = Infallible;
+
+    fn __to_result_call(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        Ok(self(input))
     }
 }
 
@@ -149,6 +149,6 @@ where
     type Input = I;
 
     fn __to_scalar_value_call(&self, input: Self::Input) -> S {
-        S::from_display(&self(input))
+        S::from_displayable_non_static(&self(input))
     }
 }

--- a/juniper/src/macros/helper/mod.rs
+++ b/juniper/src/macros/helper/mod.rs
@@ -107,7 +107,10 @@ pub trait ToScalarValueCall<S: ScalarValue> {
     fn __to_scalar_value_call(&self, input: Self::Input) -> S;
 }
 
-impl<I, S: ScalarValue> ToScalarValueCall<S> for &fn(I) -> S {
+impl<I, S> ToScalarValueCall<S> for &&&fn(I) -> S
+where
+    S: ScalarValue,
+{
     type Input = I;
 
     fn __to_scalar_value_call(&self, input: Self::Input) -> S {
@@ -115,13 +118,37 @@ impl<I, S: ScalarValue> ToScalarValueCall<S> for &fn(I) -> S {
     }
 }
 
-impl<I, O, S: ScalarValue> ToScalarValueCall<S> for fn(I) -> O
+impl<I, S> ToScalarValueCall<S> for &&fn(I) -> String
 where
+    S: ScalarValue,
+{
+    type Input = I;
+
+    fn __to_scalar_value_call(&self, input: Self::Input) -> S {
+        self(input).into()
+    }
+}
+
+impl<I, O, S> ToScalarValueCall<S> for &fn(I) -> O
+where
+    S: ScalarValue,
     O: ToScalarValue<S>,
 {
     type Input = I;
 
     fn __to_scalar_value_call(&self, input: Self::Input) -> S {
         self(input).to_scalar_value()
+    }
+}
+
+impl<I, O, S> ToScalarValueCall<S> for fn(I) -> O
+where
+    S: ScalarValue,
+    O: Display,
+{
+    type Input = I;
+
+    fn __to_scalar_value_call(&self, input: Self::Input) -> S {
+        S::from_display(&self(input))
     }
 }

--- a/juniper/src/macros/helper/mod.rs
+++ b/juniper/src/macros/helper/mod.rs
@@ -62,6 +62,12 @@ pub struct NotScalarError<'a, S: ScalarValue>(pub &'a InputValue<S>);
 /// [Autoref-based specialized][0] coercion into a [`Result`] for a function call for providing a
 /// return-type polymorphism in macros.
 ///
+/// # Priority
+///
+/// 1. Functions returning [`Result`] are propagated "as is".
+///
+/// 2. Any other function's output is wrapped into [`Result`] with an [`Infallible`] [`Err`].
+///
 /// [0]: https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
 pub trait ToResultCall {
     /// Input of this function.
@@ -97,6 +103,18 @@ impl<I, O> ToResultCall for fn(I) -> O {
 
 /// [Autoref-based specialized][0] coercion into a [`ScalarValue`] for a function call for providing
 /// a return-type polymorphism in macros.
+///
+/// # Priority
+///
+/// 1. Functions returning a [`ScalarValue`] are propagated "as is".
+///
+/// 2. Functions returning a [`String`] are followed by [`From<String>`] conversion.
+///
+/// 3. Functions returning anything implementing [`ToScalarValue`] conversion are followed by this
+///    conversion.
+///
+/// 4. Functions returning anything implementing [`Display`] are followed by the
+///    [`ScalarValue::from_displayable_non_static()`] method call.
 ///
 /// [0]: https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html
 pub trait ToScalarValueCall<S: ScalarValue> {

--- a/juniper/src/types/containers.rs
+++ b/juniper/src/types/containers.rs
@@ -90,7 +90,10 @@ impl<S, T: FromInputValue<S>> FromInputValue<S> for Option<T> {
     }
 }
 
-impl<S, T: ToInputValue<S>> ToInputValue<S> for Option<T> {
+impl<S, T> ToInputValue<S> for Option<T>
+where
+    T: ToInputValue<S>,
+{
     fn to_input_value(&self) -> InputValue<S> {
         match self {
             Some(v) => v.to_input_value(),
@@ -176,7 +179,6 @@ impl<S: ScalarValue, T: FromInputValue<S>> FromInputValue<S> for Vec<T> {
 impl<T, S> ToInputValue<S> for Vec<T>
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::list(self.iter().map(T::to_input_value).collect())
@@ -270,10 +272,9 @@ where
     }
 }
 
-impl<T, S> ToInputValue<S> for &[T]
+impl<T, S> ToInputValue<S> for [T]
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::list(self.iter().map(T::to_input_value).collect())
@@ -462,7 +463,6 @@ where
 impl<T, S, const N: usize> ToInputValue<S> for [T; N]
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::list(self.iter().map(T::to_input_value).collect())

--- a/juniper/src/types/nullable.rs
+++ b/juniper/src/types/nullable.rs
@@ -302,11 +302,10 @@ impl<S, T: FromInputValue<S>> FromInputValue<S> for Nullable<T> {
 impl<S, T> ToInputValue<S> for Nullable<T>
 where
     T: ToInputValue<S>,
-    S: ScalarValue,
 {
     fn to_input_value(&self) -> InputValue<S> {
-        match *self {
-            Self::Some(ref v) => v.to_input_value(),
+        match self {
+            Self::Some(v) => v.to_input_value(),
             _ => InputValue::null(),
         }
     }

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 use arcstr::ArcStr;
 
@@ -11,7 +11,7 @@ use crate::{
         async_await::GraphQLValueAsync,
         base::{Arguments, GraphQLType, GraphQLValue},
     },
-    value::{FromScalarValue, ToScalarValue, ScalarValue},
+    value::{FromScalarValue, ScalarValue, ToScalarValue},
 };
 
 impl<S, T> GraphQLType<S> for Box<T>
@@ -122,8 +122,7 @@ where
 
 impl<T, S> ToInputValue<S> for Box<T>
 where
-    S: fmt::Debug,
-    T: ToInputValue<S>,
+    T: ToInputValue<S> + ?Sized,
 {
     fn to_input_value(&self) -> InputValue<S> {
         (**self).to_input_value()
@@ -224,8 +223,7 @@ where
 
 impl<T, S> ToInputValue<S> for &T
 where
-    S: fmt::Debug,
-    T: ToInputValue<S>,
+    T: ToInputValue<S> + ?Sized,
 {
     fn to_input_value(&self) -> InputValue<S> {
         (**self).to_input_value()
@@ -340,8 +338,7 @@ where
 
 impl<T, S> ToInputValue<S> for Arc<T>
 where
-    S: fmt::Debug,
-    T: ToInputValue<S>,
+    T: ToInputValue<S> + ?Sized,
 {
     fn to_input_value(&self) -> InputValue<S> {
         (**self).to_input_value()

--- a/juniper/src/types/pointers.rs
+++ b/juniper/src/types/pointers.rs
@@ -11,7 +11,7 @@ use crate::{
         async_await::GraphQLValueAsync,
         base::{Arguments, GraphQLType, GraphQLValue},
     },
-    value::{FromScalarValue, ScalarValue},
+    value::{FromScalarValue, ToScalarValue, ScalarValue},
 };
 
 impl<S, T> GraphQLType<S> for Box<T>
@@ -96,6 +96,15 @@ where
 
     fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
         T::from_scalar_value(v).map(Self::new)
+    }
+}
+
+impl<T, S> ToScalarValue<S> for Box<T>
+where
+    T: ToScalarValue<S> + ?Sized,
+{
+    fn to_scalar_value(&self) -> S {
+        (**self).to_scalar_value()
     }
 }
 
@@ -204,6 +213,15 @@ where
     }
 }
 
+impl<T, S> ToScalarValue<S> for &T
+where
+    T: ToScalarValue<S> + ?Sized,
+{
+    fn to_scalar_value(&self) -> S {
+        (**self).to_scalar_value()
+    }
+}
+
 impl<T, S> ToInputValue<S> for &T
 where
     S: fmt::Debug,
@@ -296,6 +314,15 @@ where
 
     fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
         T::from_scalar_value(v).map(Self::new)
+    }
+}
+
+impl<T, S> ToScalarValue<S> for Arc<T>
+where
+    T: ToScalarValue<S> + ?Sized,
+{
+    fn to_scalar_value(&self) -> S {
+        (**self).to_scalar_value()
     }
 }
 

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -185,16 +185,17 @@ where
 }
 
 #[graphql_scalar]
-#[graphql(name = "String", with = impl_arcstr_scalar, parse_token(String))]
+#[graphql(
+    name = "String", 
+    with = impl_arcstr_scalar,
+    to_output_with = ScalarValue::from_displayable,
+    parse_token(String)
+)]
 type ArcStr = arcstr::ArcStr;
 
 mod impl_arcstr_scalar {
     use super::ArcStr;
     use crate::{FromScalarValue, Scalar, ScalarValue};
-
-    pub(super) fn to_output<S: ScalarValue>(v: &ArcStr) -> S {
-        S::from_displayable(v) // TODO: Better ergonomics?
-    }
 
     pub(super) fn from_input<S: ScalarValue>(
         v: &Scalar<S>,
@@ -208,16 +209,17 @@ mod impl_arcstr_scalar {
 }
 
 #[graphql_scalar]
-#[graphql(name = "String", with = impl_compactstring_scalar, parse_token(String))]
+#[graphql(
+    name = "String", 
+    with = impl_compactstring_scalar,
+    to_output_with = ScalarValue::from_displayable,
+    parse_token(String),
+)]
 type CompactString = compact_str::CompactString;
 
 mod impl_compactstring_scalar {
     use super::CompactString;
     use crate::{FromScalarValue, Scalar, ScalarValue};
-
-    pub(super) fn to_output<S: ScalarValue>(v: &CompactString) -> S {
-        S::from_displayable(v) // TODO: Better ergonomics?
-    }
 
     pub(super) fn from_input<S: ScalarValue>(
         v: &Scalar<S>,

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -312,7 +312,7 @@ impl<S: ScalarValue> ToScalarValue<S> for str {
 
 impl<S> ToInputValue<S> for str
 where
-    str: ToScalarValue<S>,
+    Self: ToScalarValue<S>,
 {
     fn to_input_value(&self) -> InputValue<S> {
         InputValue::Scalar(self.to_scalar_value())

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -17,7 +17,7 @@ use crate::{
         subscriptions::GraphQLSubscriptionValue,
     },
     value::{
-        FromScalarValue, ParseScalarResult, ScalarValue, TryToPrimitive, Value,
+        FromScalarValue, ParseScalarResult, ScalarValue, ToScalarValue, TryToPrimitive, Value,
         WrongInputScalarTypeError,
     },
 };
@@ -73,6 +73,15 @@ mod impl_string_scalar {
 
         fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
             v.try_to_primitive()
+        }
+    }
+
+    impl<S> ToScalarValue<S> for String
+    where
+        Self: Into<S>,
+    {
+        fn to_scalar_value(&self) -> S {
+            self.clone().into()
         }
     }
 
@@ -291,15 +300,6 @@ where
     }
 }
 
-impl<S> ToInputValue<S> for &str
-where
-    S: ScalarValue,
-{
-    fn to_input_value(&self) -> InputValue<S> {
-        InputValue::scalar(String::from(*self))
-    }
-}
-
 impl<'s, S> FromScalarValue<'s, S> for &'s str
 where
     S: TryToPrimitive<'s, Self, Error: IntoFieldError<S>> + 's,
@@ -308,6 +308,21 @@ where
 
     fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
         v.try_to_primitive()
+    }
+}
+
+impl<S: ScalarValue> ToScalarValue<S> for str {
+    fn to_scalar_value(&self) -> S {
+        S::from_displayable(self)
+    }
+}
+
+impl<S> ToInputValue<S> for &str
+where
+    str: ToScalarValue<S>,
+{
+    fn to_input_value(&self) -> InputValue<S> {
+        InputValue::scalar::<S>(self.to_scalar_value())
     }
 }
 
@@ -326,6 +341,15 @@ mod impl_boolean_scalar {
 
         fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
             v.try_to_primitive()
+        }
+    }
+
+    impl<S> ToScalarValue<S> for Boolean
+    where
+        Self: Into<S>,
+    {
+        fn to_scalar_value(&self) -> S {
+            (*self).into()
         }
     }
 
@@ -354,6 +378,15 @@ mod impl_int_scalar {
 
         fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
             v.try_to_primitive()
+        }
+    }
+
+    impl<S> ToScalarValue<S> for Int
+    where
+        Self: Into<S>,
+    {
+        fn to_scalar_value(&self) -> S {
+            (*self).into()
         }
     }
 
@@ -387,6 +420,15 @@ mod impl_float_scalar {
 
         fn from_scalar_value(v: &'s S) -> Result<Self, Self::Error> {
             v.try_to_primitive()
+        }
+    }
+
+    impl<S> ToScalarValue<S> for Float
+    where
+        Self: Into<S>,
+    {
+        fn to_scalar_value(&self) -> S {
+            (*self).into()
         }
     }
 

--- a/juniper/src/types/scalars.rs
+++ b/juniper/src/types/scalars.rs
@@ -317,7 +317,7 @@ impl<S: ScalarValue> ToScalarValue<S> for str {
     }
 }
 
-impl<S> ToInputValue<S> for &str
+impl<S> ToInputValue<S> for str
 where
     str: ToScalarValue<S>,
 {

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -9,8 +9,8 @@ use compact_str::CompactString;
 pub use self::{
     object::Object,
     scalar::{
-        AnyExt, DefaultScalarValue, FromScalarValue, ParseScalarResult, ParseScalarValue, Scalar,
-        ScalarValue, TryToPrimitive, WrongInputScalarTypeError, IntoScalarValue,
+        AnyExt, DefaultScalarValue, FromScalarValue, ToScalarValue, ParseScalarResult,
+        ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, WrongInputScalarTypeError,
     },
 };
 use crate::{

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -10,7 +10,7 @@ pub use self::{
     object::Object,
     scalar::{
         AnyExt, DefaultScalarValue, FromScalarValue, ParseScalarResult, ParseScalarValue, Scalar,
-        ScalarValue, TryToPrimitive, WrongInputScalarTypeError,
+        ScalarValue, TryToPrimitive, WrongInputScalarTypeError, IntoScalarValue,
     },
 };
 use crate::{

--- a/juniper/src/value/mod.rs
+++ b/juniper/src/value/mod.rs
@@ -9,8 +9,8 @@ use compact_str::CompactString;
 pub use self::{
     object::Object,
     scalar::{
-        AnyExt, DefaultScalarValue, FromScalarValue, ToScalarValue, ParseScalarResult,
-        ParseScalarValue, Scalar, ScalarValue, TryToPrimitive, WrongInputScalarTypeError,
+        AnyExt, DefaultScalarValue, FromScalarValue, ParseScalarResult, ParseScalarValue, Scalar,
+        ScalarValue, ToScalarValue, TryToPrimitive, WrongInputScalarTypeError,
     },
 };
 use crate::{

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -10,10 +10,7 @@ use std::{
     fmt, ptr,
 };
 
-use crate::{
-    FieldError, IntoFieldError,
-    parser::{ParseError, ScalarToken},
-};
+use crate::{FieldError, IntoFieldError, parser::{ParseError, ScalarToken}, Value};
 #[cfg(doc)]
 use crate::{GraphQLScalar, GraphQLValue, Value};
 
@@ -567,6 +564,18 @@ pub struct WrongInputScalarTypeError<'a, S: ScalarValue> {
 impl<'a, S: ScalarValue> IntoFieldError<S> for WrongInputScalarTypeError<'a, S> {
     fn into_field_error(self) -> FieldError<S> {
         FieldError::<S>::from(self)
+    }
+}
+
+pub trait IntoScalarValue<S = DefaultScalarValue>: Sized {
+    /// Converts this value into a [`ScalarValue`].
+    #[must_use]
+    fn into_scalar_value(self) -> S;
+}
+
+impl<S: ScalarValue> IntoScalarValue<S> for S {
+    fn into_scalar_value(self) -> Self {
+        self
     }
 }
 

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -488,6 +488,11 @@ pub trait ScalarValue:
     fn from_displayable<Str: Display + Any + ?Sized>(s: &Str) -> Self {
         s.to_string().into()
     }
+
+    #[must_use]
+    fn from_display<Str: Display + ?Sized>(s: &Str) -> Self {
+        s.to_string().into()
+    }
 }
 
 /// Fallible representation of a [`ScalarValue`] as one of the types it consists of, or derived ones

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -522,7 +522,7 @@ pub trait ScalarValue:
     ///     Boolean(bool),
     /// }
     ///
-    /// // Custom implementation of `ScalarValue::from_displayable()` method for specializing 
+    /// // Custom implementation of `ScalarValue::from_displayable()` method for specializing
     /// // an efficient conversions from `ArcStr` into `MyScalarValue`.
     /// fn from_arcstr<Str: Display + Any + ?Sized>(s: &Str) -> MyScalarValue {
     ///     use juniper::AnyExt as _; // allows downcasting directly on types without `dyn`
@@ -531,7 +531,7 @@ pub trait ScalarValue:
     ///         MyScalarValue::String(s.clone()) // `Clone`ing `ArcStr` is cheap
     ///     } else {
     ///         // We do not override `ScalarValue::from_displayable_non_static()` here,
-    ///         // since `arcstr` crate doesn't provide API for efficient conversion into 
+    ///         // since `arcstr` crate doesn't provide API for efficient conversion into
     ///         // an `ArcStr` for any `Display`able type, unfortunately.
     ///         // The closest possible way is to use `arcstr::format!("{s}")` expression.
     ///         // However, it actually expands to `ArcStr::from(fmt::format(format_args!("{s}")))`,

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -10,7 +10,10 @@ use std::{
     fmt, ptr,
 };
 
-use crate::{FieldError, IntoFieldError, parser::{ParseError, ScalarToken}, Value};
+use crate::{
+    FieldError, IntoFieldError,
+    parser::{ParseError, ScalarToken},
+};
 #[cfg(doc)]
 use crate::{GraphQLScalar, GraphQLValue, Value};
 
@@ -567,16 +570,10 @@ impl<'a, S: ScalarValue> IntoFieldError<S> for WrongInputScalarTypeError<'a, S> 
     }
 }
 
-pub trait IntoScalarValue<S = DefaultScalarValue>: Sized {
+pub trait ToScalarValue<S = DefaultScalarValue> {
     /// Converts this value into a [`ScalarValue`].
     #[must_use]
-    fn into_scalar_value(self) -> S;
-}
-
-impl<S: ScalarValue> IntoScalarValue<S> for S {
-    fn into_scalar_value(self) -> Self {
-        self
-    }
+    fn to_scalar_value(&self) -> S;
 }
 
 /// Transparent wrapper over a value, indicating it being a [`ScalarValue`].

--- a/juniper/src/value/scalar.rs
+++ b/juniper/src/value/scalar.rs
@@ -476,22 +476,158 @@ pub trait ScalarValue:
 
     /// Creates this [`ScalarValue`] from the provided [`Display`]able type.
     ///
-    /// This method should be implemented if [`ScalarValue`] implementation uses some custom string
-    /// type inside to enable efficient conversion from values of this type.
+    /// # Usage
+    ///
+    /// This method cannot work with non-`'static` types due to [`Any`] `'static` restriction. For
+    /// non-`'static` types the [`ScalarValue::from_displayable_non_static()`] method should be used
+    /// instead. However, the [`Any`] here allows implementors to specialize some conversions to be
+    /// cheaper for their [`ScalarValue`] implementation, and so, using this method is preferred
+    /// whenever is possible.
+    ///
+    /// # Implementation
     ///
     /// Default implementation allocates by converting [`ToString`] and [`From<String>`].
     ///
-    /// # Example
+    /// This method should be implemented if [`ScalarValue`] implementation uses some custom string
+    /// type inside to enable efficient conversion from values of this type.
     ///
-    /// See the [example in trait documentation](ScalarValue#example) for how it can be used.
+    /// ```rust
+    /// # use std::any::Any;
+    /// #
+    /// use arcstr::ArcStr;
+    /// use derive_more::with_trait::{Display, From, TryInto};
+    /// use juniper::ScalarValue;
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(
+    ///     Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    /// )]
+    /// #[serde(untagged)]
+    /// #[value(from_displayable_with = from_arcstr)]
+    /// enum MyScalarValue {
+    ///     #[from]
+    ///     #[value(to_float, to_int)]
+    ///     Int(i32),
+    ///     
+    ///     #[from]
+    ///     #[value(to_float)]
+    ///     Float(f64),
+    ///
+    ///     #[from(&str, String, ArcStr)]
+    ///     #[value(as_str, to_string)]
+    ///     String(ArcStr),
+    ///     
+    ///     #[from]
+    ///     #[value(to_bool)]
+    ///     Boolean(bool),
+    /// }
+    ///
+    /// // Custom implementation of `ScalarValue::from_displayable()` method for specializing 
+    /// // an efficient conversions from `ArcStr` into `MyScalarValue`.
+    /// fn from_arcstr<Str: Display + Any + ?Sized>(s: &Str) -> MyScalarValue {
+    ///     use juniper::AnyExt as _; // allows downcasting directly on types without `dyn`
+    ///
+    ///     if let Some(s) = s.downcast_ref::<ArcStr>() {
+    ///         MyScalarValue::String(s.clone()) // `Clone`ing `ArcStr` is cheap
+    ///     } else {
+    ///         // We do not override `ScalarValue::from_displayable_non_static()` here,
+    ///         // since `arcstr` crate doesn't provide API for efficient conversion into 
+    ///         // an `ArcStr` for any `Display`able type, unfortunately.
+    ///         // The closest possible way is to use `arcstr::format!("{s}")` expression.
+    ///         // However, it actually expands to `ArcStr::from(fmt::format(format_args!("{s}")))`,
+    ///         // where `fmt::format()` allocates a `String`, and thus, is fully equivalent to the
+    ///         // default implementation, which does `.to_string().into()` conversion.
+    ///         MyScalarValue::from_displayable_non_static(s)
+    ///     }
+    /// }
+    /// #
+    /// # // `derive_more::TryInto` is not capable for transitive conversions yet,
+    /// # // so this impl is manual as a custom string type is used instead of `String`.
+    /// # impl TryFrom<MyScalarValue> for String {
+    /// #     type Error = MyScalarValue;
+    /// #
+    /// #     fn try_from(value: MyScalarValue) -> Result<Self, Self::Error> {
+    /// #         if let MyScalarValue::String(s) = value {
+    /// #             Ok(s.to_string())
+    /// #         } else {
+    /// #             Err(value)
+    /// #         }
+    /// #     }
+    /// # }
+    /// ```
     #[must_use]
-    fn from_displayable<Str: Display + Any + ?Sized>(s: &Str) -> Self {
-        s.to_string().into()
+    fn from_displayable<T: Display + Any + ?Sized>(value: &T) -> Self {
+        Self::from_displayable_non_static(value)
     }
 
+    /// Creates this [`ScalarValue`] from the provided non-`'static` [`Display`]able type.
+    ///
+    /// # Usage
+    ///
+    /// This method exists solely because [`Any`] requires `'static`, and so the
+    /// [`ScalarValue::from_displayable()`] method cannot cover non-`'static` types. Always prefer
+    /// to use the [`ScalarValue::from_displayable()`] method instead of this one, whenever it's
+    /// possible, to allow possible cheap conversion specialization.
+    ///
+    /// # Implementation
+    ///
+    /// Default implementation allocates by converting [`ToString`] and [`From<String>`].
+    ///
+    /// This method should be implemented if [`ScalarValue`] implementation uses some custom string
+    /// type inside to create its values efficiently without intermediate [`String`]-conversion.
+    ///
+    /// ```rust
+    /// use compact_str::{CompactString, ToCompactString as _};
+    /// use derive_more::with_trait::{Display, From, TryInto};
+    /// use juniper::ScalarValue;
+    /// use serde::{Deserialize, Serialize};
+    ///
+    /// #[derive(
+    ///     Clone, Debug, Deserialize, Display, From, PartialEq, ScalarValue, Serialize, TryInto,
+    /// )]
+    /// #[serde(untagged)]
+    /// #[value(from_displayable_non_static_with = to_compact_string)]
+    /// enum MyScalarValue {
+    ///     #[from]
+    ///     #[value(to_float, to_int)]
+    ///     Int(i32),
+    ///     
+    ///     #[from]
+    ///     #[value(to_float)]
+    ///     Float(f64),
+    ///
+    ///     #[from(&str, String, CompactString)]
+    ///     #[value(as_str, to_string)]
+    ///     String(CompactString),
+    ///     
+    ///     #[from]
+    ///     #[value(to_bool)]
+    ///     Boolean(bool),
+    /// }
+    ///
+    /// // Custom implementation of `ScalarValue::from_displayable_non_static()` method
+    /// // for efficient writing into a `CompactString` as a `MyScalarValue::String`.
+    /// fn to_compact_string<T: Display + ?Sized>(v: &T) -> MyScalarValue {
+    ///     v.to_compact_string().into()
+    /// }
+    /// #
+    /// # // `derive_more::TryInto` is not capable for transitive conversions yet,
+    /// # // so this impl is manual as a custom string type is used instead of `String`.
+    /// # impl TryFrom<MyScalarValue> for String {
+    /// #     type Error = MyScalarValue;
+    /// #
+    /// #     fn try_from(value: MyScalarValue) -> Result<Self, Self::Error> {
+    /// #         if let MyScalarValue::String(s) = value {
+    /// #             Ok(s.into())
+    /// #         } else {
+    /// #             Err(value)
+    /// #         }
+    /// #     }
+    /// # }
+    /// ```
     #[must_use]
-    fn from_display<Str: Display + ?Sized>(s: &Str) -> Self {
-        s.to_string().into()
+    fn from_displayable_non_static<T: Display + ?Sized>(value: &T) -> Self {
+        value.to_string().into()
     }
 }
 

--- a/juniper_codegen/CHANGELOG.md
+++ b/juniper_codegen/CHANGELOG.md
@@ -21,20 +21,25 @@ All user visible changes to `juniper_codegen` crate will be documented in this f
     - `From` and `Display` implementations are not derived anymore.
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros:
     - Made provided `from_input()` function to accept `ScalarValue` directly instead of `InputValue`. ([#1327])
+    - Made provided `to_output()` function to return `ScalarValue` directly instead of `Value`. ([#1330])
 
 ### Added
 
 - `#[derive(ScalarValue)]` macro:
     - Support of top-level `#[value(from_displayable_with = ...)]` attribute. ([#1324])
+    - Support of top-level `#[value(from_displayable_non_static_with = ...)]` attribute. ([#1330])
 - `#[derive(GraphQLScalar)]` and `#[graphql_scalar]` macros:
     - Support for specifying concrete types as input argument in provided `from_input()` function. ([#1327])
     - Support for non-`Result` return type in provided `from_input()` function. ([#1327])
-    - Generating of `FromScalarValue` implementation. ([#1329]) 
+    - Generating of `FromScalarValue` implementation. ([#1329])
+    - Support for concrete and `impl Display` return types in provided `to_output()` function. ([#1330])
+    - Generating of `ToScalarValue` implementation. ([#1330]) 
 
 [#1272]: /../../pull/1272
 [#1324]: /../../pull/1324
 [#1327]: /../../pull/1327
 [#1329]: /../../pull/1329
+[#1330]: /../../pull/1330
 [1b1fc618]: /../../commit/1b1fc61879ffdd640d741e187dc20678bf7ab295
 
 

--- a/juniper_codegen/Cargo.toml
+++ b/juniper_codegen/Cargo.toml
@@ -31,7 +31,8 @@ url = "2.0"
 [dev-dependencies]
 derive_more = { version = "2.0", features = ["from", "try_into"] }
 futures = "0.3.22"
-juniper = { path = "../juniper" }
+jiff = { version = "0.2", features = ["std"], default-features = false }
+juniper = { path = "../juniper", features = ["jiff"] }
 serde = "1.0.122"
 
 [lints.clippy]

--- a/juniper_codegen/src/graphql_scalar/mod.rs
+++ b/juniper_codegen/src/graphql_scalar/mod.rs
@@ -424,7 +424,7 @@ impl Definition {
                 let field_ty = field.ty();
 
                 generics.make_where_clause().predicates.push(parse_quote! {
-                    #field_ty: ::juniper::GraphQLValue<#scalar>
+                    #field_ty: ::juniper::GraphQLValue<#scalar, Context = (), TypeInfo = ()>
                 });
 
                 quote! {
@@ -511,7 +511,7 @@ impl Definition {
                     use ::juniper::macros::helper::ToScalarValueCall as _;
 
                     let func: fn(_) -> _ = #to_output;
-                    (&&func).__to_scalar_value_call(self)
+                    (&&&&func).__to_scalar_value_call(self)
                 }
             }
             Methods::Delegated { field, .. } => {

--- a/tests/codegen/fail/input-object/derive_incompatible_field_type.stderr
+++ b/tests/codegen/fail/input-object/derive_incompatible_field_type.stderr
@@ -14,7 +14,6 @@ error[E0277]: the trait bound `ObjectA: IsInputType<__S>` is not satisfied
              `TypeKind` implements `IsInputType<__S>`
              `Vec<T>` implements `IsInputType<S>`
            and $N others
-
 error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
   --> fail/input-object/derive_incompatible_field_type.rs:10:12
    |
@@ -42,7 +41,6 @@ note: required by a bound in `Registry::<S>::arg`
    |     where
    |         T: GraphQLType<S> + FromInputValue<S>,
    |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<S>::arg`
-
 error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
  --> fail/input-object/derive_incompatible_field_type.rs:8:10
   |
@@ -60,7 +58,6 @@ error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
             `[T; N]` implements `FromInputValue<S>`
           and $N others
   = note: this error originates in the derive macro `GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: the trait bound `ObjectA: ToInputValue<_>` is not satisfied
  --> fail/input-object/derive_incompatible_field_type.rs:8:10
   |
@@ -69,12 +66,12 @@ error[E0277]: the trait bound `ObjectA: ToInputValue<_>` is not satisfied
   |
   = help: the following other types implement trait `ToInputValue<S>`:
             `&T` implements `ToInputValue<S>`
-            `&[T]` implements `ToInputValue<S>`
-            `&str` implements `ToInputValue<S>`
             `Arc<T>` implements `ToInputValue<S>`
             `ArcStr` implements `ToInputValue<__S>`
             `Box<T>` implements `ToInputValue<S>`
             `ID` implements `ToInputValue<__S>`
             `Object` implements `ToInputValue<__S>`
+            `TypeKind` implements `ToInputValue<__S>`
+            `Value<S>` implements `ToInputValue<S>`
           and $N others
   = note: this error originates in the derive macro `GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/codegen/fail/input-object/derive_incompatible_field_type.stderr
+++ b/tests/codegen/fail/input-object/derive_incompatible_field_type.stderr
@@ -14,6 +14,7 @@ error[E0277]: the trait bound `ObjectA: IsInputType<__S>` is not satisfied
              `TypeKind` implements `IsInputType<__S>`
              `Vec<T>` implements `IsInputType<S>`
            and $N others
+
 error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
   --> fail/input-object/derive_incompatible_field_type.rs:10:12
    |
@@ -41,6 +42,7 @@ note: required by a bound in `Registry::<S>::arg`
    |     where
    |         T: GraphQLType<S> + FromInputValue<S>,
    |                             ^^^^^^^^^^^^^^^^^ required by this bound in `Registry::<S>::arg`
+
 error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
  --> fail/input-object/derive_incompatible_field_type.rs:8:10
   |
@@ -58,6 +60,7 @@ error[E0277]: the trait bound `ObjectA: FromInputValue<__S>` is not satisfied
             `[T; N]` implements `FromInputValue<S>`
           and $N others
   = note: this error originates in the derive macro `GraphQLInputObject` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `ObjectA: ToInputValue<_>` is not satisfied
  --> fail/input-object/derive_incompatible_field_type.rs:8:10
   |

--- a/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_invalid_url.rs
@@ -1,4 +1,4 @@
-use juniper::{graphql_scalar, Scalar, ScalarValue, Value};
+use juniper::{graphql_scalar, Scalar, ScalarValue};
 
 struct ScalarSpecifiedByUrl;
 
@@ -13,8 +13,8 @@ type MyScalar = ScalarSpecifiedByUrl;
 mod scalar {
     use super::*;
 
-    pub(super) fn to_output<S: ScalarValue>(_: &ScalarSpecifiedByUrl) -> Value<S> {
-        Value::scalar(0)
+    pub(super) fn to_output(_: &ScalarSpecifiedByUrl) -> i32 {
+        0
     }
 
     pub(super) fn from_input(_: &Scalar<impl ScalarValue>) -> ScalarSpecifiedByUrl {

--- a/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.rs
+++ b/tests/codegen/fail/scalar/type_alias/attr_with_not_all_resolvers.rs
@@ -1,4 +1,4 @@
-use juniper::{graphql_scalar, Value};
+use juniper::graphql_scalar;
 
 struct Scalar;
 
@@ -7,8 +7,8 @@ struct Scalar;
 type CustomScalar = Scalar;
 
 impl Scalar {
-    fn to_output(&self) -> Value {
-        Value::scalar(0)
+    fn to_output(&self) -> i32 {
+        0
     }
 }
 

--- a/tests/integration/tests/codegen_scalar_attr_derive_input.rs
+++ b/tests/integration/tests/codegen_scalar_attr_derive_input.rs
@@ -8,8 +8,8 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value, execute,
-    graphql_object, graphql_scalar, graphql_value, graphql_vars,
+    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, execute, graphql_object,
+    graphql_scalar, graphql_value, graphql_vars,
 };
 
 use self::common::{
@@ -27,8 +27,8 @@ mod trivial {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -166,8 +166,8 @@ mod transparent_with_resolver {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0 + 1)
+        fn to_output(&self) -> i32 {
+            self.0 + 1
         }
     }
 
@@ -236,8 +236,8 @@ mod all_custom_resolvers {
     #[graphql(parse_token_with = parse_token)]
     struct Counter(i32);
 
-    fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-        Value::scalar(v.0)
+    fn to_output(v: &Counter) -> i32 {
+        v.0
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -306,8 +306,8 @@ mod explicit_name {
     struct CustomCounter(i32);
 
     impl CustomCounter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -381,8 +381,8 @@ mod delegated_parse_token {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -455,10 +455,10 @@ mod multiple_delegated_parse_token {
     }
 
     impl StringOrInt {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
+        fn to_output<S: ScalarValue>(&self) -> S {
             match self {
-                Self::String(s) => Value::scalar(s.to_owned()),
-                Self::Int(i) => Value::scalar(*i),
+                Self::String(s) => S::from_displayable(s),
+                Self::Int(i) => (*i).into(),
             }
         }
 
@@ -517,13 +517,12 @@ mod where_attribute {
     )]
     struct CustomDateTime<Tz: TimeZone>(DateTime<Tz>);
 
-    fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+    fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
     where
-        S: ScalarValue,
         Tz: From<Utc> + TimeZone,
         Tz::Offset: fmt::Display,
     {
-        Value::scalar(v.0.to_rfc3339())
+        v.0.to_rfc3339()
     }
 
     fn from_input<Tz>(s: &str) -> prelude::Result<CustomDateTime<Tz>, prelude::Box<str>>
@@ -588,8 +587,8 @@ mod with_self {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -670,13 +669,12 @@ mod with_module {
     mod custom_date_time {
         use super::*;
 
-        pub(super) fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+        pub(super) fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
         where
-            S: ScalarValue,
             Tz: From<Utc> + TimeZone,
             Tz::Offset: fmt::Display,
         {
-            Value::scalar(v.0.to_rfc3339())
+            v.0.to_rfc3339()
         }
 
         pub(super) fn from_input<Tz>(
@@ -745,8 +743,8 @@ mod description_from_doc_comment {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -820,8 +818,8 @@ mod description_from_attribute {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -895,8 +893,8 @@ mod custom_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -970,8 +968,8 @@ mod generic_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -1044,8 +1042,8 @@ mod bounded_generic_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {

--- a/tests/integration/tests/codegen_scalar_attr_type_alias.rs
+++ b/tests/integration/tests/codegen_scalar_attr_type_alias.rs
@@ -6,8 +6,8 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value, execute,
-    graphql_object, graphql_scalar, graphql_value, graphql_vars,
+    ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, execute, graphql_object,
+    graphql_scalar, graphql_value, graphql_vars,
 };
 
 use self::common::{
@@ -33,8 +33,8 @@ mod all_custom_resolvers {
     )]
     type Counter = CustomCounter;
 
-    fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-        Value::scalar(v.0)
+    fn to_output(v: &Counter) -> i32 {
+        v.0
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -109,8 +109,8 @@ mod explicit_name {
     )]
     type CounterScalar = CustomCounter;
 
-    fn to_output<S: ScalarValue>(v: &CounterScalar) -> Value<S> {
-        Value::scalar(v.0)
+    fn to_output(v: &CounterScalar) -> i32 {
+        v.0
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -204,8 +204,8 @@ mod delegated_parse_token {
     )]
     type Counter = CustomCounter;
 
-    fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-        Value::scalar(v.0)
+    fn to_output(v: &Counter) -> i32 {
+        v.0
     }
 
     struct QueryRoot;
@@ -278,10 +278,10 @@ mod multiple_delegated_parse_token {
     )]
     type StringOrInt = StringOrIntScalar;
 
-    fn to_output<S: ScalarValue>(v: &StringOrInt) -> Value<S> {
+    fn to_output<S: ScalarValue>(v: &StringOrInt) -> S {
         match v {
-            StringOrInt::String(s) => Value::scalar(s.to_owned()),
-            StringOrInt::Int(i) => Value::scalar(*i),
+            StringOrInt::String(s) => S::from_displayable(s),
+            StringOrInt::Int(i) => (*i).into(),
         }
     }
 
@@ -341,13 +341,12 @@ mod where_attribute {
     )]
     type CustomDateTime<Tz> = CustomDateTimeScalar<Tz>;
 
-    fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+    fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
     where
-        S: ScalarValue,
         Tz: From<Utc> + TimeZone,
         Tz::Offset: fmt::Display,
     {
-        Value::scalar(v.0.to_rfc3339())
+        v.0.to_rfc3339()
     }
 
     fn from_input<Tz>(s: &str) -> prelude::Result<CustomDateTime<Tz>, prelude::Box<str>>
@@ -414,8 +413,8 @@ mod with_self {
     type Counter = CustomCounter;
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -498,13 +497,12 @@ mod with_module {
     mod custom_date_time {
         use super::*;
 
-        pub(super) fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+        pub(super) fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
         where
-            S: ScalarValue,
             Tz: From<Utc> + TimeZone,
             Tz::Offset: fmt::Display,
         {
-            Value::scalar(v.0.to_rfc3339())
+            v.0.to_rfc3339()
         }
 
         pub(super) fn from_input<Tz>(
@@ -577,8 +575,8 @@ mod description_from_doc_comment {
     mod counter {
         use super::*;
 
-        pub(super) fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-            Value::scalar(v.0)
+        pub(super) fn to_output(v: &Counter) -> i32 {
+            v.0
         }
 
         pub(super) fn from_input(i: i32) -> Counter {
@@ -660,8 +658,8 @@ mod description_from_attribute {
     mod counter {
         use super::*;
 
-        pub(super) fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-            Value::scalar(v.0)
+        pub(super) fn to_output(v: &Counter) -> i32 {
+            v.0
         }
 
         pub(super) fn from_input(i: i32) -> Counter {
@@ -743,8 +741,8 @@ mod custom_scalar {
     mod counter {
         use super::*;
 
-        pub(super) fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-            Value::scalar(v.0)
+        pub(super) fn to_output(v: &Counter) -> i32 {
+            v.0
         }
 
         pub(super) fn from_input(i: i32) -> Counter {
@@ -826,8 +824,8 @@ mod generic_scalar {
     mod counter {
         use super::*;
 
-        pub(super) fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-            Value::scalar(v.0)
+        pub(super) fn to_output(v: &Counter) -> i32 {
+            v.0
         }
 
         pub(super) fn from_input(i: i32) -> Counter {
@@ -909,8 +907,8 @@ mod bounded_generic_scalar {
     mod counter {
         use super::*;
 
-        pub(super) fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-            Value::scalar(v.0)
+        pub(super) fn to_output(v: &Counter) -> i32 {
+            v.0
         }
 
         pub(super) fn from_input(i: i32) -> Counter {

--- a/tests/integration/tests/codegen_scalar_derive.rs
+++ b/tests/integration/tests/codegen_scalar_derive.rs
@@ -6,8 +6,8 @@ use std::fmt;
 
 use chrono::{DateTime, TimeZone, Utc};
 use juniper::{
-    GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, Value,
-    execute, graphql_object, graphql_value, graphql_vars,
+    GraphQLScalar, ParseScalarResult, ParseScalarValue, Scalar, ScalarToken, ScalarValue, execute,
+    graphql_object, graphql_value, graphql_vars,
 };
 
 use self::common::{
@@ -25,8 +25,8 @@ mod trivial {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -161,8 +161,8 @@ mod transparent_with_resolver {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0 + 1)
+        fn to_output(&self) -> i32 {
+            self.0 + 1
         }
     }
 
@@ -231,8 +231,8 @@ mod all_custom_resolvers {
     #[graphql(parse_token_with = parse_token)]
     struct Counter(i32);
 
-    fn to_output<S: ScalarValue>(v: &Counter) -> Value<S> {
-        Value::scalar(v.0)
+    fn to_output(v: &Counter) -> i32 {
+        v.0
     }
 
     fn parse_token<S: ScalarValue>(value: ScalarToken<'_>) -> ParseScalarResult<S> {
@@ -301,8 +301,8 @@ mod explicit_name {
     struct CustomCounter(i32);
 
     impl CustomCounter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -376,8 +376,8 @@ mod delegated_parse_token {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -450,10 +450,10 @@ mod multiple_delegated_parse_token {
     }
 
     impl StringOrInt {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
+        fn to_output<S: ScalarValue>(&self) -> S {
             match self {
-                Self::String(s) => Value::scalar(s.to_owned()),
-                Self::Int(i) => Value::scalar(*i),
+                Self::String(s) => S::from_displayable(s),
+                Self::Int(i) => (*i).into(),
             }
         }
 
@@ -512,13 +512,12 @@ mod where_attribute {
     )]
     struct CustomDateTime<Tz: TimeZone>(DateTime<Tz>);
 
-    fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+    fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
     where
-        S: ScalarValue,
         Tz: From<Utc> + TimeZone,
         Tz::Offset: fmt::Display,
     {
-        Value::scalar(v.0.to_rfc3339())
+        v.0.to_rfc3339()
     }
 
     fn from_input<Tz>(s: &str) -> prelude::Result<CustomDateTime<Tz>, prelude::Box<str>>
@@ -583,8 +582,8 @@ mod with_self {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -665,13 +664,12 @@ mod with_module {
     mod custom_date_time {
         use super::*;
 
-        pub(super) fn to_output<S, Tz>(v: &CustomDateTime<Tz>) -> Value<S>
+        pub(super) fn to_output<Tz>(v: &CustomDateTime<Tz>) -> prelude::String
         where
-            S: ScalarValue,
             Tz: From<Utc> + TimeZone,
             Tz::Offset: fmt::Display,
         {
-            Value::scalar(v.0.to_rfc3339())
+            v.0.to_rfc3339()
         }
 
         pub(super) fn from_input<Tz>(
@@ -740,8 +738,8 @@ mod description_from_doc_comment {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -815,8 +813,8 @@ mod description_from_attribute {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -890,8 +888,8 @@ mod custom_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -965,8 +963,8 @@ mod generic_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {
@@ -1039,8 +1037,8 @@ mod bounded_generic_scalar {
     struct Counter(i32);
 
     impl Counter {
-        fn to_output<S: ScalarValue>(&self) -> Value<S> {
-            Value::scalar(self.0)
+        fn to_output(&self) -> i32 {
+            self.0
         }
 
         fn from_input(i: i32) -> Self {

--- a/tests/integration/tests/custom_scalar.rs
+++ b/tests/integration/tests/custom_scalar.rs
@@ -18,8 +18,8 @@ type Long = i64;
 mod long {
     use super::*;
 
-    pub(super) fn to_output(v: &Long) -> Value<MyScalarValue> {
-        Value::scalar(*v)
+    pub(super) fn to_output(v: &Long) -> MyScalarValue {
+        (*v).into()
     }
 
     pub(super) fn from_input(s: &MyScalarValue) -> Result<Long, Box<str>> {


### PR DESCRIPTION
Related to #1327

## Synopsis

Counterpart of #1327 making the `to_output()` function returning `ScalarValue` directly instead of `Value`.

## Solution

Now `to_output()` function should return a `ScalarValue` directly, instead of a `Value`.

Of course, the output type polymorphism is supported.

Either concrete type could be specified:
```rust
#[derive(Debug, GraphQLScalar)]
#[graphql(parse_token(String))]
struct TestComplexScalar;

impl TestComplexScalar {
    fn to_output(&self) -> &'static str {
        "SerializedValue"
    }
    // ...
}
```

Or a `Display`able one:
```rust
#[graphql_scalar]
#[graphql(with = local_date, parse_token(String))]
pub type LocalDate = chrono::NaiveDate;

mod local_date {
    use std::fmt::Display;
    use super::LocalDate;

    pub(super) fn to_output(v: &LocalDate) -> impl Display {
        v.format("%Y-%m-%d")
    }
    // ....
}
```

Or just a generic:
```rust
    #[graphql_scalar]
    #[graphql(
        to_output_with = to_output,
        parse_token(prelude::String, i32),
    )]
    type StringOrInt = StringOrIntScalar;

    fn to_output<S: ScalarValue>(v: &StringOrInt) -> S {
        match v {
            StringOrInt::String(s) => S::from_displayable(s),
            StringOrInt::Int(i) => (*i).into(),
        }
    }
    // ...
```