### PR TITLE
Fix Juniper Book deploy for mdBook 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,9 +444,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: peaceiris/actions-mdbook@v2
 
-      - run: make book.build out=gh-pages${{ (github.ref == 'refs/heads/master'
-                                              && '/master')
-                                          ||     '' }}
+      - run: make book.build out=book/gh-pages${{ (github.ref == 'refs/heads/master'
+                                                   && '/master')
+                                               ||     '' }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
mdBook 0.5 makes `--dest-dir` relative to the CWD, so the book was written to `gh-pages/` (repo root) instead of `book/gh-pages` where the deploy step publishes from.
Pass `out=book/gh-pages` to fix the broken `deploy (Book)` job.
