### PR TITLE
Rename `VariableDefinitions` to `VariablesDefinition` (#1347)

### DIFF
--- a/juniper/CHANGELOG.md
+++ b/juniper/CHANGELOG.md
@@ -16,6 +16,8 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
     - Made `includeDeprecated` argument of `__Type.fields`, `__Type.enumValues`, `__Type.inputFields`, `__Field.args` and `__Directive.args` fields non-`Null`. ([#1348], [graphql/graphql-spec#1142])
     - Made `@deprecated(reason:)` argument non-`Null`. ([#1348], [graphql/graphql-spec#1040])
     - Added `description` field to `ast::Operation`, `ast::Fragment` and `ast::VariableDefinition`. ([#1349], [graphql/graphql-spec#1170])
+    - Renamed `ast::VariableDefinitions` to `ast::VariablesDefinition`: ([#1353], [graphql/graphql-spec#916])
+        - Renamed `ast::Operation::variable_definitions` field to `variables_definition`.
 - Changed `ScalarToken::String` to contain raw quoted and escaped `StringLiteral` (was unquoted but escaped string before). ([#1349])
 - Added `LexerError::UnterminatedBlockString` variant. ([#1349])
 
@@ -51,11 +53,13 @@ All user visible changes to `juniper` crate will be documented in this file. Thi
 [#1347]: /../../issues/1347
 [#1348]: /../../pull/1348
 [#1349]: /../../pull/1349
+[#1353]: /../../pull/1353
 [graphql/graphql-spec#525]: https://github.com/graphql/graphql-spec/pull/525
 [graphql/graphql-spec#687]: https://github.com/graphql/graphql-spec/issues/687
 [graphql/graphql-spec#805]: https://github.com/graphql/graphql-spec/pull/805
 [graphql/graphql-spec#825]: https://github.com/graphql/graphql-spec/pull/825
 [graphql/graphql-spec#849]: https://github.com/graphql/graphql-spec/pull/849
+[graphql/graphql-spec#916]: https://github.com/graphql/graphql-spec/pull/916
 [graphql/graphql-spec#1040]: https://github.com/graphql/graphql-spec/pull/1040
 [graphql/graphql-spec#1142]: https://github.com/graphql/graphql-spec/pull/1142
 [graphql/graphql-spec#1170]: https://github.com/graphql/graphql-spec/pull/1170

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -319,7 +319,7 @@ pub struct Arguments<'a, S> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct VariableDefinitions<'a, S> {
+pub struct VariablesDefinition<'a, S> {
     pub items: Vec<(Spanning<&'a str>, VariableDefinition<'a, S>)>,
 }
 
@@ -388,7 +388,7 @@ pub struct Operation<'a, S> {
     pub description: Option<Spanning<Cow<'a, str>>>,
     pub operation_type: OperationType,
     pub name: Option<Spanning<&'a str>>,
-    pub variable_definitions: Option<Spanning<VariableDefinitions<'a, S>>>,
+    pub variables_definition: Option<Spanning<VariablesDefinition<'a, S>>>,
     pub directives: Option<Vec<Spanning<Directive<'a, S>>>>,
     pub selection_set: Vec<Selection<'a, S>>,
 }
@@ -824,7 +824,7 @@ impl<'a, S> Arguments<'a, S> {
     }
 }
 
-impl<'a, S> VariableDefinitions<'a, S> {
+impl<'a, S> VariablesDefinition<'a, S> {
     pub fn iter(&self) -> slice::Iter<'_, (Spanning<&'a str>, VariableDefinition<'a, S>)> {
         self.items.iter()
     }

--- a/juniper/src/ast.rs
+++ b/juniper/src/ast.rs
@@ -323,6 +323,12 @@ pub struct VariablesDefinition<'a, S> {
     pub items: Vec<(Spanning<&'a str>, VariableDefinition<'a, S>)>,
 }
 
+impl<'a, S> VariablesDefinition<'a, S> {
+    pub fn iter(&self) -> slice::Iter<'_, (Spanning<&'a str>, VariableDefinition<'a, S>)> {
+        self.items.iter()
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Field<'a, S> {
     pub alias: Option<Spanning<&'a str>>,
@@ -821,12 +827,6 @@ impl<'a, S> Arguments<'a, S> {
             .filter(|&(k, _)| k.item == key)
             .map(|(_, v)| v)
             .next()
-    }
-}
-
-impl<'a, S> VariablesDefinition<'a, S> {
-    pub fn iter(&self) -> slice::Iter<'_, (Spanning<&'a str>, VariableDefinition<'a, S>)> {
-        self.items.iter()
     }
 }
 

--- a/juniper/src/executor/mod.rs
+++ b/juniper/src/executor/mod.rs
@@ -820,7 +820,7 @@ where
         };
     }
 
-    let default_variable_values = operation.item.variable_definitions.as_ref().map(|defs| {
+    let default_variable_values = operation.item.variables_definition.as_ref().map(|defs| {
         defs.item
             .items
             .iter()
@@ -918,7 +918,7 @@ where
         };
     }
 
-    let default_variable_values = operation.item.variable_definitions.as_ref().map(|defs| {
+    let default_variable_values = operation.item.variables_definition.as_ref().map(|defs| {
         defs.item
             .items
             .iter()
@@ -1065,7 +1065,7 @@ where
         }
     }
 
-    let default_variable_values = operation.item.variable_definitions.as_ref().map(|defs| {
+    let default_variable_values = operation.item.variables_definition.as_ref().map(|defs| {
         defs.item
             .items
             .iter()

--- a/juniper/src/parser/document.rs
+++ b/juniper/src/parser/document.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{
         Arguments, Definition, Directive, Field, Fragment, FragmentSpread, InlineFragment,
         InputValue, Operation, OperationType, OwnedDocument, Selection, Type, VariableDefinition,
-        VariableDefinitions,
+        VariablesDefinition,
     },
     parser::{
         Lexer, OptionParseResult, ParseError, ParseResult, Parser, ScalarToken, Spanning, Token,
@@ -94,7 +94,7 @@ where
                 operation_type: OperationType::Query,
                 name: None,
                 description: None,
-                variable_definitions: None,
+                variables_definition: None,
                 directives: None,
                 selection_set: selection_set.item,
             },
@@ -114,7 +114,7 @@ where
             Token::Name(_) => Some(parser.expect_name()?),
             _ => None,
         };
-        let variable_definitions = parse_variable_definitions(parser, schema)?;
+        let variables_definition = parse_variables_definition(parser, schema)?;
         let directives = parse_directives(parser, schema)?;
         let selection_set = parse_selection_set(parser, schema, fields)?;
 
@@ -125,7 +125,7 @@ where
                 operation_type: operation_type.item,
                 name,
                 description: None,
-                variable_definitions,
+                variables_definition,
                 directives: directives.map(|s| s.item),
                 selection_set: selection_set.item,
             },
@@ -409,10 +409,10 @@ fn parse_operation_type(parser: &mut Parser<'_>) -> ParseResult<OperationType> {
     }
 }
 
-fn parse_variable_definitions<'a, S>(
+fn parse_variables_definition<'a, S>(
     parser: &mut Parser<'a>,
     schema: &SchemaType<S>,
-) -> OptionParseResult<VariableDefinitions<'a, S>>
+) -> OptionParseResult<VariablesDefinition<'a, S>>
 where
     S: ScalarValue,
 {
@@ -426,7 +426,7 @@ where
                     |p| parse_variable_definition(p, schema),
                     &Token::ParenClose,
                 )?
-                .map(|defs| VariableDefinitions {
+                .map(|defs| VariablesDefinition {
                     items: defs.into_iter().map(|s| s.item).collect(),
                 }),
         ))

--- a/juniper/src/parser/tests/document.rs
+++ b/juniper/src/parser/tests/document.rs
@@ -49,7 +49,7 @@ fn simple_ast() {
                 operation_type: ast::OperationType::Query,
                 name: None,
                 description: None,
-                variable_definitions: None,
+                variables_definition: None,
                 directives: None,
                 selection_set: vec![ast::Selection::Field(Spanning::start_end(
                     &SourcePosition::new(18, 1, 16),
@@ -168,10 +168,10 @@ fn description() {
                         &SourcePosition::new(54, 1, 53),
                         Cow::Owned("Some description with \u{90AB} symbol".into()),
                     )),
-                    variable_definitions: Some(Spanning::start_end(
+                    variables_definition: Some(Spanning::start_end(
                         &SourcePosition::new(90, 2, 35),
                         &SourcePosition::new(364, 10, 17),
-                        ast::VariableDefinitions {
+                        ast::VariablesDefinition {
                             items: vec![
                                 (
                                     Spanning::start_end(

--- a/juniper/src/validation/input_value.rs
+++ b/juniper/src/validation/input_value.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use derive_more::with_trait::Display;
 
 use crate::{
-    ast::{InputValue, Operation, VariableDefinitions},
+    ast::{InputValue, Operation, VariablesDefinition},
     executor::Variables,
     parser::{SourcePosition, Spanning},
     schema::{
@@ -35,7 +35,7 @@ where
 {
     let mut errs = vec![];
 
-    if let Some(ref vars) = operation.item.variable_definitions {
+    if let Some(ref vars) = operation.item.variables_definition {
         validate_var_defs(values, &vars.item, schema, &mut errs);
     }
 
@@ -45,7 +45,7 @@ where
 
 fn validate_var_defs<S>(
     values: &Variables<S>,
-    var_defs: &VariableDefinitions<S>,
+    var_defs: &VariablesDefinition<S>,
     schema: &SchemaType<S>,
     errors: &mut Vec<RuleError>,
 ) where

--- a/juniper/src/validation/visitor.rs
+++ b/juniper/src/validation/visitor.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{
         Arguments, BorrowedType, Definition, Directive, Document, Field, Fragment, FragmentSpread,
-        InlineFragment, InputValue, Operation, OperationType, Selection, VariableDefinitions,
+        InlineFragment, InputValue, Operation, OperationType, Selection, VariablesDefinition,
     },
     parser::Spanning,
     schema::meta::Argument,
@@ -109,7 +109,7 @@ where
 {
     match *def {
         Definition::Operation(ref op) => {
-            visit_variable_definitions(v, ctx, &op.item.variable_definitions);
+            visit_variables_definition(v, ctx, &op.item.variables_definition);
             visit_directives(v, ctx, &op.item.directives);
             visit_selection_set(v, ctx, &op.item.selection_set);
         }
@@ -120,10 +120,10 @@ where
     }
 }
 
-fn visit_variable_definitions<'a, S, V>(
+fn visit_variables_definition<'a, S, V>(
     v: &mut V,
     ctx: &mut ValidatorContext<'a, S>,
-    defs: &'a Option<Spanning<VariableDefinitions<S>>>,
+    defs: &'a Option<Spanning<VariablesDefinition<S>>>,
 ) where
     S: ScalarValue,
     V: Visitor<'a, S>,


### PR DESCRIPTION
Part of #1347

## Synopsis

`VariableDefinitions` was renamed to `VariablesDefinition` in [GraphQL spec September 2025](https://spec.graphql.org/September2025):
- graphql/graphql-spec#916

## Solution

Rename all the related items.