### PR TITLE
Fix failing CI

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -12,7 +12,7 @@ build-dir = "_rendered"
 create-missing = false
 
 [output.html]
-git_repository_url = "https://github.com/graphql-rust/juniper"
+git-repository-url = "https://github.com/graphql-rust/juniper"
 
 [rust]
 edition = "2024"

--- a/juniper_hyper/Cargo.toml
+++ b/juniper_hyper/Cargo.toml
@@ -31,7 +31,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 juniper = { version = "0.17", path = "../juniper", features = ["expose-test-schema"] }
 log = "0.4"
 pretty_env_logger = "0.5"
-reqwest = { version = "0.13", features = ["blocking", "rustls"], default-features = false }
+reqwest = { version = "0.13", features = ["blocking"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread"] }
 
 [lints.clippy]


### PR DESCRIPTION
Use kebab-case `git-repository-url` so mdBook 0.5 accepts `book.toml`.
Drop the unused `rustls` reqwest feature whose `aws-lc-sys` build breaks `juniper_hyper` MSRV on Windows.
